### PR TITLE
Refactor document fields storage

### DIFF
--- a/admin/class-resolate-admin-settings.php
+++ b/admin/class-resolate-admin-settings.php
@@ -502,7 +502,7 @@ class Resolate_Admin_Settings {
 		echo '</div>';
 		echo '<button type="button" class="button" id="resolate_odt_template_select">' . esc_html__( 'Seleccionar plantilla ODT', 'resolate' ) . '</button> ';
 		echo '<button type="button" class="button" id="resolate_odt_template_remove">' . esc_html__( 'Quitar', 'resolate' ) . '</button>';
-		echo '<p class="description">' . esc_html__( 'Sube una plantilla .odt con marcadores OpenTBS. Campos: [title], [objeto], [antecedentes], [fundamentos], [dispositivo], [firma], [margen].', 'resolate' ) . '</p>';
+			echo '<p class="description">' . esc_html__( 'Sube una plantilla .odt con marcadores OpenTBS. Los campos disponibles dependen del tipo de documento seleccionado. Siempre podrás usar [title] y [margen].', 'resolate' ) . '</p>';
 		echo '</div>';
 	}
 
@@ -523,7 +523,7 @@ class Resolate_Admin_Settings {
 		echo '</div>';
 		echo '<button type="button" class="button" id="resolate_docx_template_select">' . esc_html__( 'Seleccionar plantilla DOCX', 'resolate' ) . '</button> ';
 		echo '<button type="button" class="button" id="resolate_docx_template_remove">' . esc_html__( 'Quitar', 'resolate' ) . '</button>';
-		echo '<p class="description">' . esc_html__( 'Sube una plantilla .docx con marcadores OpenTBS. Campos: [title], [objeto], [antecedentes], [fundamentos], [dispositivo], [firma], [margen].', 'resolate' ) . '</p>';
+			echo '<p class="description">' . esc_html__( 'Sube una plantilla .docx con marcadores OpenTBS. Los campos disponibles dependen del tipo de documento seleccionado. Siempre podrás usar [title] y [margen].', 'resolate' ) . '</p>';
 		echo '</div>';
 	}
 


### PR DESCRIPTION
## Summary
- remove legacy static meta fields from document edit flow in favour of taxonomy-defined schema
- persist document section content within structured post_content markers and update generators to consume them
- update legacy preview to read structured sections while keeping backwards compatibility for existing meta

## Testing
- php -l includes/custom-post-types/class-resolate-documents.php
- php -l includes/class-resolate-document-generator.php
- php -l includes/class-resolate-admin-helper.php
- make test *(fails: Docker environment unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68ee046ff9fc83229110bc65449a5ac2