### PR TITLE
Fix Composer dependency name for TinyButStrong

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {    
     "require": {
-        "vendor/tinybutstrong": "*"
+        "tinybutstrong/tinybutstrong": "*"
     },
     "require-dev": {
         "phpcompatibility/phpcompatibility-wp": "*",


### PR DESCRIPTION
## Summary
- update the Composer requirement to use the published tinybutstrong/tinybutstrong package name so the dependency can be installed

## Testing
- composer validate

------
https://chatgpt.com/codex/tasks/task_e_68ed7d05229883229c2d924b3f84435b