### PR TITLE
Update references to Resolate repository owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 ![WordPress Version](https://img.shields.io/badge/WordPress-6.1-blue)
 ![Language](https://img.shields.io/badge/Language-PHP-orange)
 ![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)
-![Downloads](https://img.shields.io/github/downloads/ateeducacion/wp-resolate/total)
-![Last Commit](https://img.shields.io/github/last-commit/ateeducacion/wp-resolate)
-![Open Issues](https://img.shields.io/github/issues/ateeducacion/wp-resolate)
+![Downloads](https://img.shields.io/github/downloads/erseco/wp-resolate/total)
+![Last Commit](https://img.shields.io/github/last-commit/erseco/wp-resolate)
+![Open Issues](https://img.shields.io/github/issues/erseco/wp-resolate)
 
 **Resolate** es un plugin de WordPress para la generación de resoluciones oficiales con estructura de secciones y exportación a DOCX.
 
@@ -13,7 +13,7 @@
 
 Try Resolate instantly in your browser using WordPress Playground! The demo includes sample data to help you explore the features. Note that all changes will be lost when you close the browser window, as everything runs locally in your browser.
 
-[<kbd> <br> Preview in WordPress Playground <br> </kbd>](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/ateeducacion/wp-resolate/refs/heads/main/blueprint.json)
+[<kbd> <br> Preview in WordPress Playground <br> </kbd>](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/erseco/wp-resolate/refs/heads/main/blueprint.json)
 
 
 ### Key Features
@@ -26,7 +26,7 @@ Try Resolate instantly in your browser using WordPress Playground! The demo incl
 
 ## Installation
 
-1. **Download the latest release** from the [GitHub Releases page](https://github.com/ateeducacion/wp-resolate/releases).
+1. **Download the latest release** from the [GitHub Releases page](https://github.com/erseco/wp-resolate/releases).
 2. Upload the downloaded ZIP file to your WordPress site via **Plugins > Add New > Upload Plugin**.
 3. Activate the plugin through the 'Plugins' menu in WordPress.
 4. Configure the plugin under 'Settings' by providing the necessary Nextcloud API details.

--- a/blueprint.json
+++ b/blueprint.json
@@ -28,7 +28,7 @@
       "step": "installPlugin",
       "pluginData": {
         "resource": "url",
-        "url": "https://github.com/ateeducacion/wp-resolate/archive/refs/heads/main.zip"
+        "url": "https://github.com/erseco/wp-resolate/archive/refs/heads/main.zip"
       },
       "options": {
         "activate": true

--- a/includes/custom-post-types/class-resolate-documents.php
+++ b/includes/custom-post-types/class-resolate-documents.php
@@ -5,7 +5,7 @@
  * This CPT is the base for generating official documents with structured
  * sections stored as post meta, and two taxonomies: ámbitos and leyes.
  *
- * @link       https://github.com/ateeducacion/wp-resolate
+ * @link       https://github.com/erseco/wp-resolate
  * @since      0.1.0
  *
  * @package    resolate

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,13 +2,13 @@ site_name: Resolate
 site_description: A WordPress plugin that provides a Kanban board interface with a unique priority system for managing tasks
 
 site_author: ATE
-repo_url: https://github.com/ateeducacion/wp-resolate
+repo_url: https://github.com/erseco/wp-resolate
 edit_uri: edit/main/docs/
 
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/ateeducacion/wp-resolate
+      link: https://github.com/erseco/wp-resolate
 
 theme:
   name: material

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Resolate – Generador de resoluciones ===
-Contributors: ateeducacion, erseco
+Contributors: erseco
 Tags: ate, tasks, board, kanban
 Requires at least: 6.1
 Tested up to: 6.8

--- a/resolate.php
+++ b/resolate.php
@@ -3,12 +3,12 @@
  *
  * Resolate – Generador de resoluciones.
  *
- * @link              https://github.com/ateeducacion/wp-resolate
+ * @link              https://github.com/erseco/wp-resolate
  * @package           Resolate
  *
  * @wordpress-plugin
  * Plugin Name:       Resolate – Generador de resoluciones
- * Plugin URI:        https://github.com/ateeducacion/wp-resolate
+ * Plugin URI:        https://github.com/erseco/wp-resolate
  * Description:       Generador de resoluciones digitales de la Consejería de Educación del Gobierno de Canarias. Define un tipo de contenido de "Resolución" con secciones estructuradas y permite exportar a Word (DOCX) y, próximamente, PDF.
  * Version:           0.0.0
  * Author:            Área de Tecnología Educativa

--- a/tests/unit/includes/ResolateTest.php
+++ b/tests/unit/includes/ResolateTest.php
@@ -9,7 +9,7 @@
  * Main plugin test case.
  */
 class ResolateTest extends Resolate_Test_Base {
-	protected $decker;
+        protected $resolate;
 	protected $admin_user_id;
 
 	public function set_up() {
@@ -23,23 +23,23 @@ class ResolateTest extends Resolate_Test_Base {
 		wp_set_current_user( $this->admin_user_id );
 
                // Instantiate the plugin
-		$this->decker = new Resolate();
+                $this->resolate = new Resolate();
 	}
 
 	public function test_plugin_initialization() {
-		$this->assertInstanceOf( Resolate::class, $this->decker );
-		$this->assertEquals( 'decker', $this->decker->get_plugin_name() );
-		$this->assertEquals( RESOLATE_VERSION, $this->decker->get_version() );
+                $this->assertInstanceOf( Resolate::class, $this->resolate );
+                $this->assertEquals( 'resolate', $this->resolate->get_plugin_name() );
+                $this->assertEquals( RESOLATE_VERSION, $this->resolate->get_version() );
 	}
 
 	public function test_plugin_dependencies() {
            // Verify that the loader exists and is properly instantiated
-		$loader = $this->get_private_property( $this->decker, 'loader' );
+                $loader = $this->get_private_property( $this->resolate, 'loader' );
 		$this->assertInstanceOf( 'Resolate_Loader', $loader );
 
            // Verify that the required properties are set
-		$this->assertNotEmpty( $this->get_private_property( $this->decker, 'plugin_name' ) );
-		$this->assertNotEmpty( $this->get_private_property( $this->decker, 'version' ) );
+                $this->assertNotEmpty( $this->get_private_property( $this->resolate, 'plugin_name' ) );
+                $this->assertNotEmpty( $this->get_private_property( $this->resolate, 'version' ) );
 	}
 
 	/**
@@ -57,7 +57,7 @@ class ResolateTest extends Resolate_Test_Base {
 	 */
 	public function test_current_user_has_at_least_minimum_role() {
                // Configure Resolate settings
-		update_option( 'decker_settings', array( 'minimum_user_profile' => 'editor' ) );
+                update_option( 'resolate_settings', array( 'minimum_user_profile' => 'editor' ) );
 
            // Create users with standard roles
 		$admin      = $this->factory->user->create( array( 'role' => 'administrator' ) );
@@ -83,7 +83,7 @@ class ResolateTest extends Resolate_Test_Base {
 	public function tear_down() {
                // Clean up data
 		wp_delete_user( $this->admin_user_id );
-		delete_option( 'decker_settings' );
+                delete_option( 'resolate_settings' );
 		parent::tear_down();
 	}
 }


### PR DESCRIPTION
## Summary
- update documentation and metadata links to point at the erseco/wp-resolate repository
- remove remaining mentions of the former "decker" plugin name in unit tests

## Testing
- make test *(fails: Docker is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eca8bf42b08322a54288d7bb512adc