### PR TITLE
Add global template fallback for document generation

### DIFF
--- a/includes/class-resolate-document-generator.php
+++ b/includes/class-resolate-document-generator.php
@@ -207,31 +207,37 @@ class Resolate_Document_Generator {
 			return '';
 		}
 
-			$tpl_id = 0;
-			$types  = wp_get_post_terms( $post_id, 'resolate_doc_type', array( 'fields' => 'ids' ) );
-			if ( ! is_wp_error( $types ) && ! empty( $types ) ) {
-				$type_id       = intval( $types[0] );
-				$type_template = intval( get_term_meta( $type_id, 'resolate_type_template_id', true ) );
-				$template_kind = sanitize_key( (string) get_term_meta( $type_id, 'resolate_type_template_type', true ) );
-				if ( 0 < $type_template ) {
-					if ( $template_kind === $format ) {
+		$tpl_id = 0;
+		$types  = wp_get_post_terms( $post_id, 'resolate_doc_type', array( 'fields' => 'ids' ) );
+		if ( ! is_wp_error( $types ) && ! empty( $types ) ) {
+			$type_id       = intval( $types[0] );
+			$type_template = intval( get_term_meta( $type_id, 'resolate_type_template_id', true ) );
+			$template_kind = sanitize_key( (string) get_term_meta( $type_id, 'resolate_type_template_type', true ) );
+			if ( 0 < $type_template ) {
+				if ( $template_kind === $format ) {
+					$tpl_id = $type_template;
+				} elseif ( '' === $template_kind ) {
+					$path = get_attached_file( $type_template );
+					if ( $path && strtolower( pathinfo( $path, PATHINFO_EXTENSION ) ) === $format ) {
 						$tpl_id = $type_template;
-					} elseif ( '' === $template_kind ) {
-						$path = get_attached_file( $type_template );
-						if ( $path && strtolower( pathinfo( $path, PATHINFO_EXTENSION ) ) === $format ) {
-							$tpl_id = $type_template;
-						}
 					}
 				}
-				if ( 0 >= $tpl_id ) {
-					$meta_key = 'resolate_type_' . $format . '_template';
-					$tpl_id   = intval( get_term_meta( $type_id, $meta_key, true ) );
-				}
 			}
-
 			if ( 0 >= $tpl_id ) {
-				return '';
+				$meta_key = 'resolate_type_' . $format . '_template';
+				$tpl_id   = intval( get_term_meta( $type_id, $meta_key, true ) );
 			}
+		}
+
+		if ( 0 >= $tpl_id ) {
+			$options    = get_option( 'resolate_settings', array() );
+			$option_key = 'docx' === $format ? 'docx_template_id' : 'odt_template_id';
+			$tpl_id     = isset( $options[ $option_key ] ) ? intval( $options[ $option_key ] ) : 0;
+		}
+
+		if ( 0 >= $tpl_id ) {
+			return '';
+		}
 
 		$template_path = get_attached_file( $tpl_id );
 		if ( ! $template_path || ! file_exists( $template_path ) ) {

--- a/tests/unit/includes/ResolateDocumentGeneratorTemplateTest.php
+++ b/tests/unit/includes/ResolateDocumentGeneratorTemplateTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Tests for Resolate_Document_Generator template resolution.
+ *
+ * @package Resolate
+ */
+
+/**
+ * @covers Resolate_Document_Generator
+ */
+class ResolateDocumentGeneratorTemplateTest extends Resolate_Test_Base {
+
+        /**
+         * Track attachments created during the test run.
+         *
+         * @var int[]
+         */
+        private $attachment_ids = array();
+
+        public function set_up() {
+                parent::set_up();
+                require_once plugin_dir_path( RESOLATE_PLUGIN_FILE ) . 'includes/class-resolate-document-generator.php';
+        }
+
+        public function tear_down() {
+                foreach ( $this->attachment_ids as $attachment_id ) {
+                        wp_delete_attachment( $attachment_id, true );
+                }
+                $this->attachment_ids = array();
+                delete_option( 'resolate_settings' );
+                parent::tear_down();
+        }
+
+        /**
+         * Ensure global template IDs are used when the document type lacks templates.
+         */
+        public function test_get_template_path_uses_global_odt_when_type_missing() {
+                $post_id = self::factory()->post->create(
+                        array(
+                                'post_type' => 'resolate_document',
+                        )
+                );
+
+                $attachment_id = $this->create_dummy_template( 'global-template.odt' );
+
+                update_option(
+                        'resolate_settings',
+                        array(
+                                'odt_template_id' => $attachment_id,
+                        )
+                );
+
+                $path = Resolate_Document_Generator::get_template_path( $post_id, 'odt' );
+
+                $this->assertSame( get_attached_file( $attachment_id ), $path );
+        }
+
+        /**
+         * Create a dummy template attachment for testing purposes.
+         *
+         * @param string $filename Desired filename for the attachment.
+         * @return int Attachment ID.
+         */
+        private function create_dummy_template( $filename ) {
+                $upload = wp_upload_bits( $filename, null, 'contenido de prueba' );
+                $this->assertEmpty( $upload['error'] );
+
+                $attachment_id        = $this->factory->attachment->create_upload_object( $upload['file'] );
+                $this->attachment_ids[] = $attachment_id;
+
+                return $attachment_id;
+        }
+}


### PR DESCRIPTION
## Summary
- fall back to the global Resolate templates when a document type does not define its own DOCX/ODT file
- add a PHPUnit test covering the global-template fallback for ODT generation

## Testing
- `composer test` *(fails: WordPress test bootstrap not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ee1d741394832290ac933c5ac82f56