### PR TITLE
Preserve rich OpenTBS field formatting

### DIFF
--- a/includes/class-resolate-template-parser.php
+++ b/includes/class-resolate-template-parser.php
@@ -343,13 +343,18 @@ class Resolate_Template_Parser {
 
 			foreach ( $scalar_fields as $field ) {
 				unset( $field['_order'] );
-				$field['type'] = 'textarea';
-				$schema[]       = $field;
+				$field['type'] = self::infer_scalar_field_type(
+					isset( $field['slug'] ) ? $field['slug'] : '',
+					isset( $field['label'] ) ? $field['label'] : '',
+					isset( $field['data_type'] ) ? $field['data_type'] : '',
+					isset( $field['placeholder'] ) ? $field['placeholder'] : ''
+				);
+				$schema[] = $field;
 			}
 		}
 
-			return $schema;
-	}
+		return $schema;
+        }
 
 		/**
 		 * Parse a raw OpenTBS placeholder definition.
@@ -608,37 +613,65 @@ class Resolate_Template_Parser {
 		 * @param string $data_type Detected data type.
 		 * @return string
 		 */
-	private static function infer_array_item_type( $item_key, $data_type ) {
-			$item_key  = strtolower( (string) $item_key );
-			$data_type = strtolower( (string) $data_type );
+        private static function infer_array_item_type( $item_key, $data_type ) {
+                        $item_key  = strtolower( (string) $item_key );
+        		$data_type = strtolower( (string) $data_type );
 
 		if ( in_array( $data_type, array( 'number', 'date', 'boolean' ), true ) ) {
-				return 'single';
-		}
+        			return 'single';
+                }
 
-		if ( preg_match( '/^(number|numero|número|index|indice)$/', $item_key ) ) {
-				return 'single';
-		}
+                if ( preg_match( '/^(number|numero|número|index|indice)$/', $item_key ) ) {
+        			return 'single';
+                }
 
-		if ( preg_match( '/^(title|titulo|título|heading|name)$/', $item_key ) ) {
-				return 'single';
-		}
+                if ( preg_match( '/^(title|titulo|título|heading|name)$/', $item_key ) ) {
+        			return 'single';
+                }
 
-		if ( preg_match( '/(content|texto|text|body|descripcion|descripción)$/', $item_key ) ) {
-				return 'rich';
-		}
+                if ( preg_match( '/(content|texto|text|body|descripcion|descripción)$/', $item_key ) ) {
+                		return 'rich';
+                }
 
-			return 'textarea';
-	}
+                        return 'textarea';
+        }
 
-		/**
-		 * Polyfill for str_ends_with to support older PHP versions.
-		 *
-		 * @param string $haystack Full string.
-		 * @param string $needle   Ending to verify.
-		 * @return bool
-		 */
-	private static function ends_with( $haystack, $needle ) {
+        /**
+         * Infer the control type for a scalar field definition.
+         *
+         * @param string $slug         Field slug.
+         * @param string $label        Field label.
+         * @param string $data_type    Detected data type.
+         * @param string $placeholder  Placeholder name.
+         * @return string
+         */
+	private static function infer_scalar_field_type( $slug, $label, $data_type, $placeholder ) {
+		$data_type = strtolower( (string) $data_type );
+		if ( in_array( $data_type, array( 'number', 'date', 'boolean' ), true ) ) {
+			return 'single';
+                }
+
+		$haystack = strtolower( trim( (string) $slug . ' ' . (string) $label . ' ' . (string) $placeholder ) );
+
+		if ( preg_match( '/\b(title|titulo|título|heading|subject|asunto|name|nombre)\b/u', $haystack ) ) {
+			return 'single';
+                }
+
+		if ( preg_match( '/(content|contenido|texto|text|body|descripcion|descripción|detalle|summary|resumen)/u', $haystack ) ) {
+        		return 'rich';
+                }
+
+		return 'rich';
+        }
+
+        /**
+         * Polyfill for str_ends_with to support older PHP versions.
+         *
+         * @param string $haystack Full string.
+         * @param string $needle   Ending to verify.
+         * @return bool
+         */
+        private static function ends_with( $haystack, $needle ) {
 		if ( '' === $needle ) {
 			return true;
 		}

--- a/tests/unit/includes/ResolateDocumentGeneratorTest.php
+++ b/tests/unit/includes/ResolateDocumentGeneratorTest.php
@@ -44,6 +44,13 @@ class ResolateDocumentGeneratorTest extends WP_UnitTestCase {
 				'placeholder' => 'resolution_title',
 				'data_type'   => 'text',
 			),
+			array(
+				'slug'        => 'resolution_body',
+				'label'       => 'Cuerpo',
+				'type'        => 'rich',
+				'placeholder' => 'resolution_body',
+				'data_type'   => 'text',
+			),
 		);
 		update_term_meta( $term_id, 'schema', $schema );
 		update_term_meta( $term_id, 'resolate_type_fields', $schema );
@@ -74,6 +81,7 @@ class ResolateDocumentGeneratorTest extends WP_UnitTestCase {
 			)
 		);
 		$_POST['resolate_field_resolution_title'] = '  Título base  ';
+		$_POST['resolate_field_resolution_body']  = '<p><strong>Detalle</strong> con formato.</p>';
 
 		$data    = array( 'post_type' => 'resolate_document' );
 		$postarr = array( 'ID' => $post_id );
@@ -99,5 +107,6 @@ class ResolateDocumentGeneratorTest extends WP_UnitTestCase {
 		$this->assertSame( 'I', $fields['annexes'][0]['number'] );
 		$this->assertSame( '<p>Detalle I</p>', $fields['annexes'][0]['content'] );
 		$this->assertSame( 'Título base', $fields['resolution_title'] );
+		$this->assertSame( '<p><strong>Detalle</strong> con formato.</p>', $fields['resolution_body'] );
 	}
 }

--- a/tests/unit/includes/ResolateTemplateParserTest.php
+++ b/tests/unit/includes/ResolateTemplateParserTest.php
@@ -45,7 +45,14 @@ class ResolateTemplateParserTest extends WP_UnitTestCase {
 				'parameters'  => array(),
 				'data_type'   => 'text',
 			),
-		);
+			array(
+				'placeholder' => 'resolution_body',
+				'slug'        => 'resolution_body',
+				'label'       => 'Resolution Body',
+				'parameters'  => array(),
+				'data_type'   => 'text',
+			),
+                );
 
 		$schema = Resolate_Template_Parser::build_schema_from_field_definitions( $fields );
 
@@ -78,7 +85,19 @@ class ResolateTemplateParserTest extends WP_UnitTestCase {
 		}
 
 		$this->assertIsArray( $scalar_field );
-		$this->assertSame( 'textarea', $scalar_field['type'] );
+		$this->assertSame( 'single', $scalar_field['type'] );
 		$this->assertSame( 'text', $scalar_field['data_type'] );
-	}
+
+		$rich_scalar = null;
+		foreach ( $schema as $entry ) {
+			if ( isset( $entry['slug'] ) && 'resolution_body' === $entry['slug'] ) {
+				$rich_scalar = $entry;
+				break;
+			}
+		}
+
+		$this->assertIsArray( $rich_scalar );
+		$this->assertSame( 'rich', $rich_scalar['type'] );
+		$this->assertSame( 'text', $rich_scalar['data_type'] );
+        }
 }


### PR DESCRIPTION
## Summary
- keep HTML markup for rich scalar fields when composing OpenTBS merge data
- add a dedicated helper to sanitize merge values by field type and reuse it for legacy fallbacks
- extend the document generator test to cover rich scalar fields retaining their formatting

## Testing
- composer test *(fails: vendor/bin/phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ee71682af483229aca647b9a8dd884