### PR TITLE
Set Collabora as default conversion engine

### DIFF
--- a/admin/class-resolate-admin-settings.php
+++ b/admin/class-resolate-admin-settings.php
@@ -321,11 +321,11 @@ class Resolate_Admin_Settings {
      */
     public function conversion_engine_render() {
         $options = get_option( 'resolate_settings', array() );
-        $current = isset( $options['conversion_engine'] ) ? sanitize_key( $options['conversion_engine'] ) : 'wasm';
+        $current = isset( $options['conversion_engine'] ) ? sanitize_key( $options['conversion_engine'] ) : 'collabora';
 
         $engines = array(
-            'wasm'      => __( 'LibreOffice WASM (ZetaJS en el servidor)', 'resolate' ),
             'collabora' => __( 'Servicio web Collabora Online', 'resolate' ),
+            'wasm'      => __( 'LibreOffice WASM en el navegador (experimental)', 'resolate' ),
         );
 
         echo '<fieldset>';
@@ -335,7 +335,7 @@ class Resolate_Admin_Settings {
             echo esc_html( $label );
             echo '</label>';
         }
-        echo '<p class="description">' . esc_html__( 'Define si las conversiones se realizan con el ejecutable de LibreOffice WASM (ZetaJS) o a través de un servidor Collabora.', 'resolate' ) . '</p>';
+        echo '<p class="description">' . esc_html__( 'Define si las conversiones se realizan a través de Collabora Online (predeterminado) o con LibreOffice WASM en el navegador (experimental).', 'resolate' ) . '</p>';
         echo '</fieldset>';
     }
 
@@ -345,9 +345,12 @@ class Resolate_Admin_Settings {
     public function collabora_base_url_render() {
         $options = get_option( 'resolate_settings', array() );
         $value   = isset( $options['collabora_base_url'] ) ? esc_url( $options['collabora_base_url'] ) : '';
+        if ( '' === $value && defined( 'RESOLATE_COLLABORA_DEFAULT_URL' ) ) {
+            $value = esc_url( RESOLATE_COLLABORA_DEFAULT_URL );
+        }
 
         echo '<input type="url" class="regular-text" name="resolate_settings[collabora_base_url]" value="' . esc_attr( $value ) . '" placeholder="https://example.com">';
-        echo '<p class="description">' . esc_html__( 'Ejemplo: https://demo.us.collaboraonline.com', 'resolate' ) . '</p>';
+        echo '<p class="description">' . esc_html__( 'Ejemplo: https://demo.collaboraonline.com', 'resolate' ) . '</p>';
     }
 
     /**
@@ -612,9 +615,9 @@ class Resolate_Admin_Settings {
 
         // Validate conversion engine.
         $valid_engines = array( 'wasm', 'collabora' );
-        $engine        = isset( $input['conversion_engine'] ) ? sanitize_key( $input['conversion_engine'] ) : 'wasm';
+        $engine        = isset( $input['conversion_engine'] ) ? sanitize_key( $input['conversion_engine'] ) : 'collabora';
         if ( ! in_array( $engine, $valid_engines, true ) ) {
-            $engine = 'wasm';
+            $engine = 'collabora';
         }
         $input['conversion_engine'] = $engine;
 

--- a/includes/class-resolate-collabora.php
+++ b/includes/class-resolate-collabora.php
@@ -158,6 +158,10 @@ class Resolate_Collabora_Converter {
     private static function get_base_url() {
         $options = get_option( 'resolate_settings', array() );
         $value   = isset( $options['collabora_base_url'] ) ? trim( (string) $options['collabora_base_url'] ) : '';
+        if ( '' === $value && defined( 'RESOLATE_COLLABORA_DEFAULT_URL' ) ) {
+            $value = trim( (string) RESOLATE_COLLABORA_DEFAULT_URL );
+        }
+
         if ( '' === $value ) {
             return '';
         }

--- a/includes/class-resolate-conversion-manager.php
+++ b/includes/class-resolate-conversion-manager.php
@@ -26,9 +26,9 @@ class Resolate_Conversion_Manager {
      */
     public static function get_engine() {
         $options = get_option( 'resolate_settings', array() );
-        $engine  = isset( $options['conversion_engine'] ) ? sanitize_key( $options['conversion_engine'] ) : self::ENGINE_WASM;
+        $engine  = isset( $options['conversion_engine'] ) ? sanitize_key( $options['conversion_engine'] ) : self::ENGINE_COLLABORA;
         if ( ! in_array( $engine, array( self::ENGINE_WASM, self::ENGINE_COLLABORA ), true ) ) {
-            $engine = self::ENGINE_WASM;
+            $engine = self::ENGINE_COLLABORA;
         }
 
         return $engine;
@@ -46,11 +46,11 @@ class Resolate_Conversion_Manager {
         }
 
         $labels = array(
-            self::ENGINE_WASM      => __( 'LibreOffice WASM (ZetaJS)', 'resolate' ),
+            self::ENGINE_WASM      => __( 'LibreOffice WASM en el navegador (experimental)', 'resolate' ),
             self::ENGINE_COLLABORA => __( 'Collabora Online', 'resolate' ),
         );
 
-        return isset( $labels[ $engine ] ) ? $labels[ $engine ] : $labels[ self::ENGINE_WASM ];
+        return isset( $labels[ $engine ] ) ? $labels[ $engine ] : $labels[ self::ENGINE_COLLABORA ];
     }
 
     /**

--- a/includes/class-resolate-zetajs.php
+++ b/includes/class-resolate-zetajs.php
@@ -141,6 +141,12 @@ class Resolate_Zetajs_Converter {
      * @return string
      */
     public static function get_cdn_base_url() {
+        $options = get_option( 'resolate_settings', array() );
+        $engine  = isset( $options['conversion_engine'] ) ? sanitize_key( $options['conversion_engine'] ) : 'collabora';
+        if ( 'wasm' !== $engine ) {
+            return '';
+        }
+
         $base = defined( 'RESOLATE_ZETAJS_CDN_BASE' ) ? (string) RESOLATE_ZETAJS_CDN_BASE : '';
         /**
          * Filter the CDN base URL for ZetaJS assets.

--- a/resolate.php
+++ b/resolate.php
@@ -31,6 +31,10 @@ if ( ! defined( 'RESOLATE_ZETAJS_CDN_BASE' ) ) {
     define( 'RESOLATE_ZETAJS_CDN_BASE', 'https://cdn.zetaoffice.net/zetaoffice_latest/' );
 }
 
+if ( ! defined( 'RESOLATE_COLLABORA_DEFAULT_URL' ) ) {
+    define( 'RESOLATE_COLLABORA_DEFAULT_URL', 'https://demo.collaboraonline.com' );
+}
+
 /**
  * The code that runs during plugin activation.
  */


### PR DESCRIPTION
## Summary
- make Collabora the default export engine and highlight the browser WASM flow as experimental
- provide a default Collabora server URL and fall back to it when no custom value is stored
- avoid loading ZetaJS/WASM assets unless the WASM engine is selected

## Testing
- composer validate

------
https://chatgpt.com/codex/tasks/task_e_68ed6c4ce4e08322b5b8c4cd2b137698