### PR TITLE
Stream document exports and rely on type templates

### DIFF
--- a/includes/class-resolate-document-generator.php
+++ b/includes/class-resolate-document-generator.php
@@ -207,31 +207,31 @@ class Resolate_Document_Generator {
 			return '';
 		}
 
-			$tpl_id = 0;
-			$types  = wp_get_post_terms( $post_id, 'resolate_doc_type', array( 'fields' => 'ids' ) );
-			if ( ! is_wp_error( $types ) && ! empty( $types ) ) {
-				$type_id       = intval( $types[0] );
-				$type_template = intval( get_term_meta( $type_id, 'resolate_type_template_id', true ) );
-				$template_kind = sanitize_key( (string) get_term_meta( $type_id, 'resolate_type_template_type', true ) );
-				if ( 0 < $type_template ) {
-					if ( $template_kind === $format ) {
+		$tpl_id = 0;
+		$types  = wp_get_post_terms( $post_id, 'resolate_doc_type', array( 'fields' => 'ids' ) );
+		if ( ! is_wp_error( $types ) && ! empty( $types ) ) {
+			$type_id       = intval( $types[0] );
+			$type_template = intval( get_term_meta( $type_id, 'resolate_type_template_id', true ) );
+			$template_kind = sanitize_key( (string) get_term_meta( $type_id, 'resolate_type_template_type', true ) );
+			if ( 0 < $type_template ) {
+				if ( $template_kind === $format ) {
+					$tpl_id = $type_template;
+				} elseif ( '' === $template_kind ) {
+					$path = get_attached_file( $type_template );
+					if ( $path && strtolower( pathinfo( $path, PATHINFO_EXTENSION ) ) === $format ) {
 						$tpl_id = $type_template;
-					} elseif ( '' === $template_kind ) {
-						$path = get_attached_file( $type_template );
-						if ( $path && strtolower( pathinfo( $path, PATHINFO_EXTENSION ) ) === $format ) {
-							$tpl_id = $type_template;
-						}
 					}
 				}
-				if ( 0 >= $tpl_id ) {
-					$meta_key = 'resolate_type_' . $format . '_template';
-					$tpl_id   = intval( get_term_meta( $type_id, $meta_key, true ) );
-				}
 			}
-
 			if ( 0 >= $tpl_id ) {
-				return '';
+				$meta_key = 'resolate_type_' . $format . '_template';
+				$tpl_id   = intval( get_term_meta( $type_id, $meta_key, true ) );
 			}
+		}
+
+		if ( 0 >= $tpl_id ) {
+			return '';
+		}
 
 		$template_path = get_attached_file( $tpl_id );
 		if ( ! $template_path || ! file_exists( $template_path ) ) {


### PR DESCRIPTION
## Summary
- send the DOCX/ODT/PDF admin exports directly to the browser with download headers instead of redirecting to uploads URLs
- add a shared helper to validate and stream generated files from the admin actions
- remove the global template fallback so document types again rely on their configured templates

## Testing
- `composer test` *(fails: vendor/bin/phpunit missing in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ee1d741394832290ac933c5ac82f56