### PR TITLE
Restrict ZetaJS loader to document edit screens

### DIFF
--- a/includes/class-resolate-admin.php
+++ b/includes/class-resolate-admin.php
@@ -57,7 +57,10 @@ class Resolate_Admin2 {
      * @param string $hook Current admin page hook.
      * @return void
      */
-    public function enqueue_zetajs_loader( $hook ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+    public function enqueue_zetajs_loader( $hook ) {
+        if ( ! in_array( $hook, array( 'post.php', 'post-new.php' ), true ) ) {
+            return;
+        }
         if ( ! function_exists( 'get_current_screen' ) ) {
             return;
         }


### PR DESCRIPTION
## Summary
- ensure the ZetaJS loader only enqueues on document edit and creation pages
- avoid loading heavy ZetaJS assets on other admin screens like the document list

## Testing
- php -l includes/class-resolate-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68ecc670dde0832292fcce5420174bba