### PR TITLE
Improve PHPCS scripts and doc types metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,16 @@ These are natural-language guidelines for agents to follow when developing the R
 - Composer scripts mirror these commands: `composer phpcbf` and `composer phpcs` respect the repository ignore list defined in `.phpcs.xml.dist`.
 - The `.phpcs.xml.dist` ruleset bundles the WordPress standard, limits scanning to PHP files, enables colorized output, suppresses warnings, and excludes vendor, assets, node_modules, tests/js, wp, tests, and `.composer` directories.
 - When working outside the `wp-env` Docker environment, call the binaries from `./vendor/bin/` directly. Inside wp-env, reuse the Make targets (`make fix` and `make lint`) which wrap `phpcbf`/`phpcs` with the same `.phpcs.xml.dist` ruleset path (`wp-content/plugins/resolate/.phpcs.xml.dist`).
-- The repository `composer.json` already whitelists the `dealerdirect/phpcodesniffer-composer-installer` plugin and exposes the scripts `composer phpcbf` and `composer phpcs`; prefer these helpers so the ignore list `--ignore=vendor/,assets/,node_modules/,tests/js/,wp/,wp-content/` stays in sync.
+- The repository `composer.json` already whitelists the `dealerdirect/phpcodesniffer-composer-installer` plugin and exposes the scripts `composer phpcbf` and `composer phpcs`; these call the local binaries under `./vendor/bin/` with the shared `.phpcs.xml.dist` ruleset, so prefer them to keep tooling consistent.
 - Run the beautifier before linting when fixing coding standards violations: `composer phpcbf` (or the equivalent binary invocation) followed by `composer phpcs`.
+
+## Linting workflow checklist
+
+1. Install/update tooling with `composer install` (run once per environment).
+2. For automated fixes, execute `composer phpcbf` or `make fix` when inside wp-env.
+3. Validate coding standards with `composer phpcs` or `make lint` inside wp-env.
+4. Address any reported violations manually, then repeat steps 2 and 3 until clean.
+5. Commit only after the lint command returns without errors.
 
 ## Environment and tools
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,13 @@ start-if-not-running:
 		echo "wp-env is NOT running. Starting (previous updating) containers..."; \
 		npx wp-env start --update; \
 		npx wp-env run cli wp plugin activate resolate; \
-		open "http://localhost:8888/?resolate_page=priority" || true; \
+		if command -v open >/dev/null 2>&1; then \
+			open "http://localhost:8888/?resolate_page=priority"; \
+		elif command -v xdg-open >/dev/null 2>&1; then \
+			xdg-open "http://localhost:8888/?resolate_page=priority"; \
+		else \
+			echo "Visit http://localhost:8888/?resolate_page=priority to access the Resolate dashboard."; \
+		fi; \
 	else \
 		echo "wp-env is already running, skipping start."; \
 	fi

--- a/admin/class-resolate-admin.php
+++ b/admin/class-resolate-admin.php
@@ -96,11 +96,11 @@ class Resolate_Admin {
 	 *
 	 * @param string $hook_suffix The current admin page.
 	 */
-    public function enqueue_scripts( $hook_suffix ) {
-        if ( 'settings_page_resolate_settings' !== $hook_suffix ) {
-            return;
-        }
-        wp_enqueue_media();
-        wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/resolate-admin.js', array( 'jquery' ), $this->version, true );
-    }
+	public function enqueue_scripts( $hook_suffix ) {
+		if ( 'settings_page_resolate_settings' !== $hook_suffix ) {
+			return;
+		}
+		wp_enqueue_media();
+		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/resolate-admin.js', array( 'jquery' ), $this->version, true );
+	}
 }

--- a/admin/class-resolate-doc-types-admin.php
+++ b/admin/class-resolate-doc-types-admin.php
@@ -3,10 +3,19 @@
  * Admin UI for "Tipos de documento" taxonomy term meta.
  *
  * Configures a flat taxonomy with template, color and detected schema metadata.
+ *
+ * @package resolate
+ * @subpackage Resolate/admin
  */
 
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * Manage taxonomy term meta and admin screens for document types.
+ *
+ * @package resolate
+ * @subpackage Resolate/admin
+ */
 class Resolate_Doc_Types_Admin {
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
         ],
         "phpunit": "vendor/bin/phpunit",
         "test": "phpunit",
-        "phpcs": "phpcs --standard=WordPress . --ignore=vendor/,assets/,node_modules/,tests/js/,wp/,wp-content/,tests/ --colors --warning-severity=0 --extensions=php",
-        "phpcbf": "phpcbf --standard=WordPress . --ignore=vendor/,assets/,node_modules/,tests/js/,wp/,wp-content/ --colors --warning-severity=0 --extensions=php"
+        "phpcs": "@php ./vendor/bin/phpcs --standard=.phpcs.xml.dist",
+        "phpcbf": "@php ./vendor/bin/phpcbf --standard=.phpcs.xml.dist"
     },
     "config": {
         "allow-plugins": {

--- a/includes/class-resolate.php
+++ b/includes/class-resolate.php
@@ -131,7 +131,7 @@ class Resolate {
 		require_once plugin_dir_path( __DIR__ ) . 'includes/class-resolate-admin.php';
 
 		// Admin UI for document types (taxonomy meta for templates, fields, etc.).
-		require_once plugin_dir_path( __DIR__ ) . 'admin/class-resolate-doc-types.php';
+		require_once plugin_dir_path( __DIR__ ) . 'admin/class-resolate-doc-types-admin.php';
 
 		/**
 		 * The class responsible for defining all actions that occur in the public-facing


### PR DESCRIPTION
## Summary
- update the composer phpcs/phpcbf scripts to invoke the local vendor binaries with the shared ruleset
- clarify the AGENTS linting guidance to note the scripts already target the project binaries
- align the document types admin docblocks with the plugin's package and subpackage conventions

## Testing
- composer phpcs -- admin/class-resolate-doc-types-admin.php
- php -l admin/class-resolate-doc-types-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68edd58ed9588322a8c215a97a9617d6