### PR TITLE
Improve OpenTBS placeholder parsing and field typing

### DIFF
--- a/admin/class-resolate-doc-types-admin.php
+++ b/admin/class-resolate-doc-types-admin.php
@@ -82,30 +82,36 @@ class Resolate_Doc_Types_Admin {
 			}
 		}
 
-		wp_localize_script(
-			'resolate-doc-types',
-			'resolateDocTypes',
-			array(
-				'ajax'       => array(
-					'url'   => admin_url( 'admin-ajax.php' ),
-					'nonce' => wp_create_nonce( 'resolate_doc_type_template' ),
-				),
-				'i18n'       => array(
-					'select'         => __( 'Seleccionar archivo', 'resolate' ),
-					'remove'         => __( 'Eliminar', 'resolate' ),
-					'fieldsDetected' => __( 'Campos detectados', 'resolate' ),
-					'noFields'       => __( 'No se encontraron campos en la plantilla.', 'resolate' ),
-					'typeDocx'       => __( 'Plantilla DOCX', 'resolate' ),
-					'typeOdt'        => __( 'Plantilla ODT', 'resolate' ),
-					'typeUnknown'    => __( 'Formato desconocido', 'resolate' ),
-					'diffAdded'      => __( 'Campos nuevos', 'resolate' ),
-					'diffRemoved'    => __( 'Campos eliminados', 'resolate' ),
-				),
-				'schema'     => $schema_slugs,
-				'templateId' => $template_id,
-				'templateExt' => $template_ext,
-			)
-		);
+                wp_localize_script(
+                        'resolate-doc-types',
+                        'resolateDocTypes',
+                        array(
+                                'ajax'        => array(
+                                        'url'   => admin_url( 'admin-ajax.php' ),
+                                        'nonce' => wp_create_nonce( 'resolate_doc_type_template' ),
+                                ),
+                                'i18n'        => array(
+                                        'select'         => __( 'Seleccionar archivo', 'resolate' ),
+                                        'remove'         => __( 'Eliminar', 'resolate' ),
+                                        'fieldsDetected' => __( 'Campos detectados', 'resolate' ),
+                                        'noFields'       => __( 'No se encontraron campos en la plantilla.', 'resolate' ),
+                                        'typeDocx'       => __( 'Plantilla DOCX', 'resolate' ),
+                                        'typeOdt'        => __( 'Plantilla ODT', 'resolate' ),
+                                        'typeUnknown'    => __( 'Formato desconocido', 'resolate' ),
+                                        'diffAdded'      => __( 'Campos nuevos', 'resolate' ),
+                                        'diffRemoved'    => __( 'Campos eliminados', 'resolate' ),
+                                ),
+                                'fieldTypes' => array(
+                                        'text'    => __( 'Texto', 'resolate' ),
+                                        'number'  => __( 'Número', 'resolate' ),
+                                        'boolean' => __( 'Booleano', 'resolate' ),
+                                        'date'    => __( 'Fecha', 'resolate' ),
+                                ),
+                                'schema'      => $schema_slugs,
+                                'templateId'  => $template_id,
+                                'templateExt' => $template_ext,
+                        )
+                );
 	}
 
 	/**
@@ -243,19 +249,47 @@ class Resolate_Doc_Types_Admin {
 
 		require_once plugin_dir_path( __DIR__ ) . 'includes/class-resolate-template-parser.php';
 
-		$path   = get_attached_file( $attachment_id );
-		$fields = Resolate_Template_Parser::extract_fields( $path );
-		if ( is_wp_error( $fields ) ) {
-			wp_send_json_error( array( 'message' => $fields->get_error_message() ) );
-		}
+                $path   = get_attached_file( $attachment_id );
+                $fields = Resolate_Template_Parser::extract_fields( $path );
+                if ( is_wp_error( $fields ) ) {
+                        wp_send_json_error( array( 'message' => $fields->get_error_message() ) );
+                }
 
-		$type = $this->detect_template_type( $path );
-		wp_send_json_success(
-			array(
-				'type'   => $type,
-				'fields' => $fields,
-			)
-		);
+                $type   = $this->detect_template_type( $path );
+                $output = array();
+                if ( is_array( $fields ) ) {
+                        foreach ( $fields as $field ) {
+                                if ( ! is_array( $field ) ) {
+                                        continue;
+                                }
+                                $placeholder = isset( $field['placeholder'] ) ? $this->sanitize_placeholder_name( $field['placeholder'] ) : '';
+                                $slug        = isset( $field['slug'] ) ? sanitize_key( $field['slug'] ) : '';
+                                if ( '' === $slug && '' !== $placeholder ) {
+                                        $slug = sanitize_key( str_replace( array( '.', ':' ), '_', strtolower( $placeholder ) ) );
+                                }
+                                if ( '' === $slug ) {
+                                        continue;
+                                }
+                                $label     = isset( $field['label'] ) ? sanitize_text_field( $field['label'] ) : $this->humanize_slug( $slug );
+                                $data_type = isset( $field['data_type'] ) ? sanitize_key( $field['data_type'] ) : 'text';
+                                if ( ! in_array( $data_type, array( 'text', 'number', 'boolean', 'date' ), true ) ) {
+                                        $data_type = 'text';
+                                }
+                                $output[] = array(
+                                        'slug'        => $slug,
+                                        'label'       => $label,
+                                        'placeholder' => $placeholder,
+                                        'data_type'   => $data_type,
+                                );
+                        }
+                }
+
+                wp_send_json_success(
+                        array(
+                                'type'   => $type,
+                                'fields' => $output,
+                        )
+                );
 	}
 
 	/**
@@ -280,21 +314,62 @@ class Resolate_Doc_Types_Admin {
 	 *
 	 * @return array[]
 	 */
-	private function build_schema_from_fields( $fields ) {
-		$schema = array();
-		foreach ( $fields as $field ) {
-			$slug = sanitize_key( $field );
-			if ( '' === $slug ) {
-				continue;
-			}
-			$schema[] = array(
-				'slug'  => $slug,
-				'label' => $this->humanize_slug( $slug ),
-				'type'  => 'textarea',
-			);
-		}
-		return $schema;
-	}
+        private function build_schema_from_fields( $fields ) {
+                $schema = array();
+                foreach ( $fields as $field ) {
+                        $placeholder = '';
+                        $slug        = '';
+                        $label       = '';
+                        $data_type   = 'text';
+
+                        if ( is_array( $field ) ) {
+                                $placeholder = isset( $field['placeholder'] ) ? $this->sanitize_placeholder_name( $field['placeholder'] ) : '';
+                                $slug        = isset( $field['slug'] ) ? sanitize_key( $field['slug'] ) : '';
+                                if ( '' === $slug && '' !== $placeholder ) {
+                                        $slug = sanitize_key( str_replace( array( '.', ':' ), '_', strtolower( $placeholder ) ) );
+                                }
+                                $label     = isset( $field['label'] ) ? sanitize_text_field( $field['label'] ) : '';
+                                $data_type = isset( $field['data_type'] ) ? sanitize_key( $field['data_type'] ) : 'text';
+                        } else {
+                                $placeholder = is_string( $field ) ? $this->sanitize_placeholder_name( $field ) : '';
+                                $slug        = sanitize_key( $placeholder );
+                        }
+
+                        if ( '' === $slug ) {
+                                continue;
+                        }
+                        if ( '' === $label ) {
+                                $label = $this->humanize_slug( '' !== $placeholder ? $placeholder : $slug );
+                        }
+                        if ( ! in_array( $data_type, array( 'text', 'number', 'boolean', 'date' ), true ) ) {
+                                $data_type = 'text';
+                        }
+                        if ( '' === $placeholder ) {
+                                $placeholder = $slug;
+                        }
+
+                        $schema[] = array(
+                                'slug'        => $slug,
+                                'label'       => $label,
+                                'type'        => 'textarea',
+                                'placeholder' => $placeholder,
+                                'data_type'   => $data_type,
+                        );
+                }
+                return $schema;
+        }
+
+        /**
+         * Sanitize a placeholder keeping TinyButStrong supported characters.
+         *
+         * @param string $name Placeholder name.
+         * @return string
+         */
+        private function sanitize_placeholder_name( $name ) {
+                $name = (string) $name;
+                $name = preg_replace( '/[^A-Za-z0-9._:-]/', '', $name );
+                return $name;
+        }
 
 	/**
 	 * Convert slug into a human readable label.

--- a/includes/custom-post-types/class-resolate-documents.php
+++ b/includes/custom-post-types/class-resolate-documents.php
@@ -1001,23 +1001,27 @@ class Resolate_Documents {
 			if ( ! is_array( $item ) ) {
 				continue;
 			}
-			$slug  = isset( $item['slug'] ) ? sanitize_key( $item['slug'] ) : '';
-			$label = isset( $item['label'] ) ? sanitize_text_field( $item['label'] ) : '';
-			$type  = isset( $item['type'] ) ? sanitize_key( $item['type'] ) : 'textarea';
-			if ( '' === $slug || '' === $label ) {
-				continue;
-			}
-			if ( ! in_array( $type, array( 'single', 'textarea', 'rich' ), true ) ) {
-				$type = 'textarea';
-			}
-			$out[] = array(
-				'slug'  => $slug,
-				'label' => $label,
-				'type'  => $type,
-			);
-		}
-		return $out;
-	}
+                        $slug        = isset( $item['slug'] ) ? sanitize_key( $item['slug'] ) : '';
+                        $label       = isset( $item['label'] ) ? sanitize_text_field( $item['label'] ) : '';
+                        $type        = isset( $item['type'] ) ? sanitize_key( $item['type'] ) : 'textarea';
+                        $placeholder = isset( $item['placeholder'] ) ? preg_replace( '/[^A-Za-z0-9._:-]/', '', (string) $item['placeholder'] ) : '';
+                        $data_type   = isset( $item['data_type'] ) ? sanitize_key( $item['data_type'] ) : '';
+                        if ( '' === $slug || '' === $label ) {
+                                continue;
+                        }
+                        if ( ! in_array( $type, array( 'single', 'textarea', 'rich' ), true ) ) {
+                                $type = 'textarea';
+                        }
+                        $out[] = array(
+                                'slug'        => $slug,
+                                'label'       => $label,
+                                'type'        => $type,
+                                'placeholder' => $placeholder,
+                                'data_type'   => $data_type,
+                        );
+                }
+                return $out;
+        }
 
 	/**
 	 * Collect meta values whose keys start with resolate_field_ but are not part of the schema.

--- a/resolate.php
+++ b/resolate.php
@@ -368,26 +368,43 @@ function resolate_detect_template_type( $path ) {
  * @return array[]
  */
 function resolate_build_schema_from_template( $path ) {
-	$fields = Resolate_Template_Parser::extract_fields( $path );
-	if ( is_wp_error( $fields ) || ! is_array( $fields ) ) {
-		return array();
-	}
+        $fields = Resolate_Template_Parser::extract_fields( $path );
+        if ( is_wp_error( $fields ) || ! is_array( $fields ) ) {
+                return array();
+        }
 
-	$schema = array();
-	foreach ( $fields as $field ) {
-		$slug = sanitize_key( $field );
-		if ( '' === $slug ) {
-			continue;
-		}
+        $schema = array();
+        foreach ( $fields as $field ) {
+                if ( ! is_array( $field ) ) {
+                        continue;
+                }
+                $placeholder = isset( $field['placeholder'] ) ? preg_replace( '/[^A-Za-z0-9._:-]/', '', (string) $field['placeholder'] ) : '';
+                $slug        = isset( $field['slug'] ) ? sanitize_key( $field['slug'] ) : '';
+                if ( '' === $slug && '' !== $placeholder ) {
+                        $slug = sanitize_key( str_replace( array( '.', ':' ), '_', strtolower( $placeholder ) ) );
+                }
+                if ( '' === $slug ) {
+                        continue;
+                }
+                $label     = isset( $field['label'] ) ? sanitize_text_field( $field['label'] ) : resolate_humanize_slug( '' !== $placeholder ? $placeholder : $slug );
+                $data_type = isset( $field['data_type'] ) ? sanitize_key( $field['data_type'] ) : 'text';
+                if ( ! in_array( $data_type, array( 'text', 'number', 'boolean', 'date' ), true ) ) {
+                        $data_type = 'text';
+                }
+                if ( '' === $placeholder ) {
+                        $placeholder = $slug;
+                }
 
-		$schema[] = array(
-			'slug'  => $slug,
-			'label' => resolate_humanize_slug( $slug ),
-			'type'  => 'textarea',
-		);
-	}
+                $schema[] = array(
+                        'slug'        => $slug,
+                        'label'       => $label,
+                        'type'        => 'textarea',
+                        'placeholder' => $placeholder,
+                        'data_type'   => $data_type,
+                );
+        }
 
-	return $schema;
+        return $schema;
 }
 
 /**


### PR DESCRIPTION
## Summary
- parse OpenTBS placeholders including parameters to capture original placeholder names and inferred data types
- expose detected field metadata in the document type admin UI and sanitize stored schema values
- normalize merge keys when rendering templates so TinyButStrong commands receive expected values and format numbers/booleans/dates accordingly

## Testing
- php -l includes/class-resolate-template-parser.php
- php -l admin/class-resolate-doc-types-admin.php
- php -l resolate.php
- php -l includes/class-resolate-document-generator.php
- php -l includes/custom-post-types/class-resolate-documents.php

------
https://chatgpt.com/codex/tasks/task_e_68ee11ea8d588322acd226ccd09bed5f