### PR TITLE
Load ZetaJS assets from CDN for document editing

### DIFF
--- a/admin/js/resolate-zetajs-loader.js
+++ b/admin/js/resolate-zetajs-loader.js
@@ -1,0 +1,69 @@
+/**
+ * Lightweight loader to expose ZetaJS helpers from the official CDN.
+ */
+const config = window.resolateZetaLoaderConfig || {};
+const ensureTrailingSlash = (url) => (url.endsWith('/') ? url : `${url}/`);
+const baseUrl = config.baseUrl ? ensureTrailingSlash(config.baseUrl) : 'https://cdn.zetaoffice.net/zetaoffice_latest/';
+const assets = Array.isArray(config.assets) ? config.assets : [];
+
+const resolvedAssets = assets
+    .map((asset) => {
+        if (typeof asset === 'string') {
+            return { href: asset, as: 'fetch' };
+        }
+        if (!asset || typeof asset.href !== 'string') {
+            return null;
+        }
+        return {
+            href: asset.href,
+            as: asset.as || 'fetch',
+        };
+    })
+    .filter(Boolean)
+    .map((asset) => {
+        const href = /^https?:/i.test(asset.href) ? asset.href : baseUrl + asset.href.replace(/^\//, '');
+        return {
+            href,
+            as: asset.as,
+        };
+    });
+
+const head = document.head || document.getElementsByTagName('head')[0];
+const ensurePreload = ({ href, as }) => {
+    if (!head || !href) {
+        return;
+    }
+    const selector = `link[data-resolate-preload="${href}"]`;
+    if (document.querySelector(selector)) {
+        return;
+    }
+    const link = document.createElement('link');
+    link.rel = 'preload';
+    link.as = as || 'fetch';
+    link.href = href;
+    link.crossOrigin = 'anonymous';
+    link.dataset.resolatePreload = href;
+    head.appendChild(link);
+};
+
+resolvedAssets.forEach(ensurePreload);
+
+const store = window.resolateZeta || {};
+store.baseUrl = baseUrl;
+
+if (!store.loadHelper) {
+    store.loadHelper = async () => {
+        if (store.helper) {
+            return store.helper;
+        }
+        const module = await import(`${baseUrl}zetaHelper.js`);
+        store.helper = module;
+        return module;
+    };
+}
+
+window.resolateZeta = store;
+
+store.loadHelper().catch((error) => {
+    console.error('Resolate ZetaJS', error);
+});

--- a/includes/class-resolate-document-generator.php
+++ b/includes/class-resolate-document-generator.php
@@ -273,7 +273,24 @@ class Resolate_Document_Generator {
             }
 
             require_once plugin_dir_path( __DIR__ ) . 'includes/class-resolate-zetajs.php';
-            if ( ! class_exists( 'Resolate_Zetajs_Converter' ) || ! Resolate_Zetajs_Converter::is_available() ) {
+            if ( ! class_exists( 'Resolate_Zetajs_Converter' ) ) {
+                return new WP_Error( 'resolate_zetajs_not_available', __( 'No se pudo cargar el conversor de ZetaJS.', 'resolate' ) );
+            }
+
+            if ( Resolate_Zetajs_Converter::is_cdn_mode() ) {
+                return new WP_Error(
+                    'resolate_zetajs_browser_only',
+                    Resolate_Zetajs_Converter::get_browser_conversion_message(),
+                    array(
+                        'mode'       => 'cdn',
+                        'cdn_base'   => Resolate_Zetajs_Converter::get_cdn_base_url(),
+                        'source'     => $source_path,
+                        'source_ext' => $source_format,
+                    )
+                );
+            }
+
+            if ( ! Resolate_Zetajs_Converter::is_available() ) {
                 return new WP_Error( 'resolate_zetajs_not_available', __( 'Configura el ejecutable de ZetaJS para generar PDF.', 'resolate' ) );
             }
 

--- a/resolate.php
+++ b/resolate.php
@@ -27,6 +27,10 @@ if ( ! defined( 'WPINC' ) ) {
 define( 'RESOLATE_VERSION', '0.0.0' );
 define( 'RESOLATE_PLUGIN_FILE', __FILE__ );
 
+if ( ! defined( 'RESOLATE_ZETAJS_CDN_BASE' ) ) {
+    define( 'RESOLATE_ZETAJS_CDN_BASE', 'https://cdn.zetaoffice.net/zetaoffice_latest/' );
+}
+
 /**
  * The code that runs during plugin activation.
  */


### PR DESCRIPTION
## Summary
- define the default CDN endpoint for ZetaJS assets and surface a reusable browser-mode message
- update the ZetaJS converter to detect CDN usage, adjust PDF generator handling, and expose config helpers
- enqueue a module loader on the document editor to preload CDN assets and guide the admin UI when PDF export stays browser-side

## Testing
- php -l resolate.php
- php -l includes/class-resolate-zetajs.php
- php -l includes/class-resolate-document-generator.php
- php -l includes/class-resolate-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68ecb8a07e8c8322a6bf2659a6177b5f