### PR TITLE
Implement repeatable array field support

### DIFF
--- a/admin/class-resolate-doc-types-admin.php
+++ b/admin/class-resolate-doc-types-admin.php
@@ -82,36 +82,36 @@ class Resolate_Doc_Types_Admin {
 			}
 		}
 
-                wp_localize_script(
-                        'resolate-doc-types',
-                        'resolateDocTypes',
-                        array(
-                                'ajax'        => array(
-                                        'url'   => admin_url( 'admin-ajax.php' ),
-                                        'nonce' => wp_create_nonce( 'resolate_doc_type_template' ),
-                                ),
-                                'i18n'        => array(
-                                        'select'         => __( 'Seleccionar archivo', 'resolate' ),
-                                        'remove'         => __( 'Eliminar', 'resolate' ),
-                                        'fieldsDetected' => __( 'Campos detectados', 'resolate' ),
-                                        'noFields'       => __( 'No se encontraron campos en la plantilla.', 'resolate' ),
-                                        'typeDocx'       => __( 'Plantilla DOCX', 'resolate' ),
-                                        'typeOdt'        => __( 'Plantilla ODT', 'resolate' ),
-                                        'typeUnknown'    => __( 'Formato desconocido', 'resolate' ),
-                                        'diffAdded'      => __( 'Campos nuevos', 'resolate' ),
-                                        'diffRemoved'    => __( 'Campos eliminados', 'resolate' ),
-                                ),
-                                'fieldTypes' => array(
-                                        'text'    => __( 'Texto', 'resolate' ),
-                                        'number'  => __( 'Número', 'resolate' ),
-                                        'boolean' => __( 'Booleano', 'resolate' ),
-                                        'date'    => __( 'Fecha', 'resolate' ),
-                                ),
-                                'schema'      => $schema_slugs,
-                                'templateId'  => $template_id,
-                                'templateExt' => $template_ext,
-                        )
-                );
+				wp_localize_script(
+					'resolate-doc-types',
+					'resolateDocTypes',
+					array(
+						'ajax'        => array(
+							'url'   => admin_url( 'admin-ajax.php' ),
+							'nonce' => wp_create_nonce( 'resolate_doc_type_template' ),
+						),
+						'i18n'        => array(
+							'select'         => __( 'Seleccionar archivo', 'resolate' ),
+							'remove'         => __( 'Eliminar', 'resolate' ),
+							'fieldsDetected' => __( 'Campos detectados', 'resolate' ),
+							'noFields'       => __( 'No se encontraron campos en la plantilla.', 'resolate' ),
+							'typeDocx'       => __( 'Plantilla DOCX', 'resolate' ),
+							'typeOdt'        => __( 'Plantilla ODT', 'resolate' ),
+							'typeUnknown'    => __( 'Formato desconocido', 'resolate' ),
+							'diffAdded'      => __( 'Campos nuevos', 'resolate' ),
+							'diffRemoved'    => __( 'Campos eliminados', 'resolate' ),
+						),
+						'fieldTypes' => array(
+							'text'    => __( 'Texto', 'resolate' ),
+							'number'  => __( 'Número', 'resolate' ),
+							'boolean' => __( 'Booleano', 'resolate' ),
+							'date'    => __( 'Fecha', 'resolate' ),
+						),
+						'schema'      => $schema_slugs,
+						'templateId'  => $template_id,
+						'templateExt' => $template_ext,
+					)
+				);
 	}
 
 	/**
@@ -217,11 +217,11 @@ class Resolate_Doc_Types_Admin {
 		}
 
 		if ( $template_id > 0 ) {
-			$path   = get_attached_file( $template_id );
-			$fields = Resolate_Template_Parser::extract_fields( $path );
+				$path   = get_attached_file( $template_id );
+				$fields = Resolate_Template_Parser::extract_fields( $path );
 			if ( ! is_wp_error( $fields ) ) {
-				$template_type = $this->detect_template_type( $path );
-				$schema        = $this->build_schema_from_fields( $fields );
+						$template_type = $this->detect_template_type( $path );
+						$schema        = $this->build_schema_from_fields( $fields );
 			}
 		}
 
@@ -249,47 +249,21 @@ class Resolate_Doc_Types_Admin {
 
 		require_once plugin_dir_path( __DIR__ ) . 'includes/class-resolate-template-parser.php';
 
-                $path   = get_attached_file( $attachment_id );
-                $fields = Resolate_Template_Parser::extract_fields( $path );
-                if ( is_wp_error( $fields ) ) {
-                        wp_send_json_error( array( 'message' => $fields->get_error_message() ) );
-                }
+				$path   = get_attached_file( $attachment_id );
+				$fields = Resolate_Template_Parser::extract_fields( $path );
+		if ( is_wp_error( $fields ) ) {
+				wp_send_json_error( array( 'message' => $fields->get_error_message() ) );
+		}
 
-                $type   = $this->detect_template_type( $path );
-                $output = array();
-                if ( is_array( $fields ) ) {
-                        foreach ( $fields as $field ) {
-                                if ( ! is_array( $field ) ) {
-                                        continue;
-                                }
-                                $placeholder = isset( $field['placeholder'] ) ? $this->sanitize_placeholder_name( $field['placeholder'] ) : '';
-                                $slug        = isset( $field['slug'] ) ? sanitize_key( $field['slug'] ) : '';
-                                if ( '' === $slug && '' !== $placeholder ) {
-                                        $slug = sanitize_key( str_replace( array( '.', ':' ), '_', strtolower( $placeholder ) ) );
-                                }
-                                if ( '' === $slug ) {
-                                        continue;
-                                }
-                                $label     = isset( $field['label'] ) ? sanitize_text_field( $field['label'] ) : $this->humanize_slug( $slug );
-                                $data_type = isset( $field['data_type'] ) ? sanitize_key( $field['data_type'] ) : 'text';
-                                if ( ! in_array( $data_type, array( 'text', 'number', 'boolean', 'date' ), true ) ) {
-                                        $data_type = 'text';
-                                }
-                                $output[] = array(
-                                        'slug'        => $slug,
-                                        'label'       => $label,
-                                        'placeholder' => $placeholder,
-                                        'data_type'   => $data_type,
-                                );
-                        }
-                }
+				$type   = $this->detect_template_type( $path );
+				$output = $this->build_schema_from_fields( $fields );
 
-                wp_send_json_success(
-                        array(
-                                'type'   => $type,
-                                'fields' => $output,
-                        )
-                );
+				wp_send_json_success(
+					array(
+						'type'   => $type,
+						'fields' => $output,
+					)
+				);
 	}
 
 	/**
@@ -314,62 +288,100 @@ class Resolate_Doc_Types_Admin {
 	 *
 	 * @return array[]
 	 */
-        private function build_schema_from_fields( $fields ) {
-                $schema = array();
-                foreach ( $fields as $field ) {
-                        $placeholder = '';
-                        $slug        = '';
-                        $label       = '';
-                        $data_type   = 'text';
+	private function build_schema_from_fields( $fields ) {
+			$raw_schema = Resolate_Template_Parser::build_schema_from_field_definitions( $fields );
+		if ( ! is_array( $raw_schema ) ) {
+				return array();
+		}
 
-                        if ( is_array( $field ) ) {
-                                $placeholder = isset( $field['placeholder'] ) ? $this->sanitize_placeholder_name( $field['placeholder'] ) : '';
-                                $slug        = isset( $field['slug'] ) ? sanitize_key( $field['slug'] ) : '';
-                                if ( '' === $slug && '' !== $placeholder ) {
-                                        $slug = sanitize_key( str_replace( array( '.', ':' ), '_', strtolower( $placeholder ) ) );
-                                }
-                                $label     = isset( $field['label'] ) ? sanitize_text_field( $field['label'] ) : '';
-                                $data_type = isset( $field['data_type'] ) ? sanitize_key( $field['data_type'] ) : 'text';
-                        } else {
-                                $placeholder = is_string( $field ) ? $this->sanitize_placeholder_name( $field ) : '';
-                                $slug        = sanitize_key( $placeholder );
-                        }
+			$schema = array();
+		foreach ( $raw_schema as $entry ) {
+			if ( ! is_array( $entry ) || empty( $entry['slug'] ) ) {
+					continue;
+			}
 
-                        if ( '' === $slug ) {
-                                continue;
-                        }
-                        if ( '' === $label ) {
-                                $label = $this->humanize_slug( '' !== $placeholder ? $placeholder : $slug );
-                        }
-                        if ( ! in_array( $data_type, array( 'text', 'number', 'boolean', 'date' ), true ) ) {
-                                $data_type = 'text';
-                        }
-                        if ( '' === $placeholder ) {
-                                $placeholder = $slug;
-                        }
+				$slug        = sanitize_key( $entry['slug'] );
+				$label       = isset( $entry['label'] ) ? sanitize_text_field( $entry['label'] ) : $this->humanize_slug( $slug );
+				$type        = isset( $entry['type'] ) ? sanitize_key( $entry['type'] ) : 'textarea';
+				$placeholder = isset( $entry['placeholder'] ) ? $this->sanitize_placeholder_name( $entry['placeholder'] ) : $slug;
+				$data_type   = isset( $entry['data_type'] ) ? sanitize_key( $entry['data_type'] ) : 'text';
 
-                        $schema[] = array(
-                                'slug'        => $slug,
-                                'label'       => $label,
-                                'type'        => 'textarea',
-                                'placeholder' => $placeholder,
-                                'data_type'   => $data_type,
-                        );
-                }
-                return $schema;
-        }
+			if ( '' === $slug ) {
+					continue;
+			}
+			if ( '' === $label ) {
+					$label = $this->humanize_slug( $slug );
+			}
+			if ( '' === $placeholder ) {
+					$placeholder = $slug;
+			}
 
-        /**
-         * Sanitize a placeholder keeping TinyButStrong supported characters.
-         *
-         * @param string $name Placeholder name.
-         * @return string
-         */
-        private function sanitize_placeholder_name( $name ) {
-                $name = (string) $name;
-                $name = preg_replace( '/[^A-Za-z0-9._:-]/', '', $name );
-                return $name;
-        }
+			if ( 'array' === $type ) {
+					$item_schema = array();
+				if ( isset( $entry['item_schema'] ) && is_array( $entry['item_schema'] ) ) {
+					foreach ( $entry['item_schema'] as $key => $item ) {
+						$item_key = sanitize_key( $key );
+						if ( '' === $item_key ) {
+									continue;
+						}
+						$item_label = isset( $item['label'] ) ? sanitize_text_field( $item['label'] ) : $this->humanize_slug( $item_key );
+						$item_type  = isset( $item['type'] ) ? sanitize_key( $item['type'] ) : 'textarea';
+						if ( ! in_array( $item_type, array( 'single', 'textarea', 'rich' ), true ) ) {
+										$item_type = 'textarea';
+						}
+							$item_data_type = isset( $item['data_type'] ) ? sanitize_key( $item['data_type'] ) : 'text';
+						if ( ! in_array( $item_data_type, array( 'text', 'number', 'boolean', 'date' ), true ) ) {
+							$item_data_type = 'text';
+						}
+							$item_schema[ $item_key ] = array(
+								'label'     => $item_label,
+								'type'      => $item_type,
+								'data_type' => $item_data_type,
+							);
+					}
+				}
+
+					$schema[] = array(
+						'slug'        => $slug,
+						'label'       => $label,
+						'type'        => 'array',
+						'placeholder' => $placeholder,
+						'data_type'   => 'array',
+						'item_schema' => $item_schema,
+					);
+					continue;
+			}
+
+			if ( ! in_array( $type, array( 'single', 'textarea', 'rich' ), true ) ) {
+					$type = 'textarea';
+			}
+			if ( ! in_array( $data_type, array( 'text', 'number', 'boolean', 'date' ), true ) ) {
+					$data_type = 'text';
+			}
+
+				$schema[] = array(
+					'slug'        => $slug,
+					'label'       => $label,
+					'type'        => $type,
+					'placeholder' => $placeholder,
+					'data_type'   => $data_type,
+				);
+		}
+
+			return $schema;
+	}
+
+		/**
+		 * Sanitize a placeholder keeping TinyButStrong supported characters.
+		 *
+		 * @param string $name Placeholder name.
+		 * @return string
+		 */
+	private function sanitize_placeholder_name( $name ) {
+			$name = (string) $name;
+			$name = preg_replace( '/[^A-Za-z0-9._:-]/', '', $name );
+			return $name;
+	}
 
 	/**
 	 * Convert slug into a human readable label.

--- a/includes/class-resolate-admin-helper.php
+++ b/includes/class-resolate-admin-helper.php
@@ -736,13 +736,17 @@ class Resolate_Admin_Helper {
 				if ( empty( $def['slug'] ) ) {
 					continue;
 				}
-				$slug  = sanitize_key( $def['slug'] );
-				$label = isset( $def['label'] ) ? sanitize_text_field( $def['label'] ) : '';
+								$slug  = sanitize_key( $def['slug'] );
+								$label = isset( $def['label'] ) ? sanitize_text_field( $def['label'] ) : '';
 				if ( '' === $slug ) {
-					continue;
+						continue;
+				}
+								$type = isset( $def['type'] ) ? sanitize_key( $def['type'] ) : 'textarea';
+				if ( 'array' === $type ) {
+						continue;
 				}
 				if ( '' === $label ) {
-					$label = $humanize( $slug );
+						$label = $humanize( $slug );
 				}
 				if ( '' === $label ) {
 					continue;
@@ -754,13 +758,17 @@ class Resolate_Admin_Helper {
 			}
 		} elseif ( ! empty( $structured_fields ) ) {
 			foreach ( $structured_fields as $slug => $info ) {
-				$slug  = sanitize_key( $slug );
+								$slug  = sanitize_key( $slug );
 				if ( '' === $slug ) {
-					continue;
+						continue;
 				}
-				$label = $humanize( $slug );
+								$type = isset( $info['type'] ) ? sanitize_key( $info['type'] ) : 'rich';
+				if ( 'array' === $type ) {
+						continue;
+				}
+								$label = $humanize( $slug );
 				if ( '' === $label ) {
-					continue;
+						continue;
 				}
 				$fields_to_render[] = array(
 					'slug'  => $slug,
@@ -790,50 +798,68 @@ class Resolate_Admin_Helper {
 			}
 		}
 
-		$annexes = get_post_meta( $post_id, 'resolate_annexes', true );
+				$annexes = array();
+		if ( isset( $structured_fields['annexes'] ) && isset( $structured_fields['annexes']['type'] ) && 'array' === sanitize_key( $structured_fields['annexes']['type'] ) ) {
+				$annex_value = isset( $structured_fields['annexes']['value'] ) ? (string) $structured_fields['annexes']['value'] : '';
+				$annexes     = Resolate_Documents::decode_array_field_value( $annex_value );
+		} else {
+				$legacy_annexes = get_post_meta( $post_id, 'resolate_annexes', true );
+			if ( is_array( $legacy_annexes ) ) {
+						$annexes = $legacy_annexes;
+			}
+		}
+
 		if ( is_array( $annexes ) && ! empty( $annexes ) ) {
-			$roman = function ( $num ) {
-				$map = array(
-					'M'  => 1000,
-					'CM' => 900,
-					'D'  => 500,
-					'CD' => 400,
-					'C'  => 100,
-					'XC' => 90,
-					'L'  => 50,
-					'XL' => 40,
-					'X'  => 10,
-					'IX' => 9,
-					'V'  => 5,
-					'IV' => 4,
-					'I'  => 1,
-				);
-				$res = '';
-				foreach ( $map as $rom => $int ) {
-					while ( $num >= $int ) {
-						$res .= $rom;
-						$num -= $int; }
-				}
-				return $res;
-			};
+				$roman = function ( $num ) {
+						$map = array(
+							'M'  => 1000,
+							'CM' => 900,
+							'D'  => 500,
+							'CD' => 400,
+							'C'  => 100,
+							'XC' => 90,
+							'L'  => 50,
+							'XL' => 40,
+							'X'  => 10,
+							'IX' => 9,
+							'V'  => 5,
+							'IV' => 4,
+							'I'  => 1,
+						);
+						$res = '';
+						foreach ( $map as $rom => $int ) {
+							while ( $num >= $int ) {
+								$res .= $rom;
+								$num -= $int; }
+						}
+						return $res;
+				};
 
 			foreach ( $annexes as $i => $anx ) {
-				$t = isset( $anx['title'] ) ? (string) $anx['title'] : '';
-				$c = isset( $anx['text'] ) ? (string) $anx['text'] : '';
-				$c = preg_replace( '/<\\/?font[^>]*>/i', '', (string) $c );
-				$c = preg_replace( '/font-family\\s*:\\s*[^;"\']+;?/i', '', (string) $c );
-				$c = preg_replace( '/font-size\\s*:\\s*[^;"\']+;?/i', '', (string) $c );
-				if ( '' === trim( $t ) && '' === trim( wp_strip_all_tags( (string) $c ) ) ) {
-					continue;
+							$number = isset( $anx['number'] ) ? (string) $anx['number'] : '';
+							$t      = isset( $anx['title'] ) ? (string) $anx['title'] : '';
+							$c      = '';
+				if ( isset( $anx['content'] ) ) {
+						$c = (string) $anx['content'];
+				} elseif ( isset( $anx['text'] ) ) {
+						$c = (string) $anx['text'];
 				}
-				$label = sprintf( 'Anexo %s', $roman( $i + 1 ) );
-				echo '<section data-new-page="1" data-avoid-break="1">';
-				echo '<h1>' . esc_html( $label ) . '</h1>';
+							$c = preg_replace( '/<\\/?font[^>]*>/i', '', (string) $c );
+							$c = preg_replace( '/font-family\\s*:\\s*[^;"\']+;?/i', '', (string) $c );
+							$c = preg_replace( '/font-size\\s*:\\s*[^;"\']+;?/i', '', (string) $c );
+				if ( '' === trim( $t ) && '' === trim( wp_strip_all_tags( (string) $c ) ) ) {
+						continue;
+				}
+							$label_number = '' !== trim( $number ) ? $number : $roman( $i + 1 );
+							/* translators: %s: annex identifier. */
+							$label = sprintf( __( 'Anexo %s', 'resolate' ), $label_number );
+							echo '<section data-new-page="1" data-avoid-break="1">';
+							echo '<h1>' . esc_html( $label ) . '</h1>';
 				if ( '' !== trim( $t ) ) {
 					echo '<h1>' . esc_html( $t ) . '</h1>';
 				}
-				echo wp_kses_post( $c );
-				echo '</section>';
+					echo wp_kses_post( $c );
+					echo '</section>';
 			}
 		}
 		echo '</div>';

--- a/includes/class-resolate-document-generator.php
+++ b/includes/class-resolate-document-generator.php
@@ -157,14 +157,14 @@ class Resolate_Document_Generator {
 			if ( is_wp_error( $odt_result ) ) {
 				$docx_result = self::generate_docx( $post_id );
 				if ( is_wp_error( $docx_result ) ) {
-				return new WP_Error(
-					'resolate_pdf_source_missing',
-					__( 'No se pudo generar el documento base porque el tipo de documento no tiene una plantilla DOCX u ODT configurada.', 'resolate' ),
-					array(
+					return new WP_Error(
+						'resolate_pdf_source_missing',
+						__( 'No se pudo generar el documento base porque el tipo de documento no tiene una plantilla DOCX u ODT configurada.', 'resolate' ),
+						array(
 							'odt'  => $odt_result,
 							'docx' => $docx_result,
-					)
-				);
+						)
+					);
 				}
 				$source_path   = $docx_result;
 				$source_format = 'docx';
@@ -301,20 +301,28 @@ class Resolate_Document_Generator {
 			} else {
 				$schema = self::get_type_schema( $type_id );
 			}
-                        foreach ( $schema as $def ) {
-                                if ( empty( $def['slug'] ) ) {
-                                        continue;
-                                }
-                                $slug        = sanitize_key( $def['slug'] );
-                                $placeholder = isset( $def['placeholder'] ) ? self::sanitize_placeholder_name( $def['placeholder'] ) : '';
-                                if ( '' === $placeholder ) {
-                                        $placeholder = $slug;
-                                }
-                                $data_type = isset( $def['data_type'] ) ? sanitize_key( $def['data_type'] ) : 'text';
-                                $value     = self::get_structured_field_value( $structured, $slug, $post_id );
-                                $value     = wp_strip_all_tags( $value );
-                                $fields[ $placeholder ] = self::normalize_field_value( $value, $data_type );
-                        }
+			foreach ( $schema as $def ) {
+				if ( empty( $def['slug'] ) ) {
+								continue;
+				}
+					$slug        = sanitize_key( $def['slug'] );
+					$placeholder = isset( $def['placeholder'] ) ? self::sanitize_placeholder_name( $def['placeholder'] ) : '';
+				if ( '' === $placeholder ) {
+									$placeholder = $slug;
+				}
+										$data_type = isset( $def['data_type'] ) ? sanitize_key( $def['data_type'] ) : 'text';
+										$type      = isset( $def['type'] ) ? sanitize_key( $def['type'] ) : 'textarea';
+
+				if ( 'array' === $type ) {
+						$items = self::get_array_field_items_for_merge( $structured, $slug, $post_id );
+						$fields[ $placeholder ] = $items;
+						continue;
+				}
+
+										$value = self::get_structured_field_value( $structured, $slug, $post_id );
+										$value = wp_strip_all_tags( $value );
+										$fields[ $placeholder ] = self::normalize_field_value( $value, $data_type );
+			}
 
 			$logos = get_term_meta( $type_id, 'resolate_type_logos', true );
 			if ( is_array( $logos ) && ! empty( $logos ) ) {
@@ -331,28 +339,33 @@ class Resolate_Document_Generator {
 			}
 		}
 
-                if ( ! empty( $structured ) ) {
-                        foreach ( $structured as $slug => $info ) {
-                                $slug = sanitize_key( $slug );
-                                if ( '' === $slug ) {
-                                        continue;
-                                }
-                                $placeholder = $slug;
-                                if ( isset( $fields[ $placeholder ] ) && '' !== $fields[ $placeholder ] ) {
-                                        continue;
-                                }
-                                $value = '';
-                                if ( isset( $info['value'] ) ) {
-                                        $value = (string) $info['value'];
-                                }
-                                if ( '' === $value ) {
-                                        $value = self::get_structured_field_value( $structured, $slug, $post_id );
-                                }
-                                $fields[ $placeholder ] = wp_strip_all_tags( $value );
-                        }
-                }
+		if ( ! empty( $structured ) ) {
+			foreach ( $structured as $slug => $info ) {
+						$slug = sanitize_key( $slug );
+				if ( '' === $slug ) {
+					continue;
+				}
+						$placeholder = $slug;
+				if ( isset( $fields[ $placeholder ] ) && '' !== $fields[ $placeholder ] ) {
+					continue;
+				}
+				if ( isset( $info['type'] ) && 'array' === sanitize_key( $info['type'] ) ) {
+						$fields[ $placeholder ] = self::get_array_field_items_for_merge( $structured, $slug, $post_id );
+						continue;
+				}
 
-		return $fields;
+						$value = '';
+				if ( isset( $info['value'] ) ) {
+						$value = (string) $info['value'];
+				}
+				if ( '' === $value ) {
+						$value = self::get_structured_field_value( $structured, $slug, $post_id );
+				}
+						$fields[ $placeholder ] = wp_strip_all_tags( $value );
+			}
+		}
+
+				return $fields;
 	}
 
 
@@ -365,23 +378,59 @@ class Resolate_Document_Generator {
 	 * @return string
 	 */
 	private static function get_structured_field_value( $structured, $slug, $post_id ) {
-		$slug = sanitize_key( $slug );
+			$slug = sanitize_key( $slug );
 		if ( '' !== $slug && isset( $structured[ $slug ] ) && is_array( $structured[ $slug ] ) ) {
-			$value = isset( $structured[ $slug ]['value'] ) ? (string) $structured[ $slug ]['value'] : '';
+				$value = isset( $structured[ $slug ]['value'] ) ? (string) $structured[ $slug ]['value'] : '';
 			if ( '' !== $value ) {
 				return $value;
 			}
 		}
 
 		if ( '' !== $slug ) {
-			$meta_key = 'resolate_field_' . $slug;
-			$legacy   = get_post_meta( $post_id, $meta_key, true );
+				$meta_key = 'resolate_field_' . $slug;
+				$legacy   = get_post_meta( $post_id, $meta_key, true );
 			if ( '' !== $legacy ) {
-				return (string) $legacy;
+					return (string) $legacy;
 			}
 		}
 
-		return '';
+			return '';
+	}
+
+		/**
+		 * Retrieve array field items for template merges.
+		 *
+		 * @param array  $structured Structured map from post content.
+		 * @param string $slug       Field slug.
+		 * @param int    $post_id    Post ID.
+		 * @return array<int, array<string, string>>
+		 */
+	private static function get_array_field_items_for_merge( $structured, $slug, $post_id ) {
+			$slug  = sanitize_key( $slug );
+			$value = '';
+
+		if ( '' !== $slug && isset( $structured[ $slug ] ) && is_array( $structured[ $slug ] ) && isset( $structured[ $slug ]['value'] ) ) {
+				$value = (string) $structured[ $slug ]['value'];
+		}
+
+		if ( '' === $value && '' !== $slug ) {
+				$meta_value = get_post_meta( $post_id, 'resolate_field_' . $slug, true );
+			if ( '' !== $meta_value ) {
+					$value = (string) $meta_value;
+			}
+		}
+
+		if ( '' === $value && '' !== $slug ) {
+				$legacy = get_post_meta( $post_id, 'resolate_' . $slug, true );
+			if ( empty( $legacy ) && 'annexes' === $slug ) {
+					$legacy = get_post_meta( $post_id, 'resolate_annexes', true );
+			}
+			if ( is_array( $legacy ) && ! empty( $legacy ) ) {
+					$value = wp_json_encode( $legacy );
+			}
+		}
+
+			return Resolate_Documents::decode_array_field_value( $value );
 	}
 
 	/**
@@ -404,81 +453,81 @@ class Resolate_Document_Generator {
 	 *
 	 * @return string Absolute directory path.
 	 */
-        private static function ensure_output_dir() {
-                $upload_dir = wp_upload_dir();
-                $dir        = trailingslashit( $upload_dir['basedir'] ) . 'resolate';
-                if ( ! is_dir( $dir ) ) {
-                        wp_mkdir_p( $dir );
-                }
+	private static function ensure_output_dir() {
+			$upload_dir = wp_upload_dir();
+			$dir        = trailingslashit( $upload_dir['basedir'] ) . 'resolate';
+		if ( ! is_dir( $dir ) ) {
+				wp_mkdir_p( $dir );
+		}
 
-                return $dir;
-        }
+			return $dir;
+	}
 
-        /**
-         * Sanitize placeholders preserving TinyButStrong supported characters.
-         *
-         * @param string $placeholder Placeholder name.
-         * @return string
-         */
-        private static function sanitize_placeholder_name( $placeholder ) {
-                $placeholder = (string) $placeholder;
-                $placeholder = preg_replace( '/[^A-Za-z0-9._:-]/', '', $placeholder );
-                return $placeholder;
-        }
+		/**
+		 * Sanitize placeholders preserving TinyButStrong supported characters.
+		 *
+		 * @param string $placeholder Placeholder name.
+		 * @return string
+		 */
+	private static function sanitize_placeholder_name( $placeholder ) {
+			$placeholder = (string) $placeholder;
+			$placeholder = preg_replace( '/[^A-Za-z0-9._:-]/', '', $placeholder );
+			return $placeholder;
+	}
 
-        /**
-         * Normalize a field value based on the detected data type.
-         *
-         * @param string $value     Original value.
-         * @param string $data_type Detected data type.
-         * @return mixed
-         */
-        private static function normalize_field_value( $value, $data_type ) {
-                $value     = is_string( $value ) ? trim( $value ) : $value;
-                $data_type = sanitize_key( $data_type );
+		/**
+		 * Normalize a field value based on the detected data type.
+		 *
+		 * @param string $value     Original value.
+		 * @param string $data_type Detected data type.
+		 * @return mixed
+		 */
+	private static function normalize_field_value( $value, $data_type ) {
+			$value     = is_string( $value ) ? trim( $value ) : $value;
+			$data_type = sanitize_key( $data_type );
 
-                switch ( $data_type ) {
-                        case 'number':
-                                if ( '' === $value ) {
-                                        return '';
-                                }
-                                if ( is_numeric( $value ) ) {
-                                        return 0 + $value;
-                                }
-                                $filtered = preg_replace( '/[^0-9.,\-]/', '', (string) $value );
-                                if ( '' === $filtered ) {
-                                        return '';
-                                }
-                                $normalized = str_replace( ',', '.', $filtered );
-                                if ( is_numeric( $normalized ) ) {
-                                        return 0 + $normalized;
-                                }
-                                return $value;
-                        case 'boolean':
-                                if ( is_bool( $value ) ) {
-                                        return $value ? 1 : 0;
-                                }
-                                $value = strtolower( (string) $value );
-                                if ( in_array( $value, array( '1', 'true', 'si', 'sí', 'yes', 'on' ), true ) ) {
-                                        return 1;
-                                }
-                                if ( in_array( $value, array( '0', 'false', 'no', 'off' ), true ) ) {
-                                        return 0;
-                                }
-                                return '' === $value ? 0 : 0;
-                        case 'date':
-                                if ( '' === $value ) {
-                                        return '';
-                                }
-                                $timestamp = strtotime( (string) $value );
-                                if ( false === $timestamp ) {
-                                        return $value;
-                                }
-                                return wp_date( 'Y-m-d', $timestamp );
-                        default:
-                                return $value;
-                }
-        }
+		switch ( $data_type ) {
+			case 'number':
+				if ( '' === $value ) {
+						return '';
+				}
+				if ( is_numeric( $value ) ) {
+						return 0 + $value;
+				}
+				$filtered = preg_replace( '/[^0-9.,\-]/', '', (string) $value );
+				if ( '' === $filtered ) {
+						return '';
+				}
+				$normalized = str_replace( ',', '.', $filtered );
+				if ( is_numeric( $normalized ) ) {
+						return 0 + $normalized;
+				}
+				return $value;
+			case 'boolean':
+				if ( is_bool( $value ) ) {
+					return $value ? 1 : 0;
+				}
+					$value = strtolower( (string) $value );
+				if ( in_array( $value, array( '1', 'true', 'si', 'sí', 'yes', 'on' ), true ) ) {
+						return 1;
+				}
+				if ( in_array( $value, array( '0', 'false', 'no', 'off' ), true ) ) {
+						return 0;
+				}
+				return '' === $value ? 0 : 0;
+			case 'date':
+				if ( '' === $value ) {
+						return '';
+				}
+					$timestamp = strtotime( (string) $value );
+				if ( false === $timestamp ) {
+						return $value;
+				}
+				return wp_date( 'Y-m-d', $timestamp );
+			default:
+				return $value;
+		}
+	}
 
 	/**
 	 * Generate DOCX for a Law post using the same configured DOCX template.

--- a/includes/class-resolate-template-parser.php
+++ b/includes/class-resolate-template-parser.php
@@ -10,12 +10,12 @@
  */
 class Resolate_Template_Parser {
 
-	/**
-	 * Extract placeholders from an OpenTBS-compatible template.
-	 *
-	 * @param string $template_path Absolute path to template file.
-	 * @return array|string[]|WP_Error Array of unique placeholder slugs or WP_Error on failure.
-	 */
+		/**
+		 * Extract placeholders from an OpenTBS-compatible template.
+		 *
+		 * @param string $template_path Absolute path to template file.
+		 * @return array|string[]|WP_Error Array of unique placeholder slugs or WP_Error on failure.
+		 */
 	public static function extract_fields( $template_path ) {
 		if ( empty( $template_path ) || ! file_exists( $template_path ) ) {
 			return new WP_Error( 'resolate_template_missing', __( 'La plantilla seleccionada no se encuentra.', 'resolate' ) );
@@ -53,68 +53,68 @@ class Resolate_Template_Parser {
 			}
 		}
 
-               $placeholders = array();
-               foreach ( $targets as $file ) {
-                       $contents = $zip->getFromName( $file );
-                       if ( false === $contents ) {
-                               continue;
-                       }
-                       $normalized = self::normalize_xml_text( $contents );
-                       if ( '' === $normalized ) {
-                               continue;
-                       }
-                       preg_match_all( '/\[([^\]\r\n]+)\]/', $normalized, $matches );
-                       if ( empty( $matches[1] ) ) {
-                               continue;
-                       }
-                       foreach ( $matches[1] as $raw_field ) {
-                               $parsed = self::parse_placeholder( $raw_field );
-                               if ( empty( $parsed['placeholder'] ) ) {
-                                       continue;
-                               }
-                               $key = strtolower( $parsed['placeholder'] );
-                               if ( isset( $placeholders[ $key ] ) ) {
-                                       // Prefer keeping parameters when multiple instances exist.
-                                       if ( empty( $placeholders[ $key ]['parameters'] ) && ! empty( $parsed['parameters'] ) ) {
-                                               $placeholders[ $key ] = $parsed;
-                                       }
-                                       continue;
-                               }
-                               $placeholders[ $key ] = $parsed;
-                       }
-               }
+			   $placeholders = array();
+		foreach ( $targets as $file ) {
+				$contents = $zip->getFromName( $file );
+			if ( false === $contents ) {
+					   continue;
+			}
+				$normalized = self::normalize_xml_text( $contents );
+			if ( '' === $normalized ) {
+						   continue;
+			}
+						  preg_match_all( '/\[([^\]\r\n]+)\]/', $normalized, $matches );
+			if ( empty( $matches[1] ) ) {
+				 continue;
+			}
+			foreach ( $matches[1] as $raw_field ) {
+				 $parsed = self::parse_placeholder( $raw_field );
+				if ( empty( $parsed['placeholder'] ) ) {
+						continue;
+				}
+				 $key = strtolower( $parsed['placeholder'] );
+				if ( isset( $placeholders[ $key ] ) ) {
+						// Prefer keeping parameters when multiple instances exist.
+					if ( empty( $placeholders[ $key ]['parameters'] ) && ! empty( $parsed['parameters'] ) ) {
+								   $placeholders[ $key ] = $parsed;
+					}
+						continue;
+				}
+				 $placeholders[ $key ] = $parsed;
+			}
+		}
 
-               $zip->close();
+			   $zip->close();
 
-               if ( empty( $placeholders ) ) {
-                       return array();
-               }
+		if ( empty( $placeholders ) ) {
+				return array();
+		}
 
-               $fields = array();
-               foreach ( $placeholders as $parsed ) {
-                       $fields[] = self::format_field_info( $parsed );
-               }
+			   $fields = array();
+		foreach ( $placeholders as $parsed ) {
+				$fields[] = self::format_field_info( $parsed );
+		}
 
-               if ( ! empty( $fields ) ) {
-                       usort(
-                               $fields,
-                               static function ( $a, $b ) {
-                                       $label_a = isset( $a['label'] ) ? $a['label'] : '';
-                                       $label_b = isset( $b['label'] ) ? $b['label'] : '';
-                                       return strnatcasecmp( $label_a, $label_b );
-                               }
-                       );
-               }
+		if ( ! empty( $fields ) ) {
+				usort(
+					$fields,
+					static function ( $a, $b ) {
+								$label_a = isset( $a['label'] ) ? $a['label'] : '';
+								$label_b = isset( $b['label'] ) ? $b['label'] : '';
+								return strnatcasecmp( $label_a, $label_b );
+					}
+				);
+		}
 
-               return $fields;
-        }
+			   return $fields;
+	}
 
-        /**
-         * Normalize XML string content to merge split OpenTBS placeholders.
-         *
-	 * @param string $xml XML fragment.
-	 * @return string Plain text representation.
-	 */
+		/**
+		 * Normalize XML string content to merge split OpenTBS placeholders.
+		 *
+		 * @param string $xml XML fragment.
+		 * @return string Plain text representation.
+		 */
 	private static function normalize_xml_text( $xml ) {
 		if ( '' === $xml ) {
 			return '';
@@ -136,198 +136,508 @@ class Resolate_Template_Parser {
 
 		// Strip tags while keeping text.
 		$normalized = wp_strip_all_tags( $normalized );
-                return $normalized;
-        }
+				return $normalized;
+	}
 
-        /**
-         * Parse a raw OpenTBS placeholder definition.
-         *
-         * @param string $raw_field Placeholder string without brackets.
-         * @return array{
-         *     raw: string,
-         *     placeholder: string,
-         *     parameters: array<string, string>
-         * }
-         */
-        private static function parse_placeholder( $raw_field ) {
-                $raw_field = trim( $raw_field );
-                if ( '' === $raw_field ) {
-                        return array(
-                                'raw'         => '',
-                                'placeholder' => '',
-                                'parameters'  => array(),
-                        );
-                }
+		/**
+		 * Build a normalized schema from detected field definitions, including array fields.
+		 *
+		 * @param array $fields Parsed placeholder definitions returned by extract_fields().
+		 * @return array[]
+		 */
+	public static function build_schema_from_field_definitions( $fields ) {
+		if ( ! is_array( $fields ) ) {
+				return array();
+		}
 
-                $parts       = preg_split( '/\s*;\s*/', $raw_field );
-                $placeholder = trim( array_shift( $parts ) );
-                $parameters  = array();
+			$array_defs    = array();
+			$array_order   = array();
+			$repeat_hints  = array();
+			$pending       = array();
+			$order_counter = 0;
 
-                if ( ! empty( $parts ) ) {
-                        foreach ( $parts as $param ) {
-                                $param = trim( $param );
-                                if ( '' === $param ) {
-                                        continue;
-                                }
-                                $pair = explode( '=', $param, 2 );
-                                $name = strtolower( trim( $pair[0] ) );
-                                if ( '' === $name ) {
-                                        continue;
-                                }
-                                $value = ( count( $pair ) > 1 ) ? strtolower( trim( $pair[1] ) ) : '1';
-                                $parameters[ $name ] = $value;
-                        }
-                }
+		foreach ( $fields as $index => $field ) {
+			if ( ! is_array( $field ) ) {
+					continue;
+			}
 
-                return array(
-                        'raw'         => $raw_field,
-                        'placeholder' => $placeholder,
-                        'parameters'  => $parameters,
-                );
-        }
+				$placeholder = isset( $field['placeholder'] ) ? trim( (string) $field['placeholder'] ) : '';
+				$parameters  = isset( $field['parameters'] ) && is_array( $field['parameters'] ) ? $field['parameters'] : array();
+				$label       = isset( $field['label'] ) ? sanitize_text_field( $field['label'] ) : '';
+				$data_type   = isset( $field['data_type'] ) ? sanitize_key( $field['data_type'] ) : 'text';
 
-        /**
-         * Build normalized field information from a parsed placeholder.
-         *
-         * @param array $parsed Parsed placeholder data.
-         * @return array{
-         *     placeholder: string,
-         *     slug: string,
-         *     label: string,
-         *     data_type: string,
-         *     parameters: array<string, string>
-         * }
-         */
-        private static function format_field_info( $parsed ) {
-                $placeholder = isset( $parsed['placeholder'] ) ? (string) $parsed['placeholder'] : '';
-                $parameters  = isset( $parsed['parameters'] ) && is_array( $parsed['parameters'] ) ? $parsed['parameters'] : array();
+				$array_match = self::detect_array_placeholder_with_index( $placeholder );
+			if ( $array_match ) {
+					$base = $array_match['base'];
+					$key  = $array_match['key'];
 
-                $slug_source = self::normalize_slug_source( $placeholder );
-                $slug        = sanitize_key( $slug_source );
-                if ( '' === $slug ) {
-                        $slug = sanitize_key( str_replace( array( '.', ':' ), '_', strtolower( $placeholder ) ) );
-                }
+				if ( '' === $base || '' === $key ) {
+						continue;
+				}
 
-                $label_source = str_replace( array( '.', ':' ), ' ', $slug_source );
-                $label        = self::humanize_key( $label_source );
+					$repeat_hints[ $base ] = true;
 
-                $data_type = self::detect_data_type( $placeholder, $parameters );
+				if ( ! isset( $array_defs[ $base ] ) ) {
+						$array_defs[ $base ] = array(
+							'slug'        => $base,
+							'label'       => self::humanize_key( $base ),
+							'type'        => 'array',
+							'placeholder' => $base,
+							'data_type'   => 'array',
+							'item_schema' => array(),
+							'_order'      => $order_counter++,
+						);
+						$array_order[] = $base;
+				}
 
-                return array(
-                        'placeholder' => $placeholder,
-                        'slug'        => $slug,
-                        'label'       => $label,
-                        'data_type'   => $data_type,
-                        'parameters'  => $parameters,
-                );
-        }
+				if ( '' === $label ) {
+						$label = self::humanize_key( $array_match['raw_key'] );
+				}
 
-        /**
-         * Normalize the slug source by dropping known command prefixes.
-         *
-         * @param string $placeholder Placeholder name without parameters.
-         * @return string
-         */
-        private static function normalize_slug_source( $placeholder ) {
-                $placeholder = trim( (string) $placeholder );
-                if ( '' === $placeholder ) {
-                        return '';
-                }
+				if ( ! isset( $array_defs[ $base ]['item_schema'][ $key ] ) ) {
+						$item_data_type = self::detect_data_type( $placeholder, $parameters );
+					if ( '' === $item_data_type ) {
+							$item_data_type = 'text';
+					}
 
-                $segments = explode( '.', $placeholder );
-                if ( count( $segments ) > 1 ) {
-                        $prefix          = strtolower( $segments[0] );
-                        $reserved_prefix = array(
-                                'onshow',
-                                'onload',
-                                'onchange',
-                                'onformat',
-                                'ondata',
-                                'onsection',
-                                'var',
-                                'block',
-                        );
-                        if ( in_array( $prefix, $reserved_prefix, true ) ) {
-                                array_shift( $segments );
-                                $placeholder = implode( '.', $segments );
-                        }
-                }
+						$array_defs[ $base ]['item_schema'][ $key ] = array(
+							'label'     => $label,
+							'type'      => self::infer_array_item_type( $key, $item_data_type ),
+							'data_type' => $item_data_type,
+						);
+				}
 
-                return $placeholder;
-        }
+					continue;
+			}
 
-        /**
-         * Human readable label from slug source.
-         *
-         * @param string $slug Slug source.
-         * @return string
-         */
-        private static function humanize_key( $slug ) {
-                $slug = str_replace( array( '-', '_', '.' ), ' ', strtolower( $slug ) );
-                $slug = preg_replace( '/\s+/', ' ', $slug );
-                $slug = trim( $slug );
-                if ( '' === $slug ) {
-                        return '';
-                }
-                if ( function_exists( 'mb_convert_case' ) ) {
-                        return mb_convert_case( $slug, MB_CASE_TITLE, 'UTF-8' );
-                }
-                return ucwords( $slug );
-        }
+			if ( isset( $parameters['repeat'] ) ) {
+					$repeat_base = sanitize_key( $parameters['repeat'] );
+				if ( '' !== $repeat_base ) {
+						$repeat_hints[ $repeat_base ] = true;
+				}
+			}
 
-        /**
-         * Detect placeholder data type from parameters and slug heuristics.
-         *
-         * @param string $placeholder Placeholder name.
-         * @param array  $parameters  Placeholder parameters.
-         * @return string One of text|number|boolean|date.
-         */
-        private static function detect_data_type( $placeholder, $parameters ) {
-                $placeholder = strtolower( (string) $placeholder );
-                $parameters  = is_array( $parameters ) ? $parameters : array();
+				$pending[] = array(
+					'field'       => $field,
+					'placeholder' => $placeholder,
+					'parameters'  => $parameters,
+					'label'       => $label,
+					'data_type'   => $data_type,
+					'index'       => $index,
+				);
+		}
 
-                if ( isset( $parameters['ope'] ) ) {
-                        $ope = strtolower( (string) $parameters['ope'] );
-                        if ( in_array( $ope, array( 'tbs:num', 'tbs:curr', 'tbs:percent', 'xlsxnum', 'odsnum' ), true ) ) {
-                                return 'number';
-                        }
-                        if ( in_array( $ope, array( 'tbs:bool', 'xlsxbool', 'odsbool' ), true ) ) {
-                                return 'boolean';
-                        }
-                        if ( in_array( $ope, array( 'tbs:date', 'tbs:time', 'xlsxdate', 'odsdate', 'odstime' ), true ) ) {
-                                return 'date';
-                        }
-                }
+			$schema        = array();
+			$scalar_fields = array();
 
-                foreach ( array( 'frm', 'format' ) as $key ) {
-                        if ( isset( $parameters[ $key ] ) ) {
-                                $candidate = strtolower( (string) $parameters[ $key ] );
-                                if ( preg_match( '/[dmyhs]/', $candidate ) ) {
-                                        return 'date';
-                                }
-                        }
-                }
+		foreach ( $pending as $entry ) {
+				$placeholder = $entry['placeholder'];
+				$parameters  = $entry['parameters'];
+				$label       = $entry['label'];
+				$data_type   = $entry['data_type'];
 
-                if ( preg_match( '/(date|fecha)$/', $placeholder ) ) {
-                        return 'date';
-                }
-                if ( preg_match( '/(total|amount|importe|suma|numero|number|qty|cantidad)$/', $placeholder ) ) {
-                        return 'number';
-                }
-                if ( preg_match( '/^(is|has|tiene|flag|activo|enabled)[._-]?/', $placeholder ) || preg_match( '/(flag|activo|enabled)$/', $placeholder ) ) {
-                        return 'boolean';
-                }
+				$dot_match = self::detect_array_placeholder_without_index( $placeholder );
+			if ( $dot_match && ( isset( $repeat_hints[ $dot_match['base'] ] ) || isset( $array_defs[ $dot_match['base'] ] ) ) ) {
+					$base = $dot_match['base'];
+					$key  = $dot_match['key'];
 
-                return 'text';
-        }
+				if ( '' === $base || '' === $key ) {
+					continue;
+				}
 
-        /**
-         * Polyfill for str_ends_with to support older PHP versions.
-         *
-         * @param string $haystack Full string.
-         * @param string $needle   Ending to verify.
-         * @return bool
-	 */
+				if ( ! isset( $array_defs[ $base ] ) ) {
+						$array_defs[ $base ] = array(
+							'slug'        => $base,
+							'label'       => self::humanize_key( $base ),
+							'type'        => 'array',
+							'placeholder' => $base,
+							'data_type'   => 'array',
+							'item_schema' => array(),
+							'_order'      => $order_counter++,
+						);
+						$array_order[] = $base;
+				}
+
+				if ( ! isset( $array_defs[ $base ]['item_schema'][ $key ] ) ) {
+						$item_data_type = self::detect_data_type( $placeholder, $parameters );
+					if ( '' === $label ) {
+							$label = self::humanize_key( $dot_match['raw_key'] );
+					}
+					if ( '' === $item_data_type ) {
+							$item_data_type = 'text';
+					}
+						$array_defs[ $base ]['item_schema'][ $key ] = array(
+							'label'     => ( '' !== $label ) ? $label : self::humanize_key( $dot_match['raw_key'] ),
+							'type'      => self::infer_array_item_type( $key, $item_data_type ),
+							'data_type' => $item_data_type,
+						);
+				}
+
+					continue;
+			}
+
+				$slug = isset( $entry['field']['slug'] ) ? sanitize_key( $entry['field']['slug'] ) : '';
+			if ( '' === $slug ) {
+					$slug = sanitize_key( $placeholder );
+			}
+
+			if ( '' === $slug ) {
+					continue;
+			}
+
+				$normalized_placeholder = '';
+			if ( '' !== $placeholder ) {
+					$normalized_placeholder = preg_replace( '/[^A-Za-z0-9._:-]/', '', $placeholder );
+			}
+			if ( '' === $label ) {
+					$source = '' !== $normalized_placeholder ? $normalized_placeholder : $slug;
+					$label  = self::humanize_key( $source );
+			}
+
+			if ( '' === $normalized_placeholder ) {
+					$normalized_placeholder = $slug;
+			}
+
+			if ( ! in_array( $data_type, array( 'text', 'number', 'boolean', 'date' ), true ) ) {
+					$data_type = 'text';
+			}
+
+			if ( in_array( $slug, array( 'onshow', 'ondata', 'block', 'var' ), true ) ) {
+					continue;
+			}
+
+				$scalar_fields[] = array(
+					'slug'        => $slug,
+					'label'       => $label,
+					'placeholder' => $normalized_placeholder,
+					'data_type'   => $data_type,
+					'_order'      => $entry['index'],
+				);
+		}
+
+		if ( ! empty( $array_defs ) ) {
+				uasort(
+					$array_defs,
+					static function ( $a, $b ) {
+								$order_a = isset( $a['_order'] ) ? intval( $a['_order'] ) : 0;
+								$order_b = isset( $b['_order'] ) ? intval( $b['_order'] ) : 0;
+								return $order_a <=> $order_b;
+					}
+				);
+
+			foreach ( $array_defs as $base => $def ) {
+				unset( $def['_order'] );
+				$schema[] = $def;
+			}
+		}
+
+		if ( ! empty( $scalar_fields ) ) {
+				usort(
+					$scalar_fields,
+					static function ( $a, $b ) {
+								$order_a = isset( $a['_order'] ) ? intval( $a['_order'] ) : 0;
+								$order_b = isset( $b['_order'] ) ? intval( $b['_order'] ) : 0;
+								return $order_a <=> $order_b;
+					}
+				);
+
+			foreach ( $scalar_fields as $field ) {
+				unset( $field['_order'] );
+				$field['type'] = 'textarea';
+				$schema[]       = $field;
+			}
+		}
+
+			return $schema;
+	}
+
+		/**
+		 * Parse a raw OpenTBS placeholder definition.
+		 *
+		 * @param string $raw_field Placeholder string without brackets.
+		 * @return array{
+		 *     raw: string,
+		 *     placeholder: string,
+		 *     parameters: array<string, string>
+		 * }
+		 */
+	private static function parse_placeholder( $raw_field ) {
+			$raw_field = trim( $raw_field );
+		if ( '' === $raw_field ) {
+				return array(
+					'raw'         => '',
+					'placeholder' => '',
+					'parameters'  => array(),
+				);
+		}
+
+			$parts       = preg_split( '/\s*;\s*/', $raw_field );
+			$placeholder = trim( array_shift( $parts ) );
+			$parameters  = array();
+
+		if ( ! empty( $parts ) ) {
+			foreach ( $parts as $param ) {
+					$param = trim( $param );
+				if ( '' === $param ) {
+					continue;
+				}
+					$pair = explode( '=', $param, 2 );
+					$name = strtolower( trim( $pair[0] ) );
+				if ( '' === $name ) {
+						continue;
+				}
+					$value = ( count( $pair ) > 1 ) ? strtolower( trim( $pair[1] ) ) : '1';
+					$parameters[ $name ] = $value;
+			}
+		}
+
+			return array(
+				'raw'         => $raw_field,
+				'placeholder' => $placeholder,
+				'parameters'  => $parameters,
+			);
+	}
+
+		/**
+		 * Build normalized field information from a parsed placeholder.
+		 *
+		 * @param array $parsed Parsed placeholder data.
+		 * @return array{
+		 *     placeholder: string,
+		 *     slug: string,
+		 *     label: string,
+		 *     data_type: string,
+		 *     parameters: array<string, string>
+		 * }
+		 */
+	private static function format_field_info( $parsed ) {
+			$placeholder = isset( $parsed['placeholder'] ) ? (string) $parsed['placeholder'] : '';
+			$parameters  = isset( $parsed['parameters'] ) && is_array( $parsed['parameters'] ) ? $parsed['parameters'] : array();
+
+			$slug_source = self::normalize_slug_source( $placeholder );
+			$slug        = sanitize_key( $slug_source );
+		if ( '' === $slug ) {
+				$slug = sanitize_key( str_replace( array( '.', ':' ), '_', strtolower( $placeholder ) ) );
+		}
+
+			$label_source = str_replace( array( '.', ':' ), ' ', $slug_source );
+			$label        = self::humanize_key( $label_source );
+
+			$data_type = self::detect_data_type( $placeholder, $parameters );
+
+			return array(
+				'placeholder' => $placeholder,
+				'slug'        => $slug,
+				'label'       => $label,
+				'data_type'   => $data_type,
+				'parameters'  => $parameters,
+			);
+	}
+
+		/**
+		 * Normalize the slug source by dropping known command prefixes.
+		 *
+		 * @param string $placeholder Placeholder name without parameters.
+		 * @return string
+		 */
+	private static function normalize_slug_source( $placeholder ) {
+			$placeholder = trim( (string) $placeholder );
+		if ( '' === $placeholder ) {
+				return '';
+		}
+
+			$segments = explode( '.', $placeholder );
+		if ( count( $segments ) > 1 ) {
+				$prefix          = strtolower( $segments[0] );
+				$reserved_prefix = array(
+					'onshow',
+					'onload',
+					'onchange',
+					'onformat',
+					'ondata',
+					'onsection',
+					'var',
+					'block',
+				);
+				if ( in_array( $prefix, $reserved_prefix, true ) ) {
+						array_shift( $segments );
+						$placeholder = implode( '.', $segments );
+				}
+		}
+
+			return $placeholder;
+	}
+
+		/**
+		 * Human readable label from slug source.
+		 *
+		 * @param string $slug Slug source.
+		 * @return string
+		 */
+	private static function humanize_key( $slug ) {
+			$slug = str_replace( array( '-', '_', '.' ), ' ', strtolower( $slug ) );
+			$slug = preg_replace( '/\s+/', ' ', $slug );
+			$slug = trim( $slug );
+		if ( '' === $slug ) {
+				return '';
+		}
+		if ( function_exists( 'mb_convert_case' ) ) {
+				return mb_convert_case( $slug, MB_CASE_TITLE, 'UTF-8' );
+		}
+			return ucwords( $slug );
+	}
+
+		/**
+		 * Detect placeholder data type from parameters and slug heuristics.
+		 *
+		 * @param string $placeholder Placeholder name.
+		 * @param array  $parameters  Placeholder parameters.
+		 * @return string One of text|number|boolean|date.
+		 */
+	private static function detect_data_type( $placeholder, $parameters ) {
+			$placeholder = strtolower( (string) $placeholder );
+			$parameters  = is_array( $parameters ) ? $parameters : array();
+
+		if ( isset( $parameters['ope'] ) ) {
+				$ope = strtolower( (string) $parameters['ope'] );
+			if ( in_array( $ope, array( 'tbs:num', 'tbs:curr', 'tbs:percent', 'xlsxnum', 'odsnum' ), true ) ) {
+				return 'number';
+			}
+			if ( in_array( $ope, array( 'tbs:bool', 'xlsxbool', 'odsbool' ), true ) ) {
+					return 'boolean';
+			}
+			if ( in_array( $ope, array( 'tbs:date', 'tbs:time', 'xlsxdate', 'odsdate', 'odstime' ), true ) ) {
+					return 'date';
+			}
+		}
+
+		foreach ( array( 'frm', 'format' ) as $key ) {
+			if ( isset( $parameters[ $key ] ) ) {
+					$candidate = strtolower( (string) $parameters[ $key ] );
+				if ( preg_match( '/[dmyhs]/', $candidate ) ) {
+					return 'date';
+				}
+			}
+		}
+
+		if ( preg_match( '/(date|fecha)$/', $placeholder ) ) {
+				return 'date';
+		}
+		if ( preg_match( '/(total|amount|importe|suma|numero|number|qty|cantidad)$/', $placeholder ) ) {
+				return 'number';
+		}
+		if ( preg_match( '/^(is|has|tiene|flag|activo|enabled)[._-]?/', $placeholder ) || preg_match( '/(flag|activo|enabled)$/', $placeholder ) ) {
+				return 'boolean';
+		}
+
+			return 'text';
+	}
+
+		/**
+		 * Detect array placeholder using bracket notation (e.g. field[*].key).
+		 *
+		 * @param string $placeholder Placeholder string.
+		 * @return array{base:string,key:string,raw_key:string}|null
+		 */
+	private static function detect_array_placeholder_with_index( $placeholder ) {
+			$placeholder = strtolower( trim( (string) $placeholder ) );
+		if ( '' === $placeholder ) {
+				return null;
+		}
+
+			$segments = explode( '.', $placeholder );
+		if ( empty( $segments ) ) {
+				return null;
+		}
+
+			$first = array_shift( $segments );
+		if ( ! preg_match( '/^([a-z0-9_]+)\[(\*|\d+)\]$/', $first, $match ) ) {
+				return null;
+		}
+
+		if ( empty( $segments ) ) {
+				return null;
+		}
+
+			$raw_key = implode( '.', $segments );
+			$key     = sanitize_key( str_replace( '.', '_', $raw_key ) );
+
+			return array(
+				'base'    => sanitize_key( $match[1] ),
+				'key'     => $key,
+				'raw_key' => $raw_key,
+			);
+	}
+
+		/**
+		 * Detect array placeholder using dot notation when repeat hints exist.
+		 *
+		 * @param string $placeholder Placeholder string.
+		 * @return array{base:string,key:string,raw_key:string}|null
+		 */
+	private static function detect_array_placeholder_without_index( $placeholder ) {
+			$placeholder = strtolower( trim( (string) $placeholder ) );
+		if ( '' === $placeholder ) {
+				return null;
+		}
+
+			$segments = explode( '.', $placeholder );
+		if ( count( $segments ) < 2 ) {
+				return null;
+		}
+
+			$base     = sanitize_key( array_shift( $segments ) );
+			$raw_key  = implode( '.', $segments );
+			$key      = sanitize_key( str_replace( '.', '_', $raw_key ) );
+
+		if ( '' === $base || '' === $key ) {
+				return null;
+		}
+
+			return array(
+				'base'    => $base,
+				'key'     => $key,
+				'raw_key' => $raw_key,
+			);
+	}
+
+		/**
+		 * Infer the best suited control type for an array item.
+		 *
+		 * @param string $item_key  Item key.
+		 * @param string $data_type Detected data type.
+		 * @return string
+		 */
+	private static function infer_array_item_type( $item_key, $data_type ) {
+			$item_key  = strtolower( (string) $item_key );
+			$data_type = strtolower( (string) $data_type );
+
+		if ( in_array( $data_type, array( 'number', 'date', 'boolean' ), true ) ) {
+				return 'single';
+		}
+
+		if ( preg_match( '/^(number|numero|número|index|indice)$/', $item_key ) ) {
+				return 'single';
+		}
+
+		if ( preg_match( '/^(title|titulo|título|heading|name)$/', $item_key ) ) {
+				return 'single';
+		}
+
+		if ( preg_match( '/(content|texto|text|body|descripcion|descripción)$/', $item_key ) ) {
+				return 'rich';
+		}
+
+			return 'textarea';
+	}
+
+		/**
+		 * Polyfill for str_ends_with to support older PHP versions.
+		 *
+		 * @param string $haystack Full string.
+		 * @param string $needle   Ending to verify.
+		 * @return bool
+		 */
 	private static function ends_with( $haystack, $needle ) {
 		if ( '' === $needle ) {
 			return true;

--- a/includes/custom-post-types/class-resolate-documents.php
+++ b/includes/custom-post-types/class-resolate-documents.php
@@ -18,6 +18,11 @@
  */
 class Resolate_Documents {
 
+		/**
+		 * Maximum number of items allowed per array field.
+		 */
+		const ARRAY_FIELD_MAX_ITEMS = 20;
+
 	/**
 	 * Constructor.
 	 */
@@ -60,19 +65,17 @@ class Resolate_Documents {
 		$this->register_revision_ui();
 	}
 
-	/**
-	 * Return the list of custom meta keys used by this CPT for a given post.
-	 *
-	 * Includes static section fields and dynamic fields defined by the selected
-	 * document type, if any. Also includes annexes array.
-	 *
-	 * @param int $post_id Post ID.
-	 * @return string[]
-	 */
+		/**
+		 * Return the list of custom meta keys used by this CPT for a given post.
+		 *
+		 * Includes static section fields and dynamic fields defined by the selected
+		 * document type, if any.
+		 *
+		 * @param int $post_id Post ID.
+		 * @return string[]
+		 */
 	private function get_meta_fields_for_post( $post_id ) {
-               $fields = array(
-                       'resolate_annexes',
-               );
+		   $fields = array();
 
 		$dynamic = $this->get_dynamic_fields_schema_for_post( $post_id );
 		$known   = array();
@@ -192,10 +195,7 @@ class Resolate_Documents {
 	 * Hook this in define_hooks().
 	 */
 	private function register_revision_ui() {
-		add_filter( '_wp_post_revision_fields', array( $this, 'add_revision_fields' ), 10, 2 );
-
-		// One provider per field to fetch the value from the revision post.
-               add_filter( '_wp_post_revision_field_resolate_annexes', array( $this, 'revision_field_annexes' ), 10, 2 );
+				add_filter( '_wp_post_revision_fields', array( $this, 'add_revision_fields' ), 10, 2 );
 	}
 
 		/**
@@ -206,8 +206,7 @@ class Resolate_Documents {
 		 * @return array
 		 */
 	public function add_revision_fields( $fields, $post ) {
-               $fields['resolate_annexes']      = __( 'Anexos', 'resolate' );
-               return $fields;
+		   return $fields;
 	}
 
 	/**
@@ -248,60 +247,6 @@ class Resolate_Documents {
 		// Get the meta stored on the REVISION row.
 		$raw = get_metadata( 'post', $rev_id, $field, true );
 		return $this->normalize_html_for_diff( $raw );
-	}
-
-	/**
-	 * Provider for annexes (array) in revisions diff.
-	 *
-	 * @param string  $value     Current value (unused).
-	 * @param WP_Post $revision  Revision post object.
-	 * @return string
-	 */
-	public function revision_field_annexes( $value, $revision = null ) {
-		// Resolve revision ID similar to revision_field_value.
-		$rev_id = 0;
-		$args = func_get_args();
-		foreach ( $args as $arg ) {
-			if ( is_object( $arg ) && isset( $arg->ID ) ) {
-				$rev_id = intval( $arg->ID );
-				break;
-			}
-			if ( is_array( $arg ) && isset( $arg['ID'] ) && is_numeric( $arg['ID'] ) ) {
-				$maybe = get_post( intval( $arg['ID'] ) );
-				if ( $maybe && 'revision' === $maybe->post_type ) {
-					$rev_id = intval( $maybe->ID );
-					break;
-				}
-			}
-			if ( is_numeric( $arg ) ) {
-				$maybe = get_post( intval( $arg ) );
-				if ( $maybe && 'revision' === $maybe->post_type ) {
-					$rev_id = intval( $maybe->ID );
-					break;
-				}
-			}
-		}
-		if ( $rev_id <= 0 ) {
-			return '';
-		}
-		$annexes = get_metadata( 'post', $rev_id, 'resolate_annexes', true );
-		if ( ! is_array( $annexes ) || empty( $annexes ) ) {
-			return '';
-		}
-		$lines = array();
-		foreach ( $annexes as $i => $anx ) {
-			$title = isset( $anx['title'] ) ? (string) $anx['title'] : '';
-			$text  = isset( $anx['text'] ) ? (string) $anx['text'] : '';
-			$lines[] = sprintf(
-			/* translators: 1: annex number, 2: annex title */
-				__( 'Annex %1$d: %2$s', 'resolate' ),
-				( $i + 1 ),
-				$title
-			);
-			$lines[] = $this->normalize_html_for_diff( $text );
-			$lines[] = str_repeat( '-', 40 );
-		}
-		return implode( "\n", $lines );
 	}
 
 	/**
@@ -366,37 +311,37 @@ class Resolate_Documents {
 		register_post_type( 'resolate_document', $args );
 	}
 
-        /**
-         * Register taxonomies used by the documents CPT.
-         */
-        public function register_taxonomies() {
-                // Tipos de documento (definen plantillas y campos personalizados para el documento).
-                $types_labels = array(
-                        'name'              => __( 'Tipos de documento', 'resolate' ),
-			'singular_name'     => __( 'Tipo de documento', 'resolate' ),
-			'search_items'      => __( 'Buscar tipos', 'resolate' ),
-			'all_items'         => __( 'Todos los tipos', 'resolate' ),
-			'edit_item'         => __( 'Editar tipo', 'resolate' ),
-			'update_item'       => __( 'Actualizar tipo', 'resolate' ),
-			'add_new_item'      => __( 'Añadir nuevo tipo', 'resolate' ),
-			'new_item_name'     => __( 'Nuevo tipo', 'resolate' ),
-			'menu_name'         => __( 'Tipos de documento', 'resolate' ),
-		);
-		register_taxonomy(
-			'resolate_doc_type',
-			array( 'resolate_document' ),
-			array(
-				'hierarchical'      => false,
-				'labels'            => $types_labels,
-				'show_ui'           => true,
-				'show_admin_column' => true,
-				'query_var'         => true,
-				'rewrite'           => false,
-				'show_in_rest'      => false,
-				// We'll use a custom metabox to prevent editing after first save.
-				'meta_box_cb'       => false,
-			)
-		);
+		/**
+		 * Register taxonomies used by the documents CPT.
+		 */
+	public function register_taxonomies() {
+			// Tipos de documento (definen plantillas y campos personalizados para el documento).
+			$types_labels = array(
+				'name'              => __( 'Tipos de documento', 'resolate' ),
+				'singular_name'     => __( 'Tipo de documento', 'resolate' ),
+				'search_items'      => __( 'Buscar tipos', 'resolate' ),
+				'all_items'         => __( 'Todos los tipos', 'resolate' ),
+				'edit_item'         => __( 'Editar tipo', 'resolate' ),
+				'update_item'       => __( 'Actualizar tipo', 'resolate' ),
+				'add_new_item'      => __( 'Añadir nuevo tipo', 'resolate' ),
+				'new_item_name'     => __( 'Nuevo tipo', 'resolate' ),
+				'menu_name'         => __( 'Tipos de documento', 'resolate' ),
+			);
+			register_taxonomy(
+				'resolate_doc_type',
+				array( 'resolate_document' ),
+				array(
+					'hierarchical'      => false,
+					'labels'            => $types_labels,
+					'show_ui'           => true,
+					'show_admin_column' => true,
+					'query_var'         => true,
+					'rewrite'           => false,
+					'show_in_rest'      => false,
+					// We'll use a custom metabox to prevent editing after first save.
+					'meta_box_cb'       => false,
+				)
+			);
 	}
 
 	/**
@@ -431,15 +376,6 @@ class Resolate_Documents {
 			'resolate_sections',
 			__( 'Secciones del documento', 'resolate' ),
 			array( $this, 'render_sections_metabox' ),
-			'resolate_document',
-			'normal',
-			'default'
-		);
-
-		add_meta_box(
-			'resolate_annexes',
-			__( 'Anexos', 'resolate' ),
-			array( $this, 'render_annexes_metabox' ),
 			'resolate_document',
 			'normal',
 			'default'
@@ -492,10 +428,9 @@ class Resolate_Documents {
 	 * @param WP_Post $post Current post.
 	 */
 	public function render_sections_metabox( $post ) {
-		wp_nonce_field( 'resolate_sections_nonce', 'resolate_sections_nonce' );
+			wp_nonce_field( 'resolate_sections_nonce', 'resolate_sections_nonce' );
 
-		$schema = $this->get_dynamic_fields_schema_for_post( $post->ID );
-		$known_meta_keys = array();
+			$schema = $this->get_dynamic_fields_schema_for_post( $post->ID );
 		if ( empty( $schema ) ) {
 				echo '<div class="resolate-sections">';
 				echo '<p class="description">' . esc_html__( 'Configura un tipo de documento con campos para poder editar su contenido.', 'resolate' ) . '</p>';
@@ -505,52 +440,335 @@ class Resolate_Documents {
 				return;
 		}
 
-		$stored_fields   = $this->get_structured_field_values( $post->ID );
-		$known_meta_keys = array();
+			$stored_fields   = $this->get_structured_field_values( $post->ID );
+			$known_meta_keys = array();
 
-		echo '<div class="resolate-sections">';
+			echo '<div class="resolate-sections">';
 		foreach ( $schema as $row ) {
-				if ( empty( $row['slug'] ) || empty( $row['label'] ) ) {
-						continue; }
+			if ( empty( $row['slug'] ) || empty( $row['label'] ) ) {
+					continue;
+			}
+
 				$slug  = sanitize_key( $row['slug'] );
 				$label = sanitize_text_field( $row['label'] );
-				$type  = isset( $row['type'] ) ? sanitize_key( $row['type'] ) : 'textarea';
+
+			if ( '' === $slug || '' === $label ) {
+					continue;
+			}
+
+				$type = isset( $row['type'] ) ? sanitize_key( $row['type'] ) : 'textarea';
+
+			if ( 'array' === $type ) {
+					$item_schema = $this->normalize_array_item_schema( $row );
+					$items       = array();
+
+				if ( isset( $stored_fields[ $slug ] ) && isset( $stored_fields[ $slug ]['type'] ) && 'array' === $stored_fields[ $slug ]['type'] ) {
+						$items = $this->get_array_field_items_from_structured( $stored_fields[ $slug ] );
+				}
+
+				if ( empty( $items ) ) {
+						$items = array( array() );
+				}
+
+					$this->render_array_field( $slug, $label, $item_schema, $items );
+					continue;
+			}
+
+			if ( ! in_array( $type, array( 'single', 'textarea', 'rich' ), true ) ) {
+					$type = 'textarea';
+			}
+
+				$meta_key          = 'resolate_field_' . $slug;
+				$known_meta_keys[] = $meta_key;
+				$value             = '';
+
+			if ( isset( $stored_fields[ $slug ] ) ) {
+					$value = (string) $stored_fields[ $slug ]['value'];
+			}
+
+				echo '<div class="resolate-field" style="margin-bottom:16px;">';
+				echo '<label for="' . esc_attr( $meta_key ) . '" style="font-weight:600;display:block;margin-bottom:4px;">' . esc_html( $label ) . '</label>';
+
+			if ( 'single' === $type ) {
+					echo '<input type="text" class="widefat" id="' . esc_attr( $meta_key ) . '" name="' . esc_attr( $meta_key ) . '" value="' . esc_attr( $value ) . '" />';
+			} elseif ( 'rich' === $type ) {
+					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_editor handles output escaping.
+					wp_editor(
+						$value,
+						$meta_key,
+						array(
+							'textarea_name' => $meta_key,
+							'textarea_rows' => 8,
+							'media_buttons' => false,
+							'teeny'         => false,
+							'tinymce'       => array(
+								'toolbar1' => 'formatselect,bold,italic,underline,link,bullist,numlist,alignleft,aligncenter,alignright,alignjustify,undo,redo,removeformat',
+							),
+							'quicktags'     => true,
+							'editor_height' => 220,
+						)
+					);
+			} else {
+					echo '<textarea class="widefat" rows="6" id="' . esc_attr( $meta_key ) . '" name="' . esc_attr( $meta_key ) . '">' . esc_textarea( $value ) . '</textarea>';
+			}
+
+				echo '</div>';
+		}
+
+			$unknown = $this->collect_unknown_dynamic_fields( $post->ID, $known_meta_keys );
+			$this->render_unknown_dynamic_fields_ui( $unknown );
+			echo '</div>';
+	}
+
+		/**
+		 * Normalize the item schema for an array field definition.
+		 *
+		 * @param array $definition Field definition from the schema.
+		 * @return array<string, array{label:string,type:string,data_type:string}>
+		 */
+	private function normalize_array_item_schema( $definition ) {
+			$schema = array();
+
+		if ( isset( $definition['item_schema'] ) && is_array( $definition['item_schema'] ) ) {
+			foreach ( $definition['item_schema'] as $key => $item ) {
+				$item_key = sanitize_key( $key );
+				if ( '' === $item_key ) {
+						continue;
+				}
+
+				$label = isset( $item['label'] ) ? sanitize_text_field( $item['label'] ) : $this->humanize_unknown_field_label( $item_key );
+				$type  = isset( $item['type'] ) ? sanitize_key( $item['type'] ) : 'textarea';
 				if ( ! in_array( $type, array( 'single', 'textarea', 'rich' ), true ) ) {
 						$type = 'textarea';
 				}
-				$meta_key          = 'resolate_field_' . $slug;
-				$known_meta_keys[] = $meta_key;
-				$value             = isset( $stored_fields[ $slug ] ) ? (string) $stored_fields[ $slug ]['value'] : '';
-				echo '<div class="resolate-field" style="margin-bottom:16px;">';
-				echo '<label for="' . esc_attr( $meta_key ) . '" style="font-weight:600;display:block;margin-bottom:4px;">' . esc_html( $label ) . '</label>';
-				if ( 'single' === $type ) {
-						echo '<input type="text" class="widefat" id="' . esc_attr( $meta_key ) . '" name="' . esc_attr( $meta_key ) . '" value="' . esc_attr( $value ) . '" />';
-				} elseif ( 'rich' === $type ) {
-				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_editor handles output escaping.
-						wp_editor(
-								$value,
-								$meta_key,
-								array(
-										'textarea_name' => $meta_key,
-										'textarea_rows' => 8,
-										'media_buttons' => false,
-										'teeny'         => false,
-										'tinymce'       => array(
-												'toolbar1' => 'formatselect,bold,italic,underline,link,bullist,numlist,alignleft,aligncenter,alignright,alignjustify,undo,redo,removeformat',
-										),
-										'quicktags'     => true,
-										'editor_height' => 220,
-								)
-								);
-				} else {
-						echo '<textarea class="widefat" rows="6" id="' . esc_attr( $meta_key ) . '" name="' . esc_attr( $meta_key ) . '">' . esc_textarea( $value ) . '</textarea>';
+
+				$data_type = isset( $item['data_type'] ) ? sanitize_key( $item['data_type'] ) : 'text';
+				if ( ! in_array( $data_type, array( 'text', 'number', 'boolean', 'date' ), true ) ) {
+						$data_type = 'text';
 				}
+
+				$schema[ $item_key ] = array(
+					'label'     => $label,
+					'type'      => $type,
+					'data_type' => $data_type,
+				);
+			}
+		}
+
+		if ( empty( $schema ) ) {
+				$schema['content'] = array(
+					'label'     => __( 'Contenido', 'resolate' ),
+					'type'      => 'textarea',
+					'data_type' => 'text',
+				);
+		}
+
+			return $schema;
+	}
+
+		/**
+		 * Render an array field with repeatable items.
+		 *
+		 * @param string $slug        Field slug.
+		 * @param string $label       Field label.
+		 * @param array  $item_schema Item schema definition.
+		 * @param array  $items       Current values.
+		 * @return void
+		 */
+	private function render_array_field( $slug, $label, $item_schema, $items ) {
+			$slug        = sanitize_key( $slug );
+			$label       = sanitize_text_field( $label );
+			$field_id    = 'resolate-array-' . $slug;
+			$items       = is_array( $items ) ? $items : array();
+			$item_schema = is_array( $item_schema ) ? $item_schema : array();
+
+			echo '<div class="resolate-array-field" data-array-field="' . esc_attr( $slug ) . '" style="margin-bottom:24px;">';
+			echo '<div class="resolate-array-heading" style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px;gap:12px;">';
+			echo '<span class="resolate-array-title" style="font-weight:600;font-size:15px;">' . esc_html( $label ) . '</span>';
+			echo '<button type="button" class="button button-secondary resolate-array-add" data-array-target="' . esc_attr( $slug ) . '">' . esc_html__( 'Añadir elemento', 'resolate' ) . '</button>';
+			echo '</div>';
+
+			echo '<div class="resolate-array-items" id="' . esc_attr( $field_id ) . '" data-field="' . esc_attr( $slug ) . '">';
+		foreach ( $items as $index => $values ) {
+				$values = is_array( $values ) ? $values : array();
+				$this->render_array_field_item( $slug, (string) $index, $item_schema, $values );
+		}
+			echo '</div>';
+
+			echo '<template class="resolate-array-template" data-field="' . esc_attr( $slug ) . '">';
+			$this->render_array_field_item( $slug, '__INDEX__', $item_schema, array(), true );
+			echo '</template>';
+			echo '</div>';
+	}
+
+		/**
+		 * Render a single repeatable array item row.
+		 *
+		 * @param string $slug         Field slug.
+		 * @param string $index        Item index.
+		 * @param array  $item_schema  Item schema definition.
+		 * @param array  $values       Current values.
+		 * @param bool   $is_template  Whether the row is a template placeholder.
+		 * @return void
+		 */
+	private function render_array_field_item( $slug, $index, $item_schema, $values, $is_template = false ) {
+			$slug        = sanitize_key( $slug );
+			$index_attr  = (string) $index;
+			$item_schema = is_array( $item_schema ) ? $item_schema : array();
+			$values      = is_array( $values ) ? $values : array();
+
+			echo '<div class="resolate-array-item" data-index="' . esc_attr( $index_attr ) . '" draggable="true" style="border:1px solid #e5e5e5;padding:16px;margin-bottom:12px;background:#fff;">';
+			echo '<div class="resolate-array-item-toolbar" style="display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:12px;">';
+			echo '<span class="resolate-array-handle" role="button" tabindex="0" aria-label="' . esc_attr__( 'Mover elemento', 'resolate' ) . '" style="cursor:move;user-select:none;">≡</span>';
+			echo '<button type="button" class="button-link-delete resolate-array-remove">' . esc_html__( 'Eliminar', 'resolate' ) . '</button>';
+			echo '</div>';
+
+		foreach ( $item_schema as $key => $definition ) {
+				$item_key = sanitize_key( $key );
+			if ( '' === $item_key ) {
+				continue;
+			}
+
+				$field_name = 'tpl_fields[' . $slug . '][' . $index_attr . '][' . $item_key . ']';
+				$field_id   = 'resolate-' . $slug . '-' . $item_key . '-' . $index_attr;
+				$label      = isset( $definition['label'] ) ? sanitize_text_field( $definition['label'] ) : $this->humanize_unknown_field_label( $item_key );
+				$type       = isset( $definition['type'] ) ? sanitize_key( $definition['type'] ) : 'textarea';
+				$value      = isset( $values[ $item_key ] ) ? (string) $values[ $item_key ] : '';
+
+			if ( ! in_array( $type, array( 'single', 'textarea', 'rich' ), true ) ) {
+					$type = 'textarea';
+			}
+
+				echo '<div class="resolate-array-field-control" style="margin-bottom:12px;">';
+				echo '<label for="' . esc_attr( $field_id ) . '" style="font-weight:600;display:block;margin-bottom:4px;">' . esc_html( $label ) . '</label>';
+
+			if ( 'single' === $type ) {
+					echo '<input type="text" class="widefat" id="' . esc_attr( $field_id ) . '" name="' . esc_attr( $field_name ) . '" value="' . esc_attr( $value ) . '" />';
+			} else {
+					$rows = ( 'rich' === $type ) ? 8 : 4;
+					echo '<textarea class="widefat" rows="' . esc_attr( (string) $rows ) . '" id="' . esc_attr( $field_id ) . '" name="' . esc_attr( $field_name ) . '">' . esc_textarea( $value ) . '</textarea>';
+			}
+
 				echo '</div>';
 		}
-		$unknown = $this->collect_unknown_dynamic_fields( $post->ID, $known_meta_keys );
-		$this->render_unknown_dynamic_fields_ui( $unknown );
-		echo '</div>';
-	
+
+			echo '</div>';
+	}
+
+		/**
+		 * Sanitize posted array field items against the schema definition.
+		 *
+		 * @param array $items      Raw submitted items.
+		 * @param array $definition Schema definition for the field.
+		 * @return array<int, array<string, string>>
+		 */
+	private function sanitize_array_field_items( $items, $definition ) {
+		if ( ! is_array( $items ) ) {
+				return array();
+		}
+
+			$schema = $this->normalize_array_item_schema( $definition );
+			$clean  = array();
+
+		foreach ( $items as $item ) {
+			if ( ! is_array( $item ) ) {
+					continue;
+			}
+
+				$filtered = array();
+			foreach ( $schema as $key => $settings ) {
+					$raw   = isset( $item[ $key ] ) ? $item[ $key ] : '';
+					$raw   = is_scalar( $raw ) ? (string) $raw : '';
+					$type  = isset( $settings['type'] ) ? $settings['type'] : 'textarea';
+					$value = '';
+
+				switch ( $type ) {
+					case 'single':
+						$value = sanitize_text_field( $raw );
+						break;
+					case 'rich':
+							$value = wp_kses_post( $raw );
+						break;
+					default:
+							$value = sanitize_textarea_field( $raw );
+						break;
+				}
+
+					$filtered[ $key ] = $value;
+			}
+
+				$has_content = false;
+			foreach ( $filtered as $key => $value ) {
+					$type = isset( $schema[ $key ]['type'] ) ? $schema[ $key ]['type'] : 'textarea';
+				if ( 'rich' === $type ) {
+					if ( '' !== trim( wp_strip_all_tags( (string) $value ) ) ) {
+						$has_content = true;
+						break;
+					}
+				} elseif ( '' !== trim( (string) $value ) ) {
+							$has_content = true;
+							break;
+				}
+			}
+
+			if ( $has_content ) {
+					$clean[] = $filtered;
+			}
+		}
+
+		if ( empty( $clean ) ) {
+				return array();
+		}
+
+			$clean = array_slice( $clean, 0, self::ARRAY_FIELD_MAX_ITEMS );
+			return array_values( $clean );
+	}
+
+		/**
+		 * Decode stored structured field data into array items.
+		 *
+		 * @param array $entry Structured entry with type/value keys.
+		 * @return array<int, array<string, string>>
+		 */
+	private function get_array_field_items_from_structured( $entry ) {
+		if ( ! is_array( $entry ) ) {
+				return array();
+		}
+
+			$value = isset( $entry['value'] ) ? (string) $entry['value'] : '';
+			return self::decode_array_field_value( $value );
+	}
+
+		/**
+		 * Decode a structured JSON value into array items.
+		 *
+		 * @param string $value JSON encoded string.
+		 * @return array<int, array<string, string>>
+		 */
+	public static function decode_array_field_value( $value ) {
+			$value = (string) $value;
+		if ( '' === trim( $value ) ) {
+				return array();
+		}
+
+			$decoded = json_decode( $value, true );
+		if ( ! is_array( $decoded ) ) {
+				return array();
+		}
+
+			$items = array();
+		foreach ( $decoded as $item ) {
+			if ( ! is_array( $item ) ) {
+					continue;
+			}
+				$normalized = array();
+			foreach ( $item as $key => $val ) {
+					$normalized[ sanitize_key( $key ) ] = is_scalar( $val ) ? (string) $val : '';
+			}
+				$items[] = $normalized;
+		}
+
+			return array_slice( $items, 0, self::ARRAY_FIELD_MAX_ITEMS );
 	}
 
 	/**
@@ -581,124 +799,16 @@ class Resolate_Documents {
 			}
 		}
 
-		// Dynamic fields are stored via post_content in filter_post_data_compose_content().
-
-		// Save annexes.
-		$annexes = array();
-		if ( isset( $_POST['resolate_annexes'] ) && is_array( $_POST['resolate_annexes'] ) ) {
-			$raw = wp_unslash( $_POST['resolate_annexes'] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized inside the loop.
-			foreach ( $raw as $idx => $item ) {
-				if ( ! is_array( $item ) ) {
-					continue;
-				}
-				$title = isset( $item['title'] ) ? sanitize_text_field( wp_unslash( $item['title'] ) ) : '';
-				$text  = isset( $item['text'] ) ? wp_kses_post( wp_unslash( $item['text'] ) ) : '';
-				if ( '' === trim( (string) $title ) && '' === trim( (string) $text ) ) {
-					continue;
-				}
-				$annexes[] = array(
-					'title' => $title,
-					'text'  => $text,
-				);
-			}
-		}
-		if ( ! empty( $annexes ) ) {
-			update_post_meta( $post_id, 'resolate_annexes', $annexes );
-		} else {
-			delete_post_meta( $post_id, 'resolate_annexes' );
-		}
-
 		// post_content is composed in wp_insert_post_data filter; avoid recursion here.
 	}
 
-	/**
-	 * Render the annexes meta box.
-	 *
-	 * @param WP_Post $post Current post.
-	 * @return void
-	 */
-	public function render_annexes_metabox( $post ) {
-		// Reuse the same nonce as sections box.
-		if ( ! isset( $_POST['resolate_sections_nonce'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
-			wp_nonce_field( 'resolate_sections_nonce', 'resolate_sections_nonce' );
-		}
-
-		$annexes = get_post_meta( $post->ID, 'resolate_annexes', true );
-		if ( ! is_array( $annexes ) ) {
-			$annexes = array();
-		}
-
-		echo '<div id="resolate-annexes" class="resolate-annexes">';
-		echo '<p class="description" style="margin-bottom:12px;">' . esc_html__( 'Añade anexos como páginas adicionales. Cada anexo tiene su propio título y texto.', 'resolate' ) . '</p>';
-		echo '<div id="resolate-annex-list">';
-
-		foreach ( $annexes as $i => $anx ) {
-			$t = isset( $anx['title'] ) ? (string) $anx['title'] : '';
-			$c = isset( $anx['text'] ) ? (string) $anx['text'] : '';
-			echo '<div class="resolate-annex-item" data-index="' . esc_attr( (string) $i ) . '" style="border:1px solid #e5e5e5;padding:12px;margin-bottom:12px;background:#fff;">';
-			echo '<div style="display:flex;justify-content:space-between;gap:8px;align-items:center;margin-bottom:8px;">';
-			echo '<strong>' . esc_html( sprintf( /* translators: %d: annex number */ __( 'Anexo %d', 'resolate' ), ( $i + 1 ) ) ) . '</strong>';
-			echo '<button type="button" class="button button-link-delete resolate-annex-remove" aria-label="' . esc_attr__( 'Eliminar anexo', 'resolate' ) . '">&times; ' . esc_html__( 'Eliminar', 'resolate' ) . '</button>';
-			echo '</div>';
-			echo '<label>' . esc_html__( 'Título del anexo', 'resolate' ) . '</label>';
-			echo '<input type="text" class="widefat" name="resolate_annexes[' . esc_attr( (string) $i ) . '][title]" value="' . esc_attr( $t ) . '" />';
-			echo '<label style="margin-top:8px;display:block;">' . esc_html__( 'Texto del anexo', 'resolate' ) . '</label>';
-			// Classic Editor instance per annex text.
-            // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_editor handles output escaping.
-			wp_editor(
-				$c,
-				'resolate_annex_text_' . (string) $i,
-				array(
-					'textarea_name' => 'resolate_annexes[' . (string) $i . '][text]',
-					'textarea_rows' => 6,
-					'media_buttons' => false,
-					'teeny'         => false,
-					'tinymce'       => array(
-						'toolbar1' => 'formatselect,bold,italic,underline,link,bullist,numlist,alignleft,aligncenter,alignright,alignjustify,undo,redo,removeformat',
-					),
-					'quicktags'     => true,
-					'editor_height' => 170,
-				)
-			);
-			echo '</div>';
-		}
-
-		echo '</div>'; // List container.
-		echo '<p><button type="button" class="button" id="resolate-add-annex">' . esc_html__( 'Añadir anexo', 'resolate' ) . '</button></p>';
-
-		// Template markup for new annex items.
-		echo '<script type="text/template" id="resolate-annex-template">';
-		echo '<div class=\"resolate-annex-item\" data-index=\"__i__\" style=\"border:1px solid #e5e5e5;padding:12px;margin-bottom:12px;background:#fff;\">';
-		echo '<div style=\"display:flex;justify-content:space-between;gap:8px;align-items:center;margin-bottom:8px;\">';
-		echo '<strong>' . esc_html__( 'Anexo __n__', 'resolate' ) . '</strong>';
-		echo '<button type=\"button\" class=\"button button-link-delete resolate-annex-remove\" aria-label=\"' . esc_attr__( 'Eliminar anexo', 'resolate' ) . '\">&times; ' . esc_html__( 'Eliminar', 'resolate' ) . '</button>';
-		echo '</div>';
-		echo '<label>' . esc_html__( 'Título del anexo', 'resolate' ) . '</label>';
-		echo '<input type=\"text\" class=\"widefat\" name=\"resolate_annexes[__i__][title]\" value=\"\" />';
-		echo '<label style=\"margin-top:8px;display:block;\">' . esc_html__( 'Texto del anexo', 'resolate' ) . '</label>';
-		echo '<textarea id=\"resolate_annex_text___i__\" class=\"widefat\" rows=\"6\" name=\"resolate_annexes[__i__][text]\"></textarea>';
-		echo '</div>';
-		echo '</script>';
-
-		echo '</div>'; // Wrapper container.
-	}
-
-	/**
-	 * Build a Gutenberg-compatible post_content from current fields so core revisions UI shows diffs.
-	 *
-	 * The content is composed of Heading blocks (labels) and Paragraph/HTML blocks (values),
-	 * and includes Annexes as additional sections. Meta remains the source of truth for generators.
-	 *
-	 * @param int $post_id Post ID.
-	 * @return void
-	 */
-	/**
-	 * Filter post data before save to compose a Gutenberg-friendly post_content.
-	 *
-	 * @param array $data    Sanitized post data to be inserted.
-	 * @param array $postarr Raw post data.
-	 * @return array
-	 */
+		/**
+		 * Filter post data before save to compose a Gutenberg-friendly post_content.
+		 *
+		 * @param array $data    Sanitized post data to be inserted.
+		 * @param array $postarr Raw post data.
+		 * @return array
+		 */
 	public function filter_post_data_compose_content( $data, $postarr ) {
 		if ( empty( $data['post_type'] ) || 'resolate_document' !== $data['post_type'] ) {
 			return $data;
@@ -738,41 +848,61 @@ class Resolate_Documents {
 			}
 		}
 
-		$structured_fields = array();
-		$known_slugs       = array();
+		$structured_fields   = array();
+		$known_slugs         = array();
+		$posted_array_fields = array();
+		if ( isset( $_POST['tpl_fields'] ) && is_array( $_POST['tpl_fields'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$posted_array_fields = wp_unslash( $_POST['tpl_fields'] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		}
 
 		foreach ( $schema as $row ) {
 			if ( empty( $row['slug'] ) ) {
-				continue;
+						continue;
 			}
-			$slug = sanitize_key( $row['slug'] );
+					$slug = sanitize_key( $row['slug'] );
 			if ( '' === $slug ) {
 				continue;
 			}
-			$type = isset( $row['type'] ) ? sanitize_key( $row['type'] ) : 'textarea';
+					$type = isset( $row['type'] ) ? sanitize_key( $row['type'] ) : 'textarea';
+				$known_slugs[ $slug ] = true;
+
+			if ( 'array' === $type ) {
+							$items = array();
+				if ( isset( $posted_array_fields[ $slug ] ) && is_array( $posted_array_fields[ $slug ] ) ) {
+						$items = $this->sanitize_array_field_items( $posted_array_fields[ $slug ], $row );
+				} elseif ( isset( $existing_structured[ $slug ] ) && isset( $existing_structured[ $slug ]['type'] ) && 'array' === $existing_structured[ $slug ]['type'] ) {
+						$items = $this->get_array_field_items_from_structured( $existing_structured[ $slug ] );
+				}
+
+							$structured_fields[ $slug ] = array(
+								'type'  => 'array',
+								'value' => ! empty( $items ) ? wp_json_encode( $items ) : '[]',
+							);
+							continue;
+			}
+
 			if ( ! in_array( $type, array( 'single', 'textarea', 'rich' ), true ) ) {
 				$type = 'textarea';
 			}
-			$known_slugs[ $slug ] = true;
-			$meta_key             = 'resolate_field_' . $slug;
-			$value                = '';
+							$meta_key             = 'resolate_field_' . $slug;
+							$value                = '';
 
-			if ( isset( $_POST[ $meta_key ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			if ( isset( $_POST[ $meta_key ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 				if ( 'single' === $type ) {
-					$value = sanitize_text_field( wp_unslash( $_POST[ $meta_key ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+					$value = sanitize_text_field( wp_unslash( $_POST[ $meta_key ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 				} elseif ( 'rich' === $type ) {
-					$value = wp_kses_post( wp_unslash( $_POST[ $meta_key ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+							$value = wp_kses_post( wp_unslash( $_POST[ $meta_key ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 				} else {
-					$value = sanitize_textarea_field( wp_unslash( $_POST[ $meta_key ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+						$value = sanitize_textarea_field( wp_unslash( $_POST[ $meta_key ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 				}
 			} elseif ( isset( $existing_structured[ $slug ] ) ) {
 				$value = (string) $existing_structured[ $slug ]['value'];
 			}
 
-			$structured_fields[ $slug ] = array(
-				'type'  => $type,
-				'value' => (string) $value,
-			);
+							$structured_fields[ $slug ] = array(
+								'type'  => $type,
+								'value' => (string) $value,
+							);
 		}
 
 		$unknown_fields = array();
@@ -784,8 +914,8 @@ class Resolate_Documents {
 					continue;
 				}
 				$meta_key = 'resolate_field_' . $slug;
-				if ( isset( $_POST[ $meta_key ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
-					$val = wp_unslash( $_POST[ $meta_key ] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+				if ( isset( $_POST[ $meta_key ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+					$val = wp_unslash( $_POST[ $meta_key ] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 					$unknown_fields[ $slug ] = array(
 						'type'  => 'rich',
 						'value' => wp_kses_post( is_string( $val ) ? $val : '' ),
@@ -859,7 +989,7 @@ class Resolate_Documents {
 		}
 
 		$fallback = array();
-               $schema   = $this->get_dynamic_fields_schema_for_post( $post_id );
+			   $schema   = $this->get_dynamic_fields_schema_for_post( $post_id );
 		if ( ! empty( $schema ) ) {
 			foreach ( $schema as $row ) {
 				if ( empty( $row['slug'] ) ) {
@@ -874,9 +1004,32 @@ class Resolate_Documents {
 				if ( '' === $value ) {
 					continue;
 				}
-				$type = isset( $row['type'] ) ? sanitize_key( $row['type'] ) : 'textarea';
+						$type = isset( $row['type'] ) ? sanitize_key( $row['type'] ) : 'textarea';
+				if ( 'array' === $type ) {
+						$encoded = '';
+						$stored  = get_post_meta( $post_id, 'resolate_field_' . $slug, true );
+					if ( is_string( $stored ) && '' !== $stored ) {
+								$encoded = (string) $stored;
+					} else {
+									$legacy = get_post_meta( $post_id, 'resolate_' . $slug, true );
+						if ( empty( $legacy ) && 'annexes' === $slug ) {
+								$legacy = get_post_meta( $post_id, 'resolate_annexes', true );
+						}
+						if ( is_array( $legacy ) && ! empty( $legacy ) ) {
+								$encoded = wp_json_encode( $legacy );
+						}
+					}
+
+					if ( '' !== $encoded ) {
+						$fallback[ $slug ] = array(
+							'value' => $encoded,
+							'type'  => 'array',
+						);
+					}
+									continue;
+				}
 				if ( ! in_array( $type, array( 'single', 'textarea', 'rich' ), true ) ) {
-					$type = 'textarea';
+						$type = 'textarea';
 				}
 				$fallback[ $slug ] = array(
 					'value' => (string) $value,
@@ -885,7 +1038,7 @@ class Resolate_Documents {
 			}
 		}
 
-               return $fallback;
+			   return $fallback;
 	}
 
 	/**
@@ -953,12 +1106,12 @@ class Resolate_Documents {
 		if ( '' === $slug ) {
 			return '';
 		}
-		$type = sanitize_key( $type );
-		if ( ! in_array( $type, array( 'single', 'textarea', 'rich' ), true ) ) {
-			$type = '';
+				$type = sanitize_key( $type );
+		if ( ! in_array( $type, array( 'single', 'textarea', 'rich', 'array' ), true ) ) {
+				$type = '';
 		}
 
-		$attributes = 'slug="' . esc_attr( $slug ) . '"';
+				$attributes = 'slug="' . esc_attr( $slug ) . '"';
 		if ( '' !== $type ) {
 			$attributes .= ' type="' . esc_attr( $type ) . '"';
 		}
@@ -1001,27 +1154,27 @@ class Resolate_Documents {
 			if ( ! is_array( $item ) ) {
 				continue;
 			}
-                        $slug        = isset( $item['slug'] ) ? sanitize_key( $item['slug'] ) : '';
-                        $label       = isset( $item['label'] ) ? sanitize_text_field( $item['label'] ) : '';
-                        $type        = isset( $item['type'] ) ? sanitize_key( $item['type'] ) : 'textarea';
-                        $placeholder = isset( $item['placeholder'] ) ? preg_replace( '/[^A-Za-z0-9._:-]/', '', (string) $item['placeholder'] ) : '';
-                        $data_type   = isset( $item['data_type'] ) ? sanitize_key( $item['data_type'] ) : '';
-                        if ( '' === $slug || '' === $label ) {
-                                continue;
-                        }
-                        if ( ! in_array( $type, array( 'single', 'textarea', 'rich' ), true ) ) {
-                                $type = 'textarea';
-                        }
-                        $out[] = array(
-                                'slug'        => $slug,
-                                'label'       => $label,
-                                'type'        => $type,
-                                'placeholder' => $placeholder,
-                                'data_type'   => $data_type,
-                        );
-                }
-                return $out;
-        }
+						$slug        = isset( $item['slug'] ) ? sanitize_key( $item['slug'] ) : '';
+						$label       = isset( $item['label'] ) ? sanitize_text_field( $item['label'] ) : '';
+						$type        = isset( $item['type'] ) ? sanitize_key( $item['type'] ) : 'textarea';
+						$placeholder = isset( $item['placeholder'] ) ? preg_replace( '/[^A-Za-z0-9._:-]/', '', (string) $item['placeholder'] ) : '';
+						$data_type   = isset( $item['data_type'] ) ? sanitize_key( $item['data_type'] ) : '';
+			if ( '' === $slug || '' === $label ) {
+					continue;
+			}
+			if ( ! in_array( $type, array( 'single', 'textarea', 'rich' ), true ) ) {
+					$type = 'textarea';
+			}
+						$out[] = array(
+							'slug'        => $slug,
+							'label'       => $label,
+							'type'        => $type,
+							'placeholder' => $placeholder,
+							'data_type'   => $data_type,
+						);
+		}
+				return $out;
+	}
 
 	/**
 	 * Collect meta values whose keys start with resolate_field_ but are not part of the schema.

--- a/resolate.php
+++ b/resolate.php
@@ -368,43 +368,12 @@ function resolate_detect_template_type( $path ) {
  * @return array[]
  */
 function resolate_build_schema_from_template( $path ) {
-        $fields = Resolate_Template_Parser::extract_fields( $path );
-        if ( is_wp_error( $fields ) || ! is_array( $fields ) ) {
-                return array();
-        }
+		$fields = Resolate_Template_Parser::extract_fields( $path );
+	if ( is_wp_error( $fields ) || ! is_array( $fields ) ) {
+			return array();
+	}
 
-        $schema = array();
-        foreach ( $fields as $field ) {
-                if ( ! is_array( $field ) ) {
-                        continue;
-                }
-                $placeholder = isset( $field['placeholder'] ) ? preg_replace( '/[^A-Za-z0-9._:-]/', '', (string) $field['placeholder'] ) : '';
-                $slug        = isset( $field['slug'] ) ? sanitize_key( $field['slug'] ) : '';
-                if ( '' === $slug && '' !== $placeholder ) {
-                        $slug = sanitize_key( str_replace( array( '.', ':' ), '_', strtolower( $placeholder ) ) );
-                }
-                if ( '' === $slug ) {
-                        continue;
-                }
-                $label     = isset( $field['label'] ) ? sanitize_text_field( $field['label'] ) : resolate_humanize_slug( '' !== $placeholder ? $placeholder : $slug );
-                $data_type = isset( $field['data_type'] ) ? sanitize_key( $field['data_type'] ) : 'text';
-                if ( ! in_array( $data_type, array( 'text', 'number', 'boolean', 'date' ), true ) ) {
-                        $data_type = 'text';
-                }
-                if ( '' === $placeholder ) {
-                        $placeholder = $slug;
-                }
-
-                $schema[] = array(
-                        'slug'        => $slug,
-                        'label'       => $label,
-                        'type'        => 'textarea',
-                        'placeholder' => $placeholder,
-                        'data_type'   => $data_type,
-                );
-        }
-
-        return $schema;
+		return Resolate_Template_Parser::build_schema_from_field_definitions( $fields );
 }
 
 /**

--- a/tests/unit/includes/ResolateDocumentGeneratorTest.php
+++ b/tests/unit/includes/ResolateDocumentGeneratorTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Tests for Resolate_Document_Generator array exports.
+ */
+
+class ResolateDocumentGeneratorTest extends WP_UnitTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+		register_post_type( 'resolate_document', array( 'public' => false ) );
+		register_taxonomy( 'resolate_doc_type', array( 'resolate_document' ) );
+	}
+
+	/**
+	 * It should expose array fields as decoded PHP arrays for template merges.
+	 */
+	public function test_build_merge_fields_includes_array_values() {
+		$term = wp_insert_term( 'Tipo Merge', 'resolate_doc_type' );
+		$term_id = intval( $term['term_id'] );
+		$schema  = array(
+			array(
+				'slug'        => 'annexes',
+				'label'       => 'Anexos',
+				'type'        => 'array',
+				'placeholder' => 'annexes',
+				'data_type'   => 'array',
+				'item_schema' => array(
+					'number'  => array(
+						'label'     => 'Número',
+						'type'      => 'single',
+						'data_type' => 'text',
+					),
+					'content' => array(
+						'label'     => 'Contenido',
+						'type'      => 'rich',
+						'data_type' => 'text',
+					),
+				),
+			),
+			array(
+				'slug'        => 'resolution_title',
+				'label'       => 'Título',
+				'type'        => 'textarea',
+				'placeholder' => 'resolution_title',
+				'data_type'   => 'text',
+			),
+		);
+		update_term_meta( $term_id, 'schema', $schema );
+		update_term_meta( $term_id, 'resolate_type_fields', $schema );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => 'resolate_document',
+				'post_title'  => 'Documento Merge',
+				'post_status' => 'draft',
+			)
+		);
+		wp_set_post_terms( $post_id, array( $term_id ), 'resolate_doc_type', false );
+
+		$doc = new Resolate_Documents();
+		$_POST['resolate_doc_type']               = (string) $term_id;
+		$_POST['tpl_fields']                      = wp_slash(
+			array(
+				'annexes' => array(
+					array(
+						'number'  => 'I',
+						'content' => '<p>Detalle I</p>',
+					),
+					array(
+						'number'  => 'II',
+						'content' => '<p>Detalle II</p>',
+					),
+				),
+			)
+		);
+		$_POST['resolate_field_resolution_title'] = '  Título base  ';
+
+		$data    = array( 'post_type' => 'resolate_document' );
+		$postarr = array( 'ID' => $post_id );
+		$result  = $doc->filter_post_data_compose_content( $data, $postarr );
+
+		remove_filter( 'wp_insert_post_data', array( $doc, 'filter_post_data_compose_content' ), 10 );
+		$_POST = array();
+		wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => $result['post_content'],
+			)
+		);
+
+		$ref     = new ReflectionClass( Resolate_Document_Generator::class );
+		$method  = $ref->getMethod( 'build_merge_fields' );
+		$method->setAccessible( true );
+		$fields  = $method->invoke( null, $post_id );
+
+		$this->assertArrayHasKey( 'annexes', $fields );
+		$this->assertIsArray( $fields['annexes'] );
+		$this->assertCount( 2, $fields['annexes'] );
+		$this->assertSame( 'I', $fields['annexes'][0]['number'] );
+		$this->assertSame( '<p>Detalle I</p>', $fields['annexes'][0]['content'] );
+		$this->assertSame( 'Título base', $fields['resolution_title'] );
+	}
+}

--- a/tests/unit/includes/ResolateTemplateParserTest.php
+++ b/tests/unit/includes/ResolateTemplateParserTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Tests for Resolate_Template_Parser schema building.
+ */
+
+class ResolateTemplateParserTest extends WP_UnitTestCase {
+
+	/**
+	 * It should detect array fields and build item schema entries.
+	 */
+	public function test_build_schema_from_field_definitions_detects_arrays() {
+		$fields = array(
+			array(
+				'placeholder' => 'annexes[*].number',
+				'slug'        => 'annexes_number',
+				'label'       => 'Annex Number',
+				'parameters'  => array(),
+				'data_type'   => 'text',
+			),
+			array(
+				'placeholder' => 'annexes[*].title',
+				'slug'        => 'annexes_title',
+				'label'       => 'Annex Title',
+				'parameters'  => array(),
+				'data_type'   => 'text',
+			),
+			array(
+				'placeholder' => 'annexes[*].content',
+				'slug'        => 'annexes_content',
+				'label'       => 'Annex Content',
+				'parameters'  => array(),
+				'data_type'   => 'text',
+			),
+			array(
+				'placeholder' => 'onshow',
+				'slug'        => 'onshow',
+				'label'       => 'On Show',
+				'parameters'  => array( 'repeat' => 'annexes' ),
+				'data_type'   => 'text',
+			),
+			array(
+				'placeholder' => 'resolution_title',
+				'slug'        => 'resolution_title',
+				'label'       => 'Resolution Title',
+				'parameters'  => array(),
+				'data_type'   => 'text',
+			),
+		);
+
+		$schema = Resolate_Template_Parser::build_schema_from_field_definitions( $fields );
+
+		$this->assertNotEmpty( $schema, 'La definición de esquema no debe estar vacía.' );
+
+		$array_field = null;
+		foreach ( $schema as $entry ) {
+			if ( isset( $entry['slug'] ) && 'annexes' === $entry['slug'] ) {
+				$array_field = $entry;
+				break;
+			}
+		}
+
+		$this->assertIsArray( $array_field, 'Se debe detectar el campo de anexos.' );
+		$this->assertSame( 'array', $array_field['type'] );
+		$this->assertSame( 'array', $array_field['data_type'] );
+		$this->assertArrayHasKey( 'item_schema', $array_field );
+		$this->assertArrayHasKey( 'number', $array_field['item_schema'] );
+		$this->assertArrayHasKey( 'title', $array_field['item_schema'] );
+		$this->assertArrayHasKey( 'content', $array_field['item_schema'] );
+		$this->assertSame( 'single', $array_field['item_schema']['number']['type'] );
+		$this->assertSame( 'rich', $array_field['item_schema']['content']['type'] );
+
+		$scalar_field = null;
+		foreach ( $schema as $entry ) {
+			if ( isset( $entry['slug'] ) && 'resolution_title' === $entry['slug'] ) {
+				$scalar_field = $entry;
+				break;
+			}
+		}
+
+		$this->assertIsArray( $scalar_field );
+		$this->assertSame( 'textarea', $scalar_field['type'] );
+		$this->assertSame( 'text', $scalar_field['data_type'] );
+	}
+}

--- a/tests/unit/includes/custom-post-types/ResolateDocumentsArrayFieldsTest.php
+++ b/tests/unit/includes/custom-post-types/ResolateDocumentsArrayFieldsTest.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Tests for array field persistence in Resolate_Documents.
+ */
+
+class ResolateDocumentsArrayFieldsTest extends WP_UnitTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+		register_post_type( 'resolate_document', array( 'public' => false ) );
+		register_taxonomy( 'resolate_doc_type', array( 'resolate_document' ) );
+	}
+
+	/**
+	 * It should sanitize and encode array fields into structured content JSON.
+	 */
+	public function test_filter_post_data_compose_content_saves_array_fields_as_json() {
+		$term = wp_insert_term( 'Tipo Anexos', 'resolate_doc_type' );
+		$term_id = intval( $term['term_id'] );
+		$schema  = $this->get_annex_schema();
+		update_term_meta( $term_id, 'schema', $schema );
+		update_term_meta( $term_id, 'resolate_type_fields', $schema );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => 'resolate_document',
+				'post_title'  => 'Documento',
+				'post_status' => 'draft',
+			)
+		);
+		wp_set_post_terms( $post_id, array( $term_id ), 'resolate_doc_type', false );
+
+		$doc = new Resolate_Documents();
+
+		$_POST['resolate_doc_type'] = (string) $term_id;
+		$_POST['tpl_fields']        = wp_slash(
+			array(
+				'annexes' => array(
+					array(
+						'number'  => ' I ',
+						'title'   => '  Marco  ',
+						'content' => '<p>Contenido <strong>válido</strong></p><script>alert(1)</script>',
+					),
+					array(
+						'number'  => '',
+						'title'   => '',
+						'content' => '',
+					),
+				),
+			)
+		);
+
+		$data    = array( 'post_type' => 'resolate_document' );
+		$postarr = array( 'ID' => $post_id );
+		$result  = $doc->filter_post_data_compose_content( $data, $postarr );
+
+		$structured = Resolate_Documents::parse_structured_content( $result['post_content'] );
+		$this->assertArrayHasKey( 'annexes', $structured );
+		$this->assertSame( 'array', $structured['annexes']['type'] );
+		$decoded = json_decode( $structured['annexes']['value'], true );
+		$this->assertIsArray( $decoded );
+		$this->assertCount( 1, $decoded, 'Solo el elemento con contenido debe persistir.' );
+		$this->assertSame( 'I', $decoded[0]['number'] );
+		$this->assertSame( 'Marco', $decoded[0]['title'] );
+		$this->assertSame( '<p>Contenido <strong>válido</strong></p>', $decoded[0]['content'] );
+
+		$_POST = array();
+		remove_filter( 'wp_insert_post_data', array( $doc, 'filter_post_data_compose_content' ), 10 );
+	}
+
+	/**
+	 * It should cap stored items to the configured maximum.
+	 */
+	public function test_filter_post_data_compose_content_limits_array_items() {
+		$term = wp_insert_term( 'Tipo Límite', 'resolate_doc_type' );
+		$term_id = intval( $term['term_id'] );
+		$schema  = $this->get_annex_schema();
+		update_term_meta( $term_id, 'schema', $schema );
+		update_term_meta( $term_id, 'resolate_type_fields', $schema );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => 'resolate_document',
+				'post_title'  => 'Documento',
+				'post_status' => 'draft',
+			)
+		);
+		wp_set_post_terms( $post_id, array( $term_id ), 'resolate_doc_type', false );
+
+		$items = array();
+		for ( $i = 0; $i < Resolate_Documents::ARRAY_FIELD_MAX_ITEMS + 5; $i++ ) {
+			$items[] = array(
+				'number'  => 'N' . $i,
+				'title'   => 'Título ' . $i,
+				'content' => 'Contenido ' . $i,
+			);
+		}
+
+		$doc = new Resolate_Documents();
+
+		$_POST['resolate_doc_type'] = (string) $term_id;
+		$_POST['tpl_fields']        = wp_slash(
+			array(
+				'annexes' => $items,
+			)
+		);
+
+		$data    = array( 'post_type' => 'resolate_document' );
+		$postarr = array( 'ID' => $post_id );
+		$result  = $doc->filter_post_data_compose_content( $data, $postarr );
+
+		$structured = Resolate_Documents::parse_structured_content( $result['post_content'] );
+		$decoded    = json_decode( $structured['annexes']['value'], true );
+		$this->assertCount( Resolate_Documents::ARRAY_FIELD_MAX_ITEMS, $decoded );
+		$last_index = Resolate_Documents::ARRAY_FIELD_MAX_ITEMS - 1;
+		$this->assertSame( 'N' . $last_index, $decoded[ $last_index ]['number'] );
+		$this->assertSame( 'Título ' . $last_index, $decoded[ $last_index ]['title'] );
+
+		$_POST = array();
+		remove_filter( 'wp_insert_post_data', array( $doc, 'filter_post_data_compose_content' ), 10 );
+	}
+
+	/**
+	 * Helper to build the annex schema fixture.
+	 *
+	 * @return array
+	 */
+	private function get_annex_schema() {
+		return array(
+			array(
+				'slug'        => 'annexes',
+				'label'       => 'Anexos',
+				'type'        => 'array',
+				'placeholder' => 'annexes',
+				'data_type'   => 'array',
+				'item_schema' => array(
+					'number'  => array(
+						'label'     => 'Número',
+						'type'      => 'single',
+						'data_type' => 'text',
+					),
+					'title'   => array(
+						'label'     => 'Título',
+						'type'      => 'single',
+						'data_type' => 'text',
+					),
+					'content' => array(
+						'label'     => 'Contenido',
+						'type'      => 'rich',
+						'data_type' => 'text',
+					),
+				),
+			),
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- extend the template parser and document-type admin workflow to detect array placeholders and expose item schemas
- replace the sections metabox with repeatable array controls that store JSON in structured content while previews and export merges consume decoded arrays
- rebuild the annexes admin script as a vanilla JS repeater supporting add/remove/reorder operations

## Testing
- `composer test` *(fails: missing WordPress native test bootstrap)*
- `./vendor/bin/phpcs --standard=.phpcs.xml.dist .`


------
https://chatgpt.com/codex/tasks/task_e_68ee30cf252083229149dd9f656091e1