### PR TITLE
Delay ZetaJS loading with export modal

### DIFF
--- a/admin/css/resolate-export-modal.css
+++ b/admin/css/resolate-export-modal.css
@@ -1,0 +1,137 @@
+.resolate-export-modal[hidden] {
+    display: none;
+}
+
+.resolate-export-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 100000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: inherit;
+}
+
+.resolate-export-modal__overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+}
+
+.resolate-export-modal__dialog {
+    position: relative;
+    z-index: 1;
+    width: min(520px, calc(100% - 32px));
+    max-height: 90vh;
+    overflow-y: auto;
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 18px 45px rgba(0, 0, 0, 0.25);
+    padding: 24px;
+}
+
+.resolate-export-modal__title {
+    margin-top: 0;
+    margin-bottom: 12px;
+    font-size: 20px;
+    font-weight: 600;
+}
+
+.resolate-export-modal__intro {
+    margin: 0 0 16px;
+    color: #50575e;
+    font-size: 14px;
+}
+
+.resolate-export-modal__close {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    border: 0;
+    background: transparent;
+    color: #1d2327;
+    font-size: 22px;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.resolate-export-modal__close:focus {
+    outline: 2px solid #2271b1;
+    outline-offset: 2px;
+}
+
+.resolate-export-modal__steps {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 16px;
+}
+
+.resolate-export-modal__step {
+    padding: 10px 0;
+    border-bottom: 1px solid #dcdcde;
+}
+
+.resolate-export-modal__step:last-child {
+    border-bottom: 0;
+}
+
+.resolate-export-modal__step-title {
+    display: block;
+    font-weight: 600;
+    color: #1d2327;
+}
+
+.resolate-export-modal__step-status {
+    display: block;
+    font-size: 12px;
+    color: #646970;
+    margin-top: 2px;
+}
+
+.resolate-export-modal__step.is-active .resolate-export-modal__step-status {
+    color: #2271b1;
+}
+
+.resolate-export-modal__step.is-ready .resolate-export-modal__step-status {
+    color: #1d2327;
+}
+
+.resolate-export-modal__step.is-done .resolate-export-modal__step-status {
+    color: #198754;
+}
+
+.resolate-export-modal__step.is-error .resolate-export-modal__step-status {
+    color: #b32d2e;
+}
+
+.resolate-export-modal__step.is-disabled {
+    opacity: 0.6;
+}
+
+.resolate-export-modal__buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 12px;
+}
+
+.resolate-export-modal__links {
+    margin-bottom: 12px;
+}
+
+.resolate-export-modal__notice {
+    margin: 0;
+    font-size: 12px;
+    color: #646970;
+}
+
+.resolate-export-modal__frame {
+    display: none;
+    width: 0;
+    height: 0;
+    border: 0;
+}
+
+body.resolate-export-modal--open {
+    overflow: hidden;
+}

--- a/admin/js/resolate-export-modal.js
+++ b/admin/js/resolate-export-modal.js
@@ -1,0 +1,266 @@
+(function ($) {
+    'use strict';
+
+    const config = window.resolateExportModalConfig || {};
+    const selectors = {
+        modal: '#resolate-export-modal',
+        open: '[data-resolate-export-modal-open]',
+        close: '[data-resolate-export-modal-close]',
+        step: '[data-resolate-step]'
+    };
+    const bodyOpenClass = 'resolate-export-modal--open';
+    const readyEvent = (config.events && config.events.ready) || 'resolateZeta:ready';
+    const errorEvent = (config.events && config.events.error) || 'resolateZeta:error';
+    const frameTarget = config.frameTarget || 'resolateExportFrame';
+    const strings = config.strings || {};
+
+    const state = {
+        loaderPromise: null,
+        loaderLoaded: false,
+        lastTrigger: null
+    };
+
+    function getModal() {
+        return $(selectors.modal);
+    }
+
+    function normalizeAvailable(value) {
+        if (typeof value === 'string') {
+            return value === '1';
+        }
+        return Boolean(value);
+    }
+
+    function setStepState(step, stateName, message) {
+        const $modal = getModal();
+        const $step = $modal.find(selectors.step + '[data-resolate-step="' + step + '"]');
+        if (!$step.length) {
+            return;
+        }
+        const states = 'is-pending is-active is-ready is-done is-error';
+        $step.removeClass(states);
+        if (stateName) {
+            $step.addClass('is-' + stateName);
+        }
+        if (typeof message === 'string') {
+            const $status = $step.find('[data-resolate-step-status]');
+            if ($status.length) {
+                $status.text(message);
+            }
+        }
+    }
+
+    function resetSteps() {
+        const $modal = getModal();
+        setStepState('loader', 'active', strings.loaderLoading || '');
+        $modal.find(selectors.step).each(function () {
+            const $item = $(this);
+            const key = $item.data('resolate-step');
+            if (key === 'loader') {
+                return;
+            }
+            const available = normalizeAvailable($item.data('resolate-step-available'));
+            if (available) {
+                setStepState(key, 'pending', strings.stepPending || '');
+            } else {
+                $item.addClass('is-disabled');
+            }
+        });
+    }
+
+    function markStepsReady() {
+        const $modal = getModal();
+        $modal.find(selectors.step).each(function () {
+            const $item = $(this);
+            const key = $item.data('resolate-step');
+            if (key === 'loader') {
+                return;
+            }
+            if (!normalizeAvailable($item.data('resolate-step-available'))) {
+                return;
+            }
+            setStepState(key, 'ready', strings.stepReady || '');
+            const $button = $modal.find('[data-resolate-step-target="' + key + '"]');
+            if ($button.length) {
+                $button.removeClass('disabled').removeAttr('aria-disabled');
+            }
+        });
+    }
+
+    function ensureLoader() {
+        if (state.loaderLoaded || (window.resolateZeta && window.resolateZeta.ready)) {
+            state.loaderLoaded = true;
+            return Promise.resolve();
+        }
+        if (state.loaderPromise) {
+            return state.loaderPromise;
+        }
+        state.loaderPromise = new Promise(function (resolve, reject) {
+            const onReady = function () {
+                window.removeEventListener(readyEvent, onReady);
+                window.removeEventListener(errorEvent, onError);
+                state.loaderLoaded = true;
+                state.loaderPromise = null;
+                resolve();
+            };
+            const onError = function (event) {
+                window.removeEventListener(readyEvent, onReady);
+                window.removeEventListener(errorEvent, onError);
+                state.loaderPromise = null;
+                reject(event);
+            };
+            window.addEventListener(readyEvent, onReady, { once: true });
+            window.addEventListener(errorEvent, onError, { once: true });
+
+            if (config.loaderConfig) {
+                window.resolateZetaLoaderConfig = $.extend(true, {}, config.loaderConfig, window.resolateZetaLoaderConfig || {});
+            }
+
+            if (window.resolateZeta && window.resolateZeta.ready) {
+                onReady();
+                return;
+            }
+
+            const existing = document.querySelector('script[data-resolate-zetajs-loader="1"]');
+            if (existing) {
+                return;
+            }
+
+            const scriptUrl = config.loaderUrl;
+            if (!scriptUrl) {
+                onError(new Error('Missing loader URL'));
+                return;
+            }
+
+            const script = document.createElement('script');
+            script.type = 'module';
+            script.src = scriptUrl;
+            script.dataset.resolateZetajsLoader = '1';
+            script.addEventListener('error', onError);
+            document.head.appendChild(script);
+        });
+
+        return state.loaderPromise;
+    }
+
+    function getDownloadFrame() {
+        const frames = document.getElementsByName(frameTarget);
+        if (frames && frames.length) {
+            return frames[0];
+        }
+        return null;
+    }
+
+    function attachFrameListener($modal) {
+        const frame = getDownloadFrame();
+        if (!frame) {
+            return;
+        }
+        frame.addEventListener('load', function () {
+            const activeStep = frame.dataset.resolateActiveStep;
+            if (!activeStep) {
+                return;
+            }
+            setStepState(activeStep, 'done', strings.stepDone || '');
+            frame.dataset.resolateActiveStep = '';
+        });
+    }
+
+    function showModal(trigger) {
+        const $modal = getModal();
+        if (!$modal.length) {
+            return;
+        }
+        state.lastTrigger = trigger || null;
+        $modal.removeAttr('hidden');
+        $('body').addClass(bodyOpenClass);
+        resetSteps();
+        ensureLoader()
+            .then(function () {
+                setStepState('loader', 'done', strings.loaderReady || '');
+                markStepsReady();
+            })
+            .catch(function (error) {
+                setStepState('loader', 'error', strings.loaderError || '');
+                window.console.error('Resolate ZetaJS', error);
+            });
+        const $close = $modal.find(selectors.close).first();
+        if ($close.length) {
+            setTimeout(function () {
+                $close.trigger('focus');
+            }, 0);
+        }
+    }
+
+    function closeModal() {
+        const $modal = getModal();
+        if (!$modal.length || $modal.is('[hidden]')) {
+            return;
+        }
+        $modal.attr('hidden', 'hidden');
+        $('body').removeClass(bodyOpenClass);
+        if (state.lastTrigger && typeof state.lastTrigger.focus === 'function') {
+            try {
+                state.lastTrigger.focus();
+            } catch (e) {
+                // Ignore focus errors.
+            }
+        }
+        state.lastTrigger = null;
+    }
+
+    function handleActionClick(event) {
+        const $button = $(this);
+        if ($button.is('[aria-disabled="true"]') || $button.hasClass('disabled')) {
+            event.preventDefault();
+            return;
+        }
+        const step = $button.data('resolate-step-target');
+        if (!step) {
+            return;
+        }
+        setStepState(step, 'active', strings.stepWorking || '');
+        const frame = getDownloadFrame();
+        if (frame) {
+            frame.dataset.resolateActiveStep = step;
+        }
+    }
+
+    function bindEvents() {
+        const $modal = getModal();
+        if (!$modal.length) {
+            return;
+        }
+
+        attachFrameListener($modal);
+
+        $(document).on('click', selectors.open, function (event) {
+            event.preventDefault();
+            showModal(this);
+        });
+
+        $modal.on('click', selectors.close, function (event) {
+            event.preventDefault();
+            closeModal();
+        });
+
+        $modal.on('click', '.resolate-export-modal__overlay', function (event) {
+            if (event.target === this) {
+                closeModal();
+            }
+        });
+
+        $modal.on('click', '[data-resolate-step-target]', handleActionClick);
+
+        $(document).on('keydown', function (event) {
+            if ('Escape' === event.key && !getModal().is('[hidden]')) {
+                event.preventDefault();
+                closeModal();
+            }
+        });
+    }
+
+    $(function () {
+        bindEvents();
+    });
+})(jQuery);


### PR DESCRIPTION
## Summary
- add a lazy-loaded export modal for ZetaJS conversions in the document actions metabox
- enqueue new modal assets only in CDN mode and expose configuration to the browser
- style and script the modal to show progress steps and keep downloads in a hidden frame

## Testing
- composer test *(fails: phpunit not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ecd0c229c88322be53bb4131ad0f38