### PR TITLE
Add unit tests for annex array field handling

### DIFF
--- a/tests/unit/includes/ResolateDocumentGeneratorTest.php
+++ b/tests/unit/includes/ResolateDocumentGeneratorTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Tests for Resolate_Document_Generator array exports.
+ */
+
+class ResolateDocumentGeneratorTest extends WP_UnitTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+		register_post_type( 'resolate_document', array( 'public' => false ) );
+		register_taxonomy( 'resolate_doc_type', array( 'resolate_document' ) );
+	}
+
+	/**
+	 * It should expose array fields as decoded PHP arrays for template merges.
+	 */
+	public function test_build_merge_fields_includes_array_values() {
+		$term = wp_insert_term( 'Tipo Merge', 'resolate_doc_type' );
+		$term_id = intval( $term['term_id'] );
+		$schema  = array(
+			array(
+				'slug'        => 'annexes',
+				'label'       => 'Anexos',
+				'type'        => 'array',
+				'placeholder' => 'annexes',
+				'data_type'   => 'array',
+				'item_schema' => array(
+					'number'  => array(
+						'label'     => 'Número',
+						'type'      => 'single',
+						'data_type' => 'text',
+					),
+					'content' => array(
+						'label'     => 'Contenido',
+						'type'      => 'rich',
+						'data_type' => 'text',
+					),
+				),
+			),
+			array(
+				'slug'        => 'resolution_title',
+				'label'       => 'Título',
+				'type'        => 'textarea',
+				'placeholder' => 'resolution_title',
+				'data_type'   => 'text',
+			),
+		);
+		update_term_meta( $term_id, 'schema', $schema );
+		update_term_meta( $term_id, 'resolate_type_fields', $schema );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => 'resolate_document',
+				'post_title'  => 'Documento Merge',
+				'post_status' => 'draft',
+			)
+		);
+		wp_set_post_terms( $post_id, array( $term_id ), 'resolate_doc_type', false );
+
+		$doc = new Resolate_Documents();
+		$_POST['resolate_doc_type']               = (string) $term_id;
+		$_POST['tpl_fields']                      = wp_slash(
+			array(
+				'annexes' => array(
+					array(
+						'number'  => 'I',
+						'content' => '<p>Detalle I</p>',
+					),
+					array(
+						'number'  => 'II',
+						'content' => '<p>Detalle II</p>',
+					),
+				),
+			)
+		);
+		$_POST['resolate_field_resolution_title'] = '  Título base  ';
+
+		$data    = array( 'post_type' => 'resolate_document' );
+		$postarr = array( 'ID' => $post_id );
+		$result  = $doc->filter_post_data_compose_content( $data, $postarr );
+
+		remove_filter( 'wp_insert_post_data', array( $doc, 'filter_post_data_compose_content' ), 10 );
+		$_POST = array();
+		wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => $result['post_content'],
+			)
+		);
+
+		$ref     = new ReflectionClass( Resolate_Document_Generator::class );
+		$method  = $ref->getMethod( 'build_merge_fields' );
+		$method->setAccessible( true );
+		$fields  = $method->invoke( null, $post_id );
+
+		$this->assertArrayHasKey( 'annexes', $fields );
+		$this->assertIsArray( $fields['annexes'] );
+		$this->assertCount( 2, $fields['annexes'] );
+		$this->assertSame( 'I', $fields['annexes'][0]['number'] );
+		$this->assertSame( '<p>Detalle I</p>', $fields['annexes'][0]['content'] );
+		$this->assertSame( 'Título base', $fields['resolution_title'] );
+	}
+}

--- a/tests/unit/includes/ResolateTemplateParserTest.php
+++ b/tests/unit/includes/ResolateTemplateParserTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Tests for Resolate_Template_Parser schema building.
+ */
+
+class ResolateTemplateParserTest extends WP_UnitTestCase {
+
+	/**
+	 * It should detect array fields and build item schema entries.
+	 */
+	public function test_build_schema_from_field_definitions_detects_arrays() {
+		$fields = array(
+			array(
+				'placeholder' => 'annexes[*].number',
+				'slug'        => 'annexes_number',
+				'label'       => 'Annex Number',
+				'parameters'  => array(),
+				'data_type'   => 'text',
+			),
+			array(
+				'placeholder' => 'annexes[*].title',
+				'slug'        => 'annexes_title',
+				'label'       => 'Annex Title',
+				'parameters'  => array(),
+				'data_type'   => 'text',
+			),
+			array(
+				'placeholder' => 'annexes[*].content',
+				'slug'        => 'annexes_content',
+				'label'       => 'Annex Content',
+				'parameters'  => array(),
+				'data_type'   => 'text',
+			),
+			array(
+				'placeholder' => 'onshow',
+				'slug'        => 'onshow',
+				'label'       => 'On Show',
+				'parameters'  => array( 'repeat' => 'annexes' ),
+				'data_type'   => 'text',
+			),
+			array(
+				'placeholder' => 'resolution_title',
+				'slug'        => 'resolution_title',
+				'label'       => 'Resolution Title',
+				'parameters'  => array(),
+				'data_type'   => 'text',
+			),
+		);
+
+		$schema = Resolate_Template_Parser::build_schema_from_field_definitions( $fields );
+
+		$this->assertNotEmpty( $schema, 'La definición de esquema no debe estar vacía.' );
+
+		$array_field = null;
+		foreach ( $schema as $entry ) {
+			if ( isset( $entry['slug'] ) && 'annexes' === $entry['slug'] ) {
+				$array_field = $entry;
+				break;
+			}
+		}
+
+		$this->assertIsArray( $array_field, 'Se debe detectar el campo de anexos.' );
+		$this->assertSame( 'array', $array_field['type'] );
+		$this->assertSame( 'array', $array_field['data_type'] );
+		$this->assertArrayHasKey( 'item_schema', $array_field );
+		$this->assertArrayHasKey( 'number', $array_field['item_schema'] );
+		$this->assertArrayHasKey( 'title', $array_field['item_schema'] );
+		$this->assertArrayHasKey( 'content', $array_field['item_schema'] );
+		$this->assertSame( 'single', $array_field['item_schema']['number']['type'] );
+		$this->assertSame( 'rich', $array_field['item_schema']['content']['type'] );
+
+		$scalar_field = null;
+		foreach ( $schema as $entry ) {
+			if ( isset( $entry['slug'] ) && 'resolution_title' === $entry['slug'] ) {
+				$scalar_field = $entry;
+				break;
+			}
+		}
+
+		$this->assertIsArray( $scalar_field );
+		$this->assertSame( 'textarea', $scalar_field['type'] );
+		$this->assertSame( 'text', $scalar_field['data_type'] );
+	}
+}

--- a/tests/unit/includes/custom-post-types/ResolateDocumentsArrayFieldsTest.php
+++ b/tests/unit/includes/custom-post-types/ResolateDocumentsArrayFieldsTest.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Tests for array field persistence in Resolate_Documents.
+ */
+
+class ResolateDocumentsArrayFieldsTest extends WP_UnitTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+		register_post_type( 'resolate_document', array( 'public' => false ) );
+		register_taxonomy( 'resolate_doc_type', array( 'resolate_document' ) );
+	}
+
+	/**
+	 * It should sanitize and encode array fields into structured content JSON.
+	 */
+	public function test_filter_post_data_compose_content_saves_array_fields_as_json() {
+		$term = wp_insert_term( 'Tipo Anexos', 'resolate_doc_type' );
+		$term_id = intval( $term['term_id'] );
+		$schema  = $this->get_annex_schema();
+		update_term_meta( $term_id, 'schema', $schema );
+		update_term_meta( $term_id, 'resolate_type_fields', $schema );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => 'resolate_document',
+				'post_title'  => 'Documento',
+				'post_status' => 'draft',
+			)
+		);
+		wp_set_post_terms( $post_id, array( $term_id ), 'resolate_doc_type', false );
+
+		$doc = new Resolate_Documents();
+
+		$_POST['resolate_doc_type'] = (string) $term_id;
+		$_POST['tpl_fields']        = wp_slash(
+			array(
+				'annexes' => array(
+					array(
+						'number'  => ' I ',
+						'title'   => '  Marco  ',
+						'content' => '<p>Contenido <strong>válido</strong></p><script>alert(1)</script>',
+					),
+					array(
+						'number'  => '',
+						'title'   => '',
+						'content' => '',
+					),
+				),
+			)
+		);
+
+		$data    = array( 'post_type' => 'resolate_document' );
+		$postarr = array( 'ID' => $post_id );
+		$result  = $doc->filter_post_data_compose_content( $data, $postarr );
+
+		$structured = Resolate_Documents::parse_structured_content( $result['post_content'] );
+		$this->assertArrayHasKey( 'annexes', $structured );
+		$this->assertSame( 'array', $structured['annexes']['type'] );
+		$decoded = json_decode( $structured['annexes']['value'], true );
+		$this->assertIsArray( $decoded );
+		$this->assertCount( 1, $decoded, 'Solo el elemento con contenido debe persistir.' );
+		$this->assertSame( 'I', $decoded[0]['number'] );
+		$this->assertSame( 'Marco', $decoded[0]['title'] );
+		$this->assertSame( '<p>Contenido <strong>válido</strong></p>', $decoded[0]['content'] );
+
+		$_POST = array();
+		remove_filter( 'wp_insert_post_data', array( $doc, 'filter_post_data_compose_content' ), 10 );
+	}
+
+	/**
+	 * It should cap stored items to the configured maximum.
+	 */
+	public function test_filter_post_data_compose_content_limits_array_items() {
+		$term = wp_insert_term( 'Tipo Límite', 'resolate_doc_type' );
+		$term_id = intval( $term['term_id'] );
+		$schema  = $this->get_annex_schema();
+		update_term_meta( $term_id, 'schema', $schema );
+		update_term_meta( $term_id, 'resolate_type_fields', $schema );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => 'resolate_document',
+				'post_title'  => 'Documento',
+				'post_status' => 'draft',
+			)
+		);
+		wp_set_post_terms( $post_id, array( $term_id ), 'resolate_doc_type', false );
+
+		$items = array();
+		for ( $i = 0; $i < Resolate_Documents::ARRAY_FIELD_MAX_ITEMS + 5; $i++ ) {
+			$items[] = array(
+				'number'  => 'N' . $i,
+				'title'   => 'Título ' . $i,
+				'content' => 'Contenido ' . $i,
+			);
+		}
+
+		$doc = new Resolate_Documents();
+
+		$_POST['resolate_doc_type'] = (string) $term_id;
+		$_POST['tpl_fields']        = wp_slash(
+			array(
+				'annexes' => $items,
+			)
+		);
+
+		$data    = array( 'post_type' => 'resolate_document' );
+		$postarr = array( 'ID' => $post_id );
+		$result  = $doc->filter_post_data_compose_content( $data, $postarr );
+
+		$structured = Resolate_Documents::parse_structured_content( $result['post_content'] );
+		$decoded    = json_decode( $structured['annexes']['value'], true );
+		$this->assertCount( Resolate_Documents::ARRAY_FIELD_MAX_ITEMS, $decoded );
+		$last_index = Resolate_Documents::ARRAY_FIELD_MAX_ITEMS - 1;
+		$this->assertSame( 'N' . $last_index, $decoded[ $last_index ]['number'] );
+		$this->assertSame( 'Título ' . $last_index, $decoded[ $last_index ]['title'] );
+
+		$_POST = array();
+		remove_filter( 'wp_insert_post_data', array( $doc, 'filter_post_data_compose_content' ), 10 );
+	}
+
+	/**
+	 * Helper to build the annex schema fixture.
+	 *
+	 * @return array
+	 */
+	private function get_annex_schema() {
+		return array(
+			array(
+				'slug'        => 'annexes',
+				'label'       => 'Anexos',
+				'type'        => 'array',
+				'placeholder' => 'annexes',
+				'data_type'   => 'array',
+				'item_schema' => array(
+					'number'  => array(
+						'label'     => 'Número',
+						'type'      => 'single',
+						'data_type' => 'text',
+					),
+					'title'   => array(
+						'label'     => 'Título',
+						'type'      => 'single',
+						'data_type' => 'text',
+					),
+					'content' => array(
+						'label'     => 'Contenido',
+						'type'      => 'rich',
+						'data_type' => 'text',
+					),
+				),
+			),
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- add a Resolate_Template_Parser test covering array placeholder detection
- cover Resolate_Documents saving logic for array fields and item limits
- ensure Resolate_Document_Generator exposes annexes as decoded arrays for exports

## Testing
- `composer test` *(fails: missing WordPress wp-tests-config.php in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ee30cf252083229149dd9f656091e1