### PR TITLE
Seed demo document types with bundled templates

### DIFF
--- a/tests/unit/includes/ResolateDocumentTypeSeedingTest.php
+++ b/tests/unit/includes/ResolateDocumentTypeSeedingTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Tests for default document type seeding.
+ */
+
+class ResolateDocumentTypeSeedingTest extends WP_UnitTestCase {
+
+    public function set_up() : void {
+        parent::set_up();
+        register_post_type( 'resolate_document', array( 'public' => false ) );
+        register_taxonomy( 'resolate_doc_type', array( 'resolate_document' ) );
+    }
+
+    /**
+     * Ensure default document types are created with templates.
+     */
+    public function test_default_document_types_seeded() {
+        $this->delete_term_if_exists( 'resolate-demo-odt' );
+        $this->delete_term_if_exists( 'resolate-demo-docx' );
+
+        resolate_ensure_default_media();
+        resolate_maybe_seed_default_doc_types();
+
+        $odt = get_term_by( 'slug', 'resolate-demo-odt', 'resolate_doc_type' );
+        $this->assertInstanceOf( WP_Term::class, $odt );
+        $odt_template_id = intval( get_term_meta( $odt->term_id, 'resolate_type_template_id', true ) );
+        $this->assertGreaterThan( 0, $odt_template_id );
+        $this->assertSame( 'odt', get_term_meta( $odt->term_id, 'resolate_type_template_type', true ) );
+        $this->assertSame( 'resolate-demo-odt', get_term_meta( $odt->term_id, '_resolate_fixture', true ) );
+        $odt_schema = get_term_meta( $odt->term_id, 'schema', true );
+        $this->assertIsArray( $odt_schema );
+        $this->assertContainsPlaceholders( $odt_schema );
+
+        $docx = get_term_by( 'slug', 'resolate-demo-docx', 'resolate_doc_type' );
+        $this->assertInstanceOf( WP_Term::class, $docx );
+        $docx_template_id = intval( get_term_meta( $docx->term_id, 'resolate_type_template_id', true ) );
+        $this->assertGreaterThan( 0, $docx_template_id );
+        $this->assertSame( 'docx', get_term_meta( $docx->term_id, 'resolate_type_template_type', true ) );
+        $this->assertSame( 'resolate-demo-docx', get_term_meta( $docx->term_id, '_resolate_fixture', true ) );
+        $docx_schema = get_term_meta( $docx->term_id, 'schema', true );
+        $this->assertIsArray( $docx_schema );
+        $this->assertContainsPlaceholders( $docx_schema );
+
+        resolate_maybe_seed_default_doc_types();
+        $odt_after = get_term_by( 'slug', 'resolate-demo-odt', 'resolate_doc_type' );
+        $this->assertSame( $odt->term_id, $odt_after->term_id );
+    }
+
+    /**
+     * Remove a term by slug if present.
+     *
+     * @param string $slug Term slug.
+     * @return void
+     */
+    private function delete_term_if_exists( $slug ) {
+        $term = get_term_by( 'slug', $slug, 'resolate_doc_type' );
+        if ( $term && ! is_wp_error( $term ) ) {
+            wp_delete_term( $term->term_id, 'resolate_doc_type' );
+        }
+    }
+
+    /**
+     * Assert that schema contains expected placeholders.
+     *
+     * @param array $schema Schema array.
+     * @return void
+     */
+    private function assertContainsPlaceholders( $schema ) {
+        $slugs = array();
+        foreach ( $schema as $item ) {
+            if ( is_array( $item ) && isset( $item['slug'] ) ) {
+                $slugs[] = (string) $item['slug'];
+            }
+        }
+
+        sort( $slugs );
+        $expected = array( 'antecedentes', 'dispositivo', 'fundamentos', 'objeto', 'title' );
+        sort( $expected );
+        $this->assertSame( $expected, $slugs );
+    }
+}
+


### PR DESCRIPTION
## Summary
- seed demo document types on init using the bundled ODT and DOCX fixtures
- populate associated term metadata including detected placeholders and template types
- add a unit test that verifies the seeded document types and their schemas

## Testing
- php -l resolate.php

------
https://chatgpt.com/codex/tasks/task_e_68ecbd4c12148322922c370790dc7dfd