### PR TITLE
Fix AJAX handler localization and document lint workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,9 @@ These are natural-language guidelines for agents to follow when developing the R
 - Use `./vendor/bin/phpcbf --standard=.phpcs.xml.dist` first to apply automatic fixes, then `./vendor/bin/phpcs --standard=.phpcs.xml.dist` to ensure the codebase is clean.
 - Composer scripts mirror these commands: `composer phpcbf` and `composer phpcs` respect the repository ignore list defined in `.phpcs.xml.dist`.
 - The `.phpcs.xml.dist` ruleset bundles the WordPress standard, limits scanning to PHP files, enables colorized output, suppresses warnings, and excludes vendor, assets, node_modules, tests/js, wp, tests, and `.composer` directories.
+- When working outside the `wp-env` Docker environment, call the binaries from `./vendor/bin/` directly. Inside wp-env, reuse the Make targets (`make fix` and `make lint`) which wrap `phpcbf`/`phpcs` with the same `.phpcs.xml.dist` ruleset path (`wp-content/plugins/resolate/.phpcs.xml.dist`).
+- The repository `composer.json` already whitelists the `dealerdirect/phpcodesniffer-composer-installer` plugin and exposes the scripts `composer phpcbf` and `composer phpcs`; prefer these helpers so the ignore list `--ignore=vendor/,assets/,node_modules/,tests/js/,wp/,wp-content/` stays in sync.
+- Run the beautifier before linting when fixing coding standards violations: `composer phpcbf` (or the equivalent binary invocation) followed by `composer phpcs`.
 
 ## Environment and tools
 

--- a/includes/ajax/class-resolate-ajax-handlers.php
+++ b/includes/ajax/class-resolate-ajax-handlers.php
@@ -37,10 +37,10 @@ class Resolate_Ajax_Handlers {
 	public function load_tasks_by_date() {
 		// Validate request and get parameters.
 		$validation_result = $this->validate_task_date_request();
-		if ( is_wp_error( $validation_result ) ) {
-			wp_send_json_error( $validation_result->get_error_message() );
-			return;
-		}
+               if ( is_wp_error( $validation_result ) ) {
+                       wp_send_json_error( esc_html( $validation_result->get_error_message() ) );
+                       return;
+               }
 
 		list( $date_obj, $user_id ) = $validation_result;
 
@@ -77,29 +77,29 @@ class Resolate_Ajax_Handlers {
 	 */
 	private function validate_task_date_request() {
 		// Verify nonce first before processing any form data.
-		if ( ! $this->verify_nonce() ) {
-			return new WP_Error( 'invalid_nonce', 'Invalid security token' );
-		}
+               if ( ! $this->verify_nonce() ) {
+                       return new WP_Error( 'invalid_nonce', __( 'Invalid security token.', 'resolate' ) );
+               }
 
 		// Now that nonce is verified, we can safely get parameters.
 		$date = $this->get_date_param();
 		$user_id = $this->get_user_id_param();
 
 		// Validate date format.
-		if ( ! $this->is_valid_date_format( $date ) ) {
-			return new WP_Error( 'invalid_date_format', 'Invalid date format' );
-		}
+               if ( ! $this->is_valid_date_format( $date ) ) {
+                       return new WP_Error( 'invalid_date_format', __( 'Invalid date format.', 'resolate' ) );
+               }
 
-		// Verify user permissions.
-		if ( ! $this->user_has_permission( $user_id ) ) {
-			return new WP_Error( 'permission_denied', 'Permission denied' );
-		}
+               // Verify user permissions.
+               if ( ! $this->user_has_permission( $user_id ) ) {
+                       return new WP_Error( 'permission_denied', __( 'Permission denied.', 'resolate' ) );
+               }
 
-		// Create date object.
-		$date_obj = DateTime::createFromFormat( 'Y-m-d', $date );
-		if ( ! $date_obj ) {
-			return new WP_Error( 'invalid_date', 'Invalid date' );
-		}
+               // Create date object.
+               $date_obj = DateTime::createFromFormat( 'Y-m-d', $date );
+               if ( ! $date_obj ) {
+                       return new WP_Error( 'invalid_date', __( 'Invalid date.', 'resolate' ) );
+               }
 
 		return array( $date_obj, $user_id );
 	}
@@ -149,8 +149,8 @@ class Resolate_Ajax_Handlers {
 		}
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce already verified in validate_task_date_request
-		return intval( $_POST['user_id'] );
-	}
+               return absint( wp_unslash( $_POST['user_id'] ) );
+       }
 
 	/**
 	 * Checks if the date format is valid.


### PR DESCRIPTION
## Summary
- localize AJAX error handling responses and sanitize the posted user id
- document the preferred PHPCS/PHPBF execution paths in AGENTS.md

## Testing
- composer phpcbf *(fails: `phpcbf` binary not installed in environment)*
- composer phpcs *(fails: `phpcs` binary not installed in environment)*
- php -l includes/ajax/class-resolate-ajax-handlers.php


------
https://chatgpt.com/codex/tasks/task_e_68ed7c11d4548322a35207a1a270a430