### PR TITLE
Fix OpenTBS VarRef population to avoid missing placeholder errors

### DIFF
--- a/includes/class-resolate-opentbs.php
+++ b/includes/class-resolate-opentbs.php
@@ -47,7 +47,17 @@ class Resolate_OpenTBS {
 			$tbs_engine->Plugin( TBS_INSTALL, OPENTBS_PLUGIN );
 			$tbs_engine->LoadTemplate( $template_path, OPENTBS_ALREADY_UTF8 );
 
+			if ( ! is_array( $fields ) ) {
+				$fields = array();
+			}
+
+			$tbs_engine->ResetVarRef( false );
+
 			foreach ( $fields as $k => $v ) {
+				if ( ! is_string( $k ) || '' === $k ) {
+					continue;
+				}
+				$tbs_engine->SetVarRefItem( $k, $v );
 				$tbs_engine->MergeField( $k, $v );
 			}
 


### PR DESCRIPTION
## Summary
- reset the TinyButStrong VarRef reference before merging template data
- populate VarRef with the prepared merge fields so [var.*] placeholders resolve correctly

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ee1b824df883228eb533ac282f1d33