### PR TITLE
Move ZetaJS exports to dedicated workspace

### DIFF
--- a/admin/css/resolate-export-workspace.css
+++ b/admin/css/resolate-export-workspace.css
@@ -1,0 +1,176 @@
+:root {
+    color-scheme: light;
+}
+
+body.resolate-export-workspace {
+    margin: 0;
+    font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background: #f4f4f5;
+    color: #1f2933;
+}
+
+.resolate-export-workspace__layout {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.resolate-export-workspace__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px 24px;
+    background: #1d2327;
+    color: #fff;
+    gap: 16px;
+}
+
+.resolate-export-workspace__headline h1 {
+    margin: 0 0 4px;
+    font-size: 20px;
+    font-weight: 600;
+}
+
+.resolate-export-workspace__headline p {
+    margin: 0;
+    font-size: 14px;
+    opacity: 0.86;
+}
+
+.resolate-export-workspace__header-actions .button {
+    background: rgba(255, 255, 255, 0.12);
+    border-color: rgba(255, 255, 255, 0.4);
+    color: #fff;
+}
+
+.resolate-export-workspace__header-actions .button:hover,
+.resolate-export-workspace__header-actions .button:focus {
+    background: rgba(255, 255, 255, 0.2);
+    color: #fff;
+}
+
+.resolate-export-workspace__content {
+    flex: 1;
+    display: flex;
+    flex-direction: row;
+    gap: 24px;
+    padding: 24px;
+    box-sizing: border-box;
+}
+
+.resolate-export-workspace__preview {
+    flex: 3;
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.08), 0 20px 32px rgba(15, 23, 42, 0.16);
+    overflow: hidden;
+}
+
+.resolate-export-workspace__preview iframe {
+    width: 100%;
+    height: 100%;
+    min-height: 600px;
+    border: 0;
+}
+
+.resolate-export-workspace__panel {
+    flex: 2;
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.08), 0 20px 32px rgba(15, 23, 42, 0.12);
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.resolate-export-workspace__status {
+    font-weight: 600;
+    font-size: 16px;
+}
+
+.resolate-export-workspace__intro,
+.resolate-export-workspace__note {
+    margin: 0;
+    font-size: 14px;
+    color: #4b5563;
+}
+
+.resolate-export-workspace__steps {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.resolate-export-workspace__step {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 16px;
+    border-radius: 6px;
+    background: #f8fafc;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    font-size: 14px;
+}
+
+.resolate-export-workspace__step.is-active {
+    border-color: #2563eb;
+    background: rgba(37, 99, 235, 0.08);
+}
+
+.resolate-export-workspace__step.is-ready {
+    border-color: #16a34a;
+    background: rgba(22, 163, 74, 0.08);
+}
+
+.resolate-export-workspace__step.is-done {
+    border-color: #047857;
+    background: rgba(4, 120, 87, 0.08);
+}
+
+.resolate-export-workspace__step.is-error {
+    border-color: #dc2626;
+    background: rgba(220, 38, 38, 0.08);
+}
+
+.resolate-export-workspace__step.is-disabled {
+    opacity: 0.6;
+}
+
+.resolate-export-workspace__step-title {
+    font-weight: 600;
+}
+
+.resolate-export-workspace__step-status {
+    margin-left: auto;
+    white-space: nowrap;
+}
+
+.resolate-export-workspace__buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.resolate-export-workspace__buttons .button {
+    flex: 1 1 150px;
+    text-align: center;
+}
+
+.resolate-export-workspace__frame {
+    display: none;
+}
+
+@media (max-width: 1200px) {
+    .resolate-export-workspace__content {
+        flex-direction: column;
+    }
+
+    .resolate-export-workspace__preview iframe {
+        min-height: 480px;
+    }
+}

--- a/admin/js/resolate-export-workspace.js
+++ b/admin/js/resolate-export-workspace.js
@@ -1,0 +1,137 @@
+(function () {
+    'use strict';
+
+    const config = window.resolateExportWorkspaceConfig || {};
+    const readyEvent = (config.events && config.events.ready) || 'resolateZeta:ready';
+    const errorEvent = (config.events && config.events.error) || 'resolateZeta:error';
+    const frameTarget = config.frameTarget || 'resolateExportFrame';
+    const strings = config.strings || {};
+
+    const statusElement = document.querySelector('[data-resolate-workspace-status]');
+    const steps = Array.from(document.querySelectorAll('[data-resolate-step]'));
+
+    const frame = (function getFrame() {
+        const frames = document.getElementsByName(frameTarget);
+        if (frames && frames.length) {
+            return frames[0];
+        }
+        return null;
+    })();
+
+    function setStatus(message, stateClass) {
+        if (!statusElement) {
+            return;
+        }
+        statusElement.textContent = message || '';
+        statusElement.dataset.state = stateClass || '';
+    }
+
+    function setStepState(stepKey, state, message) {
+        const element = steps.find((item) => item.dataset.resolateStep === stepKey);
+        if (!element) {
+            return;
+        }
+        element.classList.remove('is-pending', 'is-active', 'is-ready', 'is-done', 'is-error');
+        if (state) {
+            element.classList.add('is-' + state);
+        }
+        if (typeof message === 'string') {
+            const status = element.querySelector('[data-resolate-step-status]');
+            if (status) {
+                status.textContent = message;
+            }
+        }
+    }
+
+    function markInitialStates() {
+        setStepState('loader', 'active', strings.loaderLoading || '');
+        steps.forEach((element) => {
+            const key = element.dataset.resolateStep;
+            if (!key || key === 'loader') {
+                return;
+            }
+            const available = element.dataset.resolateStepAvailable === '1';
+            if (available) {
+                setStepState(key, 'pending', strings.stepPending || '');
+            }
+        });
+    }
+
+    function enableButtons() {
+        document.querySelectorAll('[data-resolate-step-target]').forEach((button) => {
+            button.classList.remove('disabled');
+            button.removeAttribute('aria-disabled');
+        });
+    }
+
+    function handleReady() {
+        setStatus(strings.loaderReady || '');
+        setStepState('loader', 'done', strings.loaderReady || '');
+        steps.forEach((element) => {
+            const key = element.dataset.resolateStep;
+            if (!key || key === 'loader') {
+                return;
+            }
+            if (element.dataset.resolateStepAvailable !== '1') {
+                return;
+            }
+            setStepState(key, 'ready', strings.stepReady || '');
+        });
+        enableButtons();
+    }
+
+    function handleError(event) {
+        const message = strings.loaderError || '';
+        setStatus(message, 'error');
+        setStepState('loader', 'error', message);
+        if (event && event.detail && event.detail.error) {
+            // eslint-disable-next-line no-console
+            console.error('Resolate ZetaJS', event.detail.error);
+        }
+    }
+
+    function handleActionClick(event) {
+        const target = event.currentTarget;
+        if (target.classList.contains('disabled') || target.getAttribute('aria-disabled') === 'true') {
+            event.preventDefault();
+            return;
+        }
+        const step = target.dataset.resolateStepTarget;
+        if (!step) {
+            return;
+        }
+        setStepState(step, 'active', strings.stepWorking || '');
+        if (frame) {
+            frame.dataset.resolateActiveStep = step;
+        }
+    }
+
+    function handleFrameLoad() {
+        if (!frame) {
+            return;
+        }
+        const activeStep = frame.dataset.resolateActiveStep;
+        if (!activeStep) {
+            return;
+        }
+        setStepState(activeStep, 'done', strings.stepDone || '');
+        frame.dataset.resolateActiveStep = '';
+    }
+
+    function bindEvents() {
+        document.querySelectorAll('[data-resolate-step-target]').forEach((button) => {
+            button.addEventListener('click', handleActionClick);
+        });
+        if (frame) {
+            frame.addEventListener('load', handleFrameLoad);
+        }
+        window.addEventListener(readyEvent, handleReady, { once: true });
+        window.addEventListener(errorEvent, handleError, { once: true });
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        markInitialStates();
+        setStatus(strings.loaderLoading || '');
+        bindEvents();
+    });
+})();


### PR DESCRIPTION
## Summary
- replace the editor preview link with a "Previsualizar y exportar" button that opens a new window
- render a standalone workspace page in CDN mode that loads ZetaJS assets only there and drives the export flow
- add dedicated workspace styles and JavaScript to manage loader state, export steps, and iframe downloads

## Testing
- make lint *(fails: Docker is not available in the environment)*
- php -l includes/class-resolate-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68ecf3cfab188322949a277a24b298de