### PR TITLE
Load ZetaJS asynchronously in document editor

### DIFF
--- a/admin/js/resolate-zetajs-loader.js
+++ b/admin/js/resolate-zetajs-loader.js
@@ -28,6 +28,12 @@ const resolvedAssets = assets
         };
     });
 
+const readyEventName = config.readyEvent || 'resolateZeta:ready';
+const errorEventName = config.errorEvent || 'resolateZeta:error';
+const pendingSelector = config.pendingSelector || '[data-zetajs-disabled]';
+const loadingText = config.loadingText || '';
+const errorText = config.errorText || '';
+
 const head = document.head || document.getElementsByTagName('head')[0];
 const ensurePreload = ({ href, as }) => {
     if (!head || !href) {
@@ -64,6 +70,104 @@ if (!store.loadHelper) {
 
 window.resolateZeta = store;
 
-store.loadHelper().catch((error) => {
-    console.error('Resolate ZetaJS', error);
-});
+const disablePendingButtons = () => {
+    const apply = () => {
+        const elements = document.querySelectorAll(pendingSelector);
+        elements.forEach((element) => {
+            if (element.dataset.zetajsProcessed === '1') {
+                return;
+            }
+            const targetHref = element.dataset.zetajsHref || element.getAttribute('href');
+            if (targetHref && !element.dataset.zetajsHref) {
+                element.dataset.zetajsHref = targetHref;
+            }
+            element.dataset.zetajsProcessed = '1';
+            element.dataset.zetajsDisabled = '1';
+            element.classList.add('disabled');
+            element.setAttribute('aria-disabled', 'true');
+            element.removeAttribute('href');
+            if (!element.dataset.zetajsOriginalHtml) {
+                element.dataset.zetajsOriginalHtml = element.innerHTML;
+            }
+            if (loadingText) {
+                element.innerHTML = loadingText;
+            }
+            element.addEventListener('click', (event) => {
+                if (element.dataset.zetajsDisabled === '1') {
+                    event.preventDefault();
+                    event.stopPropagation();
+                }
+            });
+        });
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', apply, { once: true });
+    } else {
+        apply();
+    }
+};
+
+const enablePendingButtons = () => {
+    const elements = document.querySelectorAll(pendingSelector);
+    elements.forEach((element) => {
+        if (element.dataset.zetajsDisabled !== '1') {
+            return;
+        }
+        const targetHref = element.dataset.zetajsHref;
+        if (targetHref) {
+            element.setAttribute('href', targetHref);
+        }
+        element.classList.remove('disabled');
+        element.removeAttribute('aria-disabled');
+        element.dataset.zetajsDisabled = '0';
+        element.removeAttribute('data-zetajs-disabled');
+        if (element.dataset.zetajsOriginalHtml && loadingText && element.innerHTML === loadingText) {
+            element.innerHTML = element.dataset.zetajsOriginalHtml;
+        }
+        element.dataset.zetajsReady = '1';
+    });
+};
+
+const markErrorState = (error) => {
+    if (errorText) {
+        const elements = document.querySelectorAll(pendingSelector);
+        elements.forEach((element) => {
+            element.classList.add('disabled');
+            element.setAttribute('aria-disabled', 'true');
+            element.dataset.zetajsDisabled = '1';
+            element.dataset.zetajsReady = '0';
+            element.innerHTML = errorText;
+        });
+    }
+    const detail = { error };
+    window.dispatchEvent(new CustomEvent(errorEventName, { detail }));
+};
+
+window.addEventListener(readyEventName, enablePendingButtons);
+
+disablePendingButtons();
+
+const signalReady = () => {
+    window.dispatchEvent(new CustomEvent(readyEventName));
+};
+
+const bootstrap = () => {
+    if (store.ready || store.helper) {
+        store.ready = true;
+        signalReady();
+        return;
+    }
+    store.loadHelper()
+        .then((module) => {
+            store.ready = true;
+            store.helper = module;
+            signalReady();
+        })
+        .catch((error) => {
+            console.error('Resolate ZetaJS', error);
+            markErrorState(error);
+        });
+};
+
+bootstrap();


### PR DESCRIPTION
## Summary
- gate the CDN loader to emit readiness events with localized loading/error labels
- render document action links in CDN mode as disabled until ZetaJS is ready
- re-enable preview and download buttons once the browser-side helper finishes loading

## Testing
- php -l includes/class-resolate-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68ecc2a332e08322b98698853155b1fb