### PR TITLE
Add Collabora conversion engine option

### DIFF
--- a/includes/class-resolate-collabora.php
+++ b/includes/class-resolate-collabora.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * Collabora Online converter for Resolate.
+ *
+ * Provides document conversion capabilities by delegating to a Collabora
+ * Online instance using its public conversion API.
+ *
+ * @package Resolate
+ */
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Helper to convert documents through a Collabora Online endpoint.
+ */
+class Resolate_Collabora_Converter {
+
+    /**
+     * Check whether the converter has enough configuration to run.
+     *
+     * @return bool
+     */
+    public static function is_available() {
+        if ( '' === self::get_base_url() ) {
+            return false;
+        }
+
+        if ( ! function_exists( 'curl_init' ) || ! function_exists( 'curl_file_create' ) ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Return a human readable message describing missing configuration.
+     *
+     * @return string
+     */
+    public static function get_status_message() {
+        if ( '' === self::get_base_url() ) {
+            return __( 'Configura la URL base del servicio Collabora Online en los ajustes.', 'resolate' );
+        }
+
+        if ( ! function_exists( 'curl_init' ) || ! function_exists( 'curl_file_create' ) ) {
+            return __( 'Activa la extensión cURL de PHP para contactar con Collabora Online.', 'resolate' );
+        }
+
+        return '';
+    }
+
+    /**
+     * Convert a document using the configured Collabora endpoint.
+     *
+     * @param string $input_path   Absolute source path.
+     * @param string $output_path  Absolute destination path.
+     * @param string $output_format Desired output extension.
+     * @param string $input_format  Optional hint with the input extension.
+     * @return string|WP_Error
+     */
+    public static function convert( $input_path, $output_path, $output_format, $input_format = '' ) {
+        if ( ! file_exists( $input_path ) ) {
+            return new WP_Error( 'resolate_collabora_input_missing', __( 'El fichero origen para la conversión no existe.', 'resolate' ) );
+        }
+
+        $base_url = self::get_base_url();
+        if ( '' === $base_url ) {
+            return new WP_Error( 'resolate_collabora_not_configured', __( 'Configura la URL del servicio Collabora Online para convertir documentos.', 'resolate' ) );
+        }
+
+        if ( ! function_exists( 'curl_init' ) || ! function_exists( 'curl_file_create' ) ) {
+            return new WP_Error( 'resolate_collabora_missing_curl', __( 'La extensión cURL de PHP es necesaria para usar Collabora Online.', 'resolate' ) );
+        }
+
+        $supported_formats = array( 'pdf', 'docx', 'odt' );
+        $output_format     = sanitize_key( $output_format );
+        if ( ! in_array( $output_format, $supported_formats, true ) ) {
+            return new WP_Error( 'resolate_collabora_invalid_target', __( 'Formato de salida no soportado por Collabora.', 'resolate' ) );
+        }
+
+        $endpoint = untrailingslashit( $base_url ) . '/cool/convert-to/' . rawurlencode( $output_format );
+
+        $dir = dirname( $output_path );
+        if ( ! is_dir( $dir ) ) {
+            wp_mkdir_p( $dir );
+        }
+
+        if ( file_exists( $output_path ) ) {
+            @unlink( $output_path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+        }
+
+        $mime = self::guess_mime_type( $input_format, $input_path );
+
+        $post_fields = array(
+            'data' => curl_file_create( $input_path, $mime, basename( $input_path ) ),
+            'lang' => self::get_language(),
+        );
+
+        $ch = curl_init();
+        curl_setopt( $ch, CURLOPT_URL, $endpoint );
+        curl_setopt( $ch, CURLOPT_POST, true );
+        curl_setopt( $ch, CURLOPT_POSTFIELDS, $post_fields );
+        curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
+        curl_setopt( $ch, CURLOPT_HEADER, false );
+        curl_setopt( $ch, CURLOPT_TIMEOUT, apply_filters( 'resolate_collabora_timeout', 120 ) );
+        curl_setopt( $ch, CURLOPT_HTTPHEADER, array( 'Accept: application/octet-stream' ) );
+
+        if ( self::is_ssl_verification_disabled() ) {
+            curl_setopt( $ch, CURLOPT_SSL_VERIFYPEER, false );
+            curl_setopt( $ch, CURLOPT_SSL_VERIFYHOST, false );
+        }
+
+        $body = curl_exec( $ch );
+        if ( false === $body ) {
+            $error = curl_error( $ch );
+            $code  = curl_errno( $ch );
+            curl_close( $ch );
+            return new WP_Error(
+                'resolate_collabora_request_failed',
+                sprintf(
+                    /* translators: %s: error message returned by curl_error(). */
+                    __( 'Error al conectar con Collabora Online: %s', 'resolate' ),
+                    $error
+                ),
+                array( 'code' => $code )
+            );
+        }
+
+        $status = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
+        curl_close( $ch );
+
+        if ( $status < 200 || $status >= 300 ) {
+            return new WP_Error(
+                'resolate_collabora_http_error',
+                sprintf(
+                    /* translators: %d: HTTP status code returned by Collabora. */
+                    __( 'Collabora Online devolvió el código HTTP %d durante la conversión.', 'resolate' ),
+                    $status
+                ),
+                array( 'body' => $body )
+            );
+        }
+
+        $written = file_put_contents( $output_path, $body );
+        if ( false === $written ) {
+            return new WP_Error( 'resolate_collabora_write_failed', __( 'No se pudo guardar el fichero convertido en el disco.', 'resolate' ) );
+        }
+
+        return $output_path;
+    }
+
+    /**
+     * Retrieve the configured base URL.
+     *
+     * @return string
+     */
+    private static function get_base_url() {
+        $options = get_option( 'resolate_settings', array() );
+        $value   = isset( $options['collabora_base_url'] ) ? trim( (string) $options['collabora_base_url'] ) : '';
+        if ( '' === $value ) {
+            return '';
+        }
+
+        return untrailingslashit( esc_url_raw( $value ) );
+    }
+
+    /**
+     * Retrieve the language parameter configured for conversions.
+     *
+     * @return string
+     */
+    private static function get_language() {
+        $options = get_option( 'resolate_settings', array() );
+        $lang    = isset( $options['collabora_lang'] ) ? sanitize_text_field( $options['collabora_lang'] ) : 'es-ES';
+        if ( '' === $lang ) {
+            $lang = 'es-ES';
+        }
+
+        return $lang;
+    }
+
+    /**
+     * Determine whether SSL verification should be skipped.
+     *
+     * @return bool
+     */
+    private static function is_ssl_verification_disabled() {
+        $options = get_option( 'resolate_settings', array() );
+        return isset( $options['collabora_disable_ssl'] ) && '1' === $options['collabora_disable_ssl'];
+    }
+
+    /**
+     * Guess the MIME type for the uploaded document.
+     *
+     * @param string $input_format Format hint.
+     * @param string $path         Fallback file path.
+     * @return string
+     */
+    private static function guess_mime_type( $input_format, $path ) {
+        $input_format = sanitize_key( $input_format );
+        switch ( $input_format ) {
+            case 'docx':
+                return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+            case 'odt':
+                return 'application/vnd.oasis.opendocument.text';
+            case 'pdf':
+                return 'application/pdf';
+        }
+
+        $mime = function_exists( 'mime_content_type' ) ? mime_content_type( $path ) : 'application/octet-stream';
+        return $mime ? $mime : 'application/octet-stream';
+    }
+}

--- a/includes/class-resolate-conversion-manager.php
+++ b/includes/class-resolate-conversion-manager.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Conversion manager for Resolate.
+ *
+ * Chooses the appropriate engine (LibreOffice WASM via ZetaJS or Collabora
+ * Online) to convert documents generated from OpenTBS templates.
+ *
+ * @package Resolate
+ */
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main entry point to perform document conversions.
+ */
+class Resolate_Conversion_Manager {
+
+    const ENGINE_WASM      = 'wasm';
+    const ENGINE_COLLABORA = 'collabora';
+
+    /**
+     * Retrieve the engine configured in the plugin settings.
+     *
+     * @return string
+     */
+    public static function get_engine() {
+        $options = get_option( 'resolate_settings', array() );
+        $engine  = isset( $options['conversion_engine'] ) ? sanitize_key( $options['conversion_engine'] ) : self::ENGINE_WASM;
+        if ( ! in_array( $engine, array( self::ENGINE_WASM, self::ENGINE_COLLABORA ), true ) ) {
+            $engine = self::ENGINE_WASM;
+        }
+
+        return $engine;
+    }
+
+    /**
+     * Human readable label for the current engine.
+     *
+     * @param string|null $engine Optional engine name.
+     * @return string
+     */
+    public static function get_engine_label( $engine = null ) {
+        if ( null === $engine ) {
+            $engine = self::get_engine();
+        }
+
+        $labels = array(
+            self::ENGINE_WASM      => __( 'LibreOffice WASM (ZetaJS)', 'resolate' ),
+            self::ENGINE_COLLABORA => __( 'Collabora Online', 'resolate' ),
+        );
+
+        return isset( $labels[ $engine ] ) ? $labels[ $engine ] : $labels[ self::ENGINE_WASM ];
+    }
+
+    /**
+     * Determine if the configured engine can currently run server-side conversions.
+     *
+     * @return bool
+     */
+    public static function is_available() {
+        $engine = self::get_engine();
+
+        if ( self::ENGINE_COLLABORA === $engine ) {
+            require_once plugin_dir_path( __DIR__ ) . 'includes/class-resolate-collabora.php';
+            return Resolate_Collabora_Converter::is_available();
+        }
+
+        require_once plugin_dir_path( __DIR__ ) . 'includes/class-resolate-zetajs.php';
+        if ( Resolate_Zetajs_Converter::is_cdn_mode() ) {
+            return false;
+        }
+        return Resolate_Zetajs_Converter::is_available();
+    }
+
+    /**
+     * Perform a conversion using the configured engine.
+     *
+     * @param string $input_path   Absolute path to the source document.
+     * @param string $output_path  Absolute path to the target document.
+     * @param string $output_format Target extension (docx|odt|pdf).
+     * @param string $input_format  Optional source extension.
+     * @return string|WP_Error
+     */
+    public static function convert( $input_path, $output_path, $output_format, $input_format = '' ) {
+        $engine = self::get_engine();
+
+        if ( self::ENGINE_COLLABORA === $engine ) {
+            require_once plugin_dir_path( __DIR__ ) . 'includes/class-resolate-collabora.php';
+            return Resolate_Collabora_Converter::convert( $input_path, $output_path, $output_format, $input_format );
+        }
+
+        require_once plugin_dir_path( __DIR__ ) . 'includes/class-resolate-zetajs.php';
+        if ( Resolate_Zetajs_Converter::is_cdn_mode() ) {
+            return new WP_Error( 'resolate_conversion_not_available', self::get_unavailable_message( $input_format, $output_format ) );
+        }
+
+        return Resolate_Zetajs_Converter::convert( $input_path, $output_path, $output_format, $input_format );
+    }
+
+    /**
+     * Provide a contextual message describing what is missing to run conversions.
+     *
+     * @param string $source_format Optional source extension.
+     * @param string $target_format Optional target extension.
+     * @return string
+     */
+    public static function get_unavailable_message( $source_format = '', $target_format = '' ) {
+        $engine        = self::get_engine();
+        $context       = self::build_context_text( $source_format, $target_format );
+        $default_label = __( 'No se pudo completar la conversión.', 'resolate' );
+
+        if ( self::ENGINE_COLLABORA === $engine ) {
+            require_once plugin_dir_path( __DIR__ ) . 'includes/class-resolate-collabora.php';
+            $status = Resolate_Collabora_Converter::get_status_message();
+            if ( '' !== $status ) {
+                return $status . $context;
+            }
+            return __( 'Collabora Online no está disponible para convertir documentos.', 'resolate' ) . $context;
+        }
+
+        require_once plugin_dir_path( __DIR__ ) . 'includes/class-resolate-zetajs.php';
+        if ( Resolate_Zetajs_Converter::is_cdn_mode() ) {
+            return __( 'Desactiva el modo CDN de ZetaJS y configura el ejecutable local para realizar conversiones en el servidor.', 'resolate' ) . $context;
+        }
+
+        if ( Resolate_Zetajs_Converter::is_available() ) {
+            return $default_label . $context;
+        }
+
+        return __( 'Configura la ruta del ejecutable de ZetaJS (LibreOffice WASM) en el servidor.', 'resolate' ) . $context;
+    }
+
+    /**
+     * Build the contextual suffix for availability messages.
+     *
+     * @param string $source_format Source extension.
+     * @param string $target_format Target extension.
+     * @return string
+     */
+    private static function build_context_text( $source_format, $target_format ) {
+        $source_format = sanitize_key( $source_format );
+        $target_format = sanitize_key( $target_format );
+
+        if ( '' !== $source_format && '' !== $target_format ) {
+            return ' ' . sprintf(
+                /* translators: 1: source extension, 2: target extension. */
+                __( 'Necesario para convertir %1$s a %2$s.', 'resolate' ),
+                strtoupper( $source_format ),
+                strtoupper( $target_format )
+            );
+        }
+
+        if ( '' !== $target_format ) {
+            return ' ' . sprintf(
+                /* translators: %s: target extension. */
+                __( 'Necesario para generar %s.', 'resolate' ),
+                strtoupper( $target_format )
+            );
+        }
+
+        return '';
+    }
+}

--- a/includes/class-resolate-document-generator.php
+++ b/includes/class-resolate-document-generator.php
@@ -36,13 +36,16 @@ class Resolate_Document_Generator {
                 return $base_odt;
             }
 
-            require_once plugin_dir_path( __DIR__ ) . 'includes/class-resolate-zetajs.php';
-            if ( Resolate_Zetajs_Converter::is_cdn_mode() || ! Resolate_Zetajs_Converter::is_available() ) {
-                return new WP_Error( 'resolate_zetajs_not_available', __( 'Configura ZetaJS para convertir la plantilla ODT a DOCX.', 'resolate' ) );
+            require_once plugin_dir_path( __DIR__ ) . 'includes/class-resolate-conversion-manager.php';
+            if ( ! Resolate_Conversion_Manager::is_available() ) {
+                return new WP_Error(
+                    'resolate_conversion_not_available',
+                    Resolate_Conversion_Manager::get_unavailable_message( 'odt', 'docx' )
+                );
             }
 
             $target = self::build_output_path( $post_id, 'docx' );
-            $result = Resolate_Zetajs_Converter::convert( $base_odt, $target, 'docx', 'odt' );
+            $result = Resolate_Conversion_Manager::convert( $base_odt, $target, 'docx', 'odt' );
             if ( is_wp_error( $result ) ) {
                 return $result;
             }
@@ -76,13 +79,16 @@ class Resolate_Document_Generator {
                 return $base_docx;
             }
 
-            require_once plugin_dir_path( __DIR__ ) . 'includes/class-resolate-zetajs.php';
-            if ( Resolate_Zetajs_Converter::is_cdn_mode() || ! Resolate_Zetajs_Converter::is_available() ) {
-                return new WP_Error( 'resolate_zetajs_not_available', __( 'Configura ZetaJS para convertir la plantilla DOCX a ODT.', 'resolate' ) );
+            require_once plugin_dir_path( __DIR__ ) . 'includes/class-resolate-conversion-manager.php';
+            if ( ! Resolate_Conversion_Manager::is_available() ) {
+                return new WP_Error(
+                    'resolate_conversion_not_available',
+                    Resolate_Conversion_Manager::get_unavailable_message( 'docx', 'odt' )
+                );
             }
 
             $target = self::build_output_path( $post_id, 'odt' );
-            $result = Resolate_Zetajs_Converter::convert( $base_docx, $target, 'odt', 'docx' );
+            $result = Resolate_Conversion_Manager::convert( $base_docx, $target, 'odt', 'docx' );
             if ( is_wp_error( $result ) ) {
                 return $result;
             }
@@ -131,10 +137,10 @@ class Resolate_Document_Generator {
     }
 
     /**
-     * PDF generation is not implemented (use print preview in admin UI).
+     * Generate a PDF file using the configured conversion engine.
      *
      * @param int $post_id Document post ID.
-     * @return WP_Error
+     * @return string|WP_Error Absolute path to generated file or WP_Error on failure.
      */
     public static function generate_pdf( $post_id ) {
         try {
@@ -161,31 +167,17 @@ class Resolate_Document_Generator {
                 $source_format = 'odt';
             }
 
-            require_once plugin_dir_path( __DIR__ ) . 'includes/class-resolate-zetajs.php';
-            if ( ! class_exists( 'Resolate_Zetajs_Converter' ) ) {
-                return new WP_Error( 'resolate_zetajs_not_available', __( 'No se pudo cargar el conversor de ZetaJS.', 'resolate' ) );
-            }
-
-            if ( Resolate_Zetajs_Converter::is_cdn_mode() ) {
+            require_once plugin_dir_path( __DIR__ ) . 'includes/class-resolate-conversion-manager.php';
+            if ( ! Resolate_Conversion_Manager::is_available() ) {
                 return new WP_Error(
-                    'resolate_zetajs_browser_only',
-                    Resolate_Zetajs_Converter::get_browser_conversion_message(),
-                    array(
-                        'mode'       => 'cdn',
-                        'cdn_base'   => Resolate_Zetajs_Converter::get_cdn_base_url(),
-                        'source'     => $source_path,
-                        'source_ext' => $source_format,
-                    )
+                    'resolate_conversion_not_available',
+                    Resolate_Conversion_Manager::get_unavailable_message( $source_format, 'pdf' )
                 );
-            }
-
-            if ( ! Resolate_Zetajs_Converter::is_available() ) {
-                return new WP_Error( 'resolate_zetajs_not_available', __( 'Configura el ejecutable de ZetaJS para generar PDF.', 'resolate' ) );
             }
 
             $target = self::build_output_path( $post_id, 'pdf' );
 
-            $result = Resolate_Zetajs_Converter::convert( $source_path, $target, 'pdf', $source_format );
+            $result = Resolate_Conversion_Manager::convert( $source_path, $target, 'pdf', $source_format );
             if ( is_wp_error( $result ) ) {
                 return $result;
             }


### PR DESCRIPTION
## Summary
- add settings that let administrators choose the conversion engine and configure Collabora-specific parameters
- introduce a conversion manager plus a Collabora client so document generation can run through the selected backend
- refresh document exports and previews to use the chosen engine, highlight the base format button, and open PDF previews directly

## Testing
- composer test *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ed6739d16c83229465c0acd777bd2e