### PR TITLE
Enforced documents security

### DIFF
--- a/includes/class-documentate-document-access-protection.php
+++ b/includes/class-documentate-document-access-protection.php
@@ -1,0 +1,313 @@
+<?php
+/**
+ * Document Access Protection for Documentate.
+ *
+ * Ensures that documentate_document posts and their comments are not accessible
+ * to anonymous users or subscribers via web or REST API.
+ *
+ * @package    Documentate
+ * @subpackage Documentate/includes
+ */
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Documentate_Document_Access_Protection
+ *
+ * Provides comprehensive access protection for documentate_document CPT:
+ * - Blocks frontend access for unauthorized users
+ * - Filters queries to exclude documents from unauthorized users
+ * - Adds extra REST API protection layer
+ * - Ensures comments are protected
+ */
+class Documentate_Document_Access_Protection {
+
+	/**
+	 * The post type to protect.
+	 *
+	 * @var string
+	 */
+	const POST_TYPE = 'documentate_document';
+
+	/**
+	 * Minimum capability required to access documents.
+	 *
+	 * @var string
+	 */
+	const REQUIRED_CAPABILITY = 'edit_posts';
+
+	/**
+	 * Initialize the class and register hooks.
+	 */
+	public function __construct() {
+		// Frontend protection.
+		add_action( 'template_redirect', array( $this, 'block_frontend_access' ) );
+
+		// Query filtering.
+		add_action( 'pre_get_posts', array( $this, 'filter_queries' ) );
+
+		// REST API protection (extra layer even though show_in_rest is false).
+		add_action( 'rest_api_init', array( $this, 'register_rest_protection' ) );
+
+		// Register protected post types for comment protection.
+		add_filter( 'documentate/protected_comment_post_types', array( $this, 'add_document_to_protected_types' ) );
+
+		// Block comment form display for unauthorized users.
+		add_filter( 'comments_open', array( $this, 'filter_comments_open' ), 10, 2 );
+
+		// Filter comment queries to exclude document comments for unauthorized users.
+		add_filter( 'comments_pre_query', array( $this, 'filter_comment_queries' ), 10, 2 );
+	}
+
+	/**
+	 * Check if current user can access documents.
+	 *
+	 * @return bool True if user can access, false otherwise.
+	 */
+	public function user_can_access() {
+		return is_user_logged_in() && current_user_can( self::REQUIRED_CAPABILITY );
+	}
+
+	/**
+	 * Block frontend access to single documents for unauthorized users.
+	 *
+	 * @return void
+	 */
+	public function block_frontend_access() {
+		if ( ! is_singular( self::POST_TYPE ) ) {
+			return;
+		}
+
+		if ( $this->user_can_access() ) {
+			return;
+		}
+
+		// Return 404 for unauthorized access attempts.
+		global $wp_query;
+		$wp_query->set_404();
+		status_header( 404 );
+		nocache_headers();
+
+		// Try to use theme's 404 template.
+		$template = get_404_template();
+		if ( $template ) {
+			include $template;
+			exit;
+		}
+
+		// Fallback if no 404 template.
+		wp_die(
+			esc_html__( 'You are not authorized to access this resource.', 'documentate' ),
+			esc_html__( 'Access Denied', 'documentate' ),
+			array( 'response' => 404 )
+		);
+	}
+
+	/**
+	 * Filter queries to exclude documents for unauthorized users.
+	 *
+	 * @param WP_Query $query The query object.
+	 * @return void
+	 */
+	public function filter_queries( $query ) {
+		// Don't filter admin queries or if user has access.
+		if ( is_admin() || $this->user_can_access() ) {
+			return;
+		}
+
+		// Get current post types being queried.
+		$post_type = $query->get( 'post_type' );
+
+		// If querying our post type specifically, set to return nothing.
+		if ( self::POST_TYPE === $post_type ) {
+			$query->set( 'post__in', array( 0 ) );
+			return;
+		}
+
+		// If querying 'any' or array of post types including ours, exclude it.
+		if ( 'any' === $post_type ) {
+			$query->set( 'post_type', $this->get_public_post_types() );
+			return;
+		}
+
+		if ( is_array( $post_type ) && in_array( self::POST_TYPE, $post_type, true ) ) {
+			$query->set( 'post_type', array_diff( $post_type, array( self::POST_TYPE ) ) );
+		}
+	}
+
+	/**
+	 * Get list of public post types excluding our protected type.
+	 *
+	 * @return array Array of post type names.
+	 */
+	private function get_public_post_types() {
+		$types = get_post_types( array( 'public' => true ) );
+		unset( $types[ self::POST_TYPE ] );
+		return array_values( $types );
+	}
+
+	/**
+	 * Register REST API protection hooks.
+	 *
+	 * @return void
+	 */
+	public function register_rest_protection() {
+		// Block any attempts to access documents via REST API.
+		add_filter( 'rest_pre_dispatch', array( $this, 'block_rest_access' ), 10, 3 );
+
+		// Filter post queries in REST context.
+		add_filter( 'rest_post_query', array( $this, 'filter_rest_post_query' ), 10, 2 );
+	}
+
+	/**
+	 * Block REST API access to documents for unauthorized users.
+	 *
+	 * @param mixed           $result  Dispatch result.
+	 * @param WP_REST_Server  $server  Server instance.
+	 * @param WP_REST_Request $request Request object.
+	 * @return mixed WP_Error if blocked, original result otherwise.
+	 */
+	public function block_rest_access( $result, $server, $request ) {
+		if ( $this->user_can_access() ) {
+			return $result;
+		}
+
+		$route = $request->get_route();
+
+		// Block direct access to document endpoints (shouldn't exist but extra safety).
+		if ( preg_match( '#^/wp/v2/' . self::POST_TYPE . '(?:/|$)#', $route ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'You are not authorized to access this resource.', 'documentate' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		// Block access to single posts by ID if they are our post type.
+		if ( preg_match( '#^/wp/v2/posts/(\d+)#', $route, $matches ) ) {
+			$post_id = (int) $matches[1];
+			if ( get_post_type( $post_id ) === self::POST_TYPE ) {
+				return new WP_Error(
+					'rest_forbidden',
+					__( 'You are not authorized to access this resource.', 'documentate' ),
+					array( 'status' => rest_authorization_required_code() )
+				);
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Filter REST post queries to exclude documents.
+	 *
+	 * @param array           $args    Query arguments.
+	 * @param WP_REST_Request $request Request object.
+	 * @return array Modified query arguments.
+	 */
+	public function filter_rest_post_query( $args, $request ) {
+		if ( $this->user_can_access() ) {
+			return $args;
+		}
+
+		// Ensure our post type is excluded.
+		if ( ! empty( $args['post_type'] ) ) {
+			if ( is_array( $args['post_type'] ) ) {
+				$args['post_type'] = array_diff( $args['post_type'], array( self::POST_TYPE ) );
+			} elseif ( self::POST_TYPE === $args['post_type'] ) {
+				$args['post__in'] = array( 0 );
+			}
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Add documentate_document to the list of protected post types for comment protection.
+	 *
+	 * @param array $post_types Current list of protected post types.
+	 * @return array Modified list including documentate_document.
+	 */
+	public function add_document_to_protected_types( $post_types ) {
+		if ( ! in_array( self::POST_TYPE, $post_types, true ) ) {
+			$post_types[] = self::POST_TYPE;
+		}
+		return $post_types;
+	}
+
+	/**
+	 * Filter whether comments are open for documents based on user access.
+	 *
+	 * @param bool $open    Whether comments are open.
+	 * @param int  $post_id Post ID.
+	 * @return bool False if user cannot access the document, original value otherwise.
+	 */
+	public function filter_comments_open( $open, $post_id ) {
+		if ( get_post_type( $post_id ) !== self::POST_TYPE ) {
+			return $open;
+		}
+
+		if ( ! $this->user_can_access() ) {
+			return false;
+		}
+
+		return $open;
+	}
+
+	/**
+	 * Filter comment queries to exclude document comments for unauthorized users.
+	 *
+	 * @param array|null       $comments Return value. Default null to continue with query.
+	 * @param WP_Comment_Query $query    Comment query object.
+	 * @return array|null Empty array to block, null to continue.
+	 */
+	public function filter_comment_queries( $comments, $query ) {
+		if ( $this->user_can_access() ) {
+			return $comments;
+		}
+
+		// Check if query is for a specific post.
+		$query_vars = $query->query_vars;
+		if ( ! empty( $query_vars['post_id'] ) ) {
+			$post_id = (int) $query_vars['post_id'];
+			if ( get_post_type( $post_id ) === self::POST_TYPE ) {
+				return array();
+			}
+		}
+
+		// For general queries, add filter to exclude document comments.
+		add_filter( 'comments_clauses', array( $this, 'exclude_document_comments_clause' ) );
+
+		return $comments;
+	}
+
+	/**
+	 * Add SQL clause to exclude comments from documents.
+	 *
+	 * @param array $clauses Query clauses.
+	 * @return array Modified clauses.
+	 */
+	public function exclude_document_comments_clause( $clauses ) {
+		// Remove immediately to avoid affecting other queries.
+		remove_filter( 'comments_clauses', array( $this, 'exclude_document_comments_clause' ) );
+
+		global $wpdb;
+
+		// Add JOIN to posts table if not already present.
+		if ( false === strpos( $clauses['join'], "{$wpdb->posts}" ) ) {
+			$clauses['join'] .= " LEFT JOIN {$wpdb->posts} AS dap_posts ON dap_posts.ID = {$wpdb->comments}.comment_post_ID";
+		}
+
+		// Exclude comments from our post type.
+		$clauses['where'] .= $wpdb->prepare(
+			' AND (dap_posts.post_type IS NULL OR dap_posts.post_type != %s)',
+			self::POST_TYPE
+		);
+
+		return $clauses;
+	}
+}
+
+// Instantiate the protection class.
+new Documentate_Document_Access_Protection();

--- a/includes/class-documentate.php
+++ b/includes/class-documentate.php
@@ -131,6 +131,11 @@ class Documentate {
 		require_once plugin_dir_path( __DIR__ ) . 'includes/class-documentate-rest-comment-protection.php';
 
 		/**
+		 * The class responsible for protecting document access from unauthorized users.
+		 */
+		require_once plugin_dir_path( __DIR__ ) . 'includes/class-documentate-document-access-protection.php';
+
+		/**
 		 * The class responsible for defining the MVC.
 		 */
 		// Remove Task MVC models/managers; not needed for Documentate/KB.

--- a/tests/unit/includes/DocumentateDemoDocumentsTest.php
+++ b/tests/unit/includes/DocumentateDemoDocumentsTest.php
@@ -5,10 +5,26 @@
 
 class DocumentateDemoDocumentsTest extends WP_UnitTestCase {
 
+	/**
+	 * Admin user ID for testing.
+	 *
+	 * @var int
+	 */
+	protected $admin_user_id;
+
 	public function set_up(): void {
 		parent::set_up();
 		register_post_type( 'documentate_document', array( 'public' => false ) );
 		register_taxonomy( 'documentate_doc_type', array( 'documentate_document' ) );
+
+		// Create and set admin user (required for document access).
+		$this->admin_user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->admin_user_id );
+	}
+
+	public function tear_down(): void {
+		wp_set_current_user( 0 );
+		parent::tear_down();
 	}
 
 	/**

--- a/tests/unit/includes/DocumentateDocumentAccessProtectionTest.php
+++ b/tests/unit/includes/DocumentateDocumentAccessProtectionTest.php
@@ -1,0 +1,588 @@
+<?php
+/**
+ * Tests for Document Access Protection.
+ *
+ * Ensures that documentate_document posts and their comments are not accessible
+ * to anonymous users or subscribers via web or REST API.
+ *
+ * @package Documentate
+ */
+
+/**
+ * Test class for Documentate_Document_Access_Protection.
+ */
+class DocumentateDocumentAccessProtectionTest extends WP_UnitTestCase {
+
+	/**
+	 * Protection instance.
+	 *
+	 * @var Documentate_Document_Access_Protection
+	 */
+	protected $protection;
+
+	/**
+	 * Administrator user ID.
+	 *
+	 * @var int
+	 */
+	protected $admin_user_id;
+
+	/**
+	 * Editor user ID.
+	 *
+	 * @var int
+	 */
+	protected $editor_user_id;
+
+	/**
+	 * Subscriber user ID.
+	 *
+	 * @var int
+	 */
+	protected $subscriber_user_id;
+
+	/**
+	 * Test document ID.
+	 *
+	 * @var int
+	 */
+	protected $document_id;
+
+	/**
+	 * Test regular post ID.
+	 *
+	 * @var int
+	 */
+	protected $regular_post_id;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		// Ensure CPT is registered.
+		register_post_type(
+			'documentate_document',
+			array(
+				'public'       => false,
+				'show_in_rest' => false,
+			)
+		);
+
+		// Create test users.
+		$this->admin_user_id      = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$this->editor_user_id     = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$this->subscriber_user_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+
+		// Create test document as admin.
+		wp_set_current_user( $this->admin_user_id );
+		$this->document_id = wp_insert_post(
+			array(
+				'post_type'   => 'documentate_document',
+				'post_title'  => 'Test Document',
+				'post_status' => 'publish',
+			)
+		);
+
+		// Create regular post for comparison.
+		$this->regular_post_id = wp_insert_post(
+			array(
+				'post_type'   => 'post',
+				'post_title'  => 'Regular Post',
+				'post_status' => 'publish',
+			)
+		);
+
+		// Create protection instance.
+		$this->protection = new Documentate_Document_Access_Protection();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tear_down(): void {
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	// =========================================================================
+	// USER ACCESS PERMISSION TESTS
+	// =========================================================================
+
+	/**
+	 * Test that anonymous users cannot access documents.
+	 */
+	public function test_anonymous_user_cannot_access() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( $this->protection->user_can_access() );
+	}
+
+	/**
+	 * Test that subscribers cannot access documents.
+	 */
+	public function test_subscriber_cannot_access() {
+		wp_set_current_user( $this->subscriber_user_id );
+		$this->assertFalse( $this->protection->user_can_access() );
+	}
+
+	/**
+	 * Test that editors can access documents.
+	 */
+	public function test_editor_can_access() {
+		wp_set_current_user( $this->editor_user_id );
+		$this->assertTrue( $this->protection->user_can_access() );
+	}
+
+	/**
+	 * Test that administrators can access documents.
+	 */
+	public function test_admin_can_access() {
+		wp_set_current_user( $this->admin_user_id );
+		$this->assertTrue( $this->protection->user_can_access() );
+	}
+
+	// =========================================================================
+	// QUERY FILTERING TESTS
+	// =========================================================================
+
+	/**
+	 * Test that anonymous users cannot query documents directly.
+	 *
+	 * Using post_status => 'any' to test our protection, not just WP's defaults.
+	 */
+	public function test_anonymous_cannot_query_documents() {
+		wp_set_current_user( 0 );
+
+		$query = new WP_Query(
+			array(
+				'post_type'   => 'documentate_document',
+				'post_status' => 'any',
+				'fields'      => 'ids',
+			)
+		);
+
+		$this->assertEmpty( $query->posts, 'Anonymous users should not get any documents from query.' );
+	}
+
+	/**
+	 * Test that subscribers cannot query documents directly.
+	 *
+	 * Using post_status => 'any' to test our protection, not just WP's defaults.
+	 */
+	public function test_subscriber_cannot_query_documents() {
+		wp_set_current_user( $this->subscriber_user_id );
+
+		$query = new WP_Query(
+			array(
+				'post_type'   => 'documentate_document',
+				'post_status' => 'any',
+				'fields'      => 'ids',
+			)
+		);
+
+		$this->assertEmpty( $query->posts, 'Subscribers should not get any documents from query.' );
+	}
+
+	/**
+	 * Test that editors can query documents.
+	 *
+	 * Note: Documents without doc_type are forced to draft by workflow.
+	 * We use post_status => 'any' to test our protection, not WP's default behavior.
+	 */
+	public function test_editor_can_query_documents() {
+		wp_set_current_user( $this->editor_user_id );
+
+		$query = new WP_Query(
+			array(
+				'post_type'      => 'documentate_document',
+				'post_status'    => 'any',
+				'fields'         => 'ids',
+				'posts_per_page' => -1,
+			)
+		);
+
+		$this->assertContains( $this->document_id, $query->posts, 'Editors should be able to query documents.' );
+	}
+
+	/**
+	 * Test that administrators can query documents.
+	 *
+	 * Note: Documents without doc_type are forced to draft by workflow.
+	 * We use post_status => 'any' to test our protection, not WP's default behavior.
+	 */
+	public function test_admin_can_query_documents() {
+		wp_set_current_user( $this->admin_user_id );
+
+		$query = new WP_Query(
+			array(
+				'post_type'      => 'documentate_document',
+				'post_status'    => 'any',
+				'fields'         => 'ids',
+				'posts_per_page' => -1,
+			)
+		);
+
+		$this->assertContains( $this->document_id, $query->posts, 'Admins should be able to query documents.' );
+	}
+
+	/**
+	 * Test that anonymous users querying 'any' post type excludes documents.
+	 */
+	public function test_anonymous_any_query_excludes_documents() {
+		wp_set_current_user( 0 );
+
+		$query = new WP_Query(
+			array(
+				'post_type'      => 'any',
+				'fields'         => 'ids',
+				'posts_per_page' => -1,
+			)
+		);
+
+		$this->assertNotContains(
+			$this->document_id,
+			$query->posts,
+			'Anonymous users querying "any" post type should not get documents.'
+		);
+	}
+
+	/**
+	 * Test that anonymous users can still query regular posts.
+	 */
+	public function test_anonymous_can_query_regular_posts() {
+		wp_set_current_user( 0 );
+
+		$query = new WP_Query(
+			array(
+				'post_type' => 'post',
+				'fields'    => 'ids',
+			)
+		);
+
+		$this->assertContains(
+			$this->regular_post_id,
+			$query->posts,
+			'Anonymous users should still be able to query regular posts.'
+		);
+	}
+
+	// =========================================================================
+	// DIRECT POST ACCESS TESTS
+	// =========================================================================
+
+	/**
+	 * Test that get_post still returns document (needed for internal use).
+	 *
+	 * Note: get_post() bypasses WP_Query so it will return the document.
+	 * The protection happens at template_redirect and REST API level.
+	 */
+	public function test_get_post_returns_document_for_internal_use() {
+		wp_set_current_user( 0 );
+
+		$post = get_post( $this->document_id );
+
+		// get_post() should still work as it's needed internally.
+		// Protection is at query/template level.
+		$this->assertNotNull( $post );
+		$this->assertEquals( $this->document_id, $post->ID );
+	}
+
+	// =========================================================================
+	// COMMENTS PROTECTION TESTS
+	// =========================================================================
+
+	/**
+	 * Test that anonymous users cannot see comments on documents.
+	 */
+	public function test_anonymous_cannot_see_document_comments() {
+		// Create a comment on the document as admin.
+		wp_set_current_user( $this->admin_user_id );
+		$comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID' => $this->document_id,
+				'comment_content' => 'Test comment on document',
+				'user_id'         => $this->admin_user_id,
+			)
+		);
+		$this->assertGreaterThan( 0, $comment_id );
+
+		// Switch to anonymous user.
+		wp_set_current_user( 0 );
+
+		// Query comments for this document.
+		$comments = get_comments(
+			array(
+				'post_id' => $this->document_id,
+			)
+		);
+
+		$this->assertEmpty( $comments, 'Anonymous users should not see comments on documents.' );
+	}
+
+	/**
+	 * Test that subscribers cannot see comments on documents.
+	 */
+	public function test_subscriber_cannot_see_document_comments() {
+		// Create a comment on the document as admin.
+		wp_set_current_user( $this->admin_user_id );
+		$comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID' => $this->document_id,
+				'comment_content' => 'Test comment on document',
+				'user_id'         => $this->admin_user_id,
+			)
+		);
+		$this->assertGreaterThan( 0, $comment_id );
+
+		// Switch to subscriber.
+		wp_set_current_user( $this->subscriber_user_id );
+
+		// Query comments for this document.
+		$comments = get_comments(
+			array(
+				'post_id' => $this->document_id,
+			)
+		);
+
+		$this->assertEmpty( $comments, 'Subscribers should not see comments on documents.' );
+	}
+
+	/**
+	 * Test that editors can see comments on documents.
+	 */
+	public function test_editor_can_see_document_comments() {
+		// Create a comment on the document as admin.
+		wp_set_current_user( $this->admin_user_id );
+		$comment_id = wp_insert_comment(
+			array(
+				'comment_post_ID' => $this->document_id,
+				'comment_content' => 'Test comment on document',
+				'user_id'         => $this->admin_user_id,
+			)
+		);
+		$this->assertGreaterThan( 0, $comment_id );
+
+		// Switch to editor.
+		wp_set_current_user( $this->editor_user_id );
+
+		// Query comments for this document.
+		$comments = get_comments(
+			array(
+				'post_id' => $this->document_id,
+			)
+		);
+
+		$this->assertNotEmpty( $comments, 'Editors should be able to see comments on documents.' );
+		$this->assertEquals( $comment_id, $comments[0]->comment_ID );
+	}
+
+	/**
+	 * Test that comments_open returns false for anonymous users on documents.
+	 */
+	public function test_comments_closed_for_anonymous_on_documents() {
+		wp_set_current_user( 0 );
+
+		$this->assertFalse(
+			$this->protection->filter_comments_open( true, $this->document_id ),
+			'Comments should be closed for anonymous users on documents.'
+		);
+	}
+
+	/**
+	 * Test that comments_open returns false for subscribers on documents.
+	 */
+	public function test_comments_closed_for_subscriber_on_documents() {
+		wp_set_current_user( $this->subscriber_user_id );
+
+		$this->assertFalse(
+			$this->protection->filter_comments_open( true, $this->document_id ),
+			'Comments should be closed for subscribers on documents.'
+		);
+	}
+
+	/**
+	 * Test that comments_open returns original value for editors on documents.
+	 */
+	public function test_comments_open_for_editor_on_documents() {
+		wp_set_current_user( $this->editor_user_id );
+
+		$this->assertTrue(
+			$this->protection->filter_comments_open( true, $this->document_id ),
+			'Comments should be open for editors on documents (if originally open).'
+		);
+	}
+
+	/**
+	 * Test that comments on regular posts are not affected.
+	 */
+	public function test_comments_on_regular_posts_unaffected() {
+		wp_set_current_user( 0 );
+
+		$this->assertTrue(
+			$this->protection->filter_comments_open( true, $this->regular_post_id ),
+			'Comments on regular posts should not be affected by document protection.'
+		);
+	}
+
+	// =========================================================================
+	// PROTECTED POST TYPES FILTER TESTS
+	// =========================================================================
+
+	/**
+	 * Test that documentate_document is added to protected comment post types.
+	 */
+	public function test_document_added_to_protected_comment_types() {
+		$protected_types = $this->protection->add_document_to_protected_types( array() );
+
+		$this->assertContains(
+			'documentate_document',
+			$protected_types,
+			'documentate_document should be in protected post types.'
+		);
+	}
+
+	/**
+	 * Test that existing protected types are preserved.
+	 */
+	public function test_existing_protected_types_preserved() {
+		$existing_types  = array( 'documentate_task', 'some_other_type' );
+		$protected_types = $this->protection->add_document_to_protected_types( $existing_types );
+
+		$this->assertContains( 'documentate_task', $protected_types );
+		$this->assertContains( 'some_other_type', $protected_types );
+		$this->assertContains( 'documentate_document', $protected_types );
+	}
+
+	/**
+	 * Test that duplicates are not added to protected types.
+	 */
+	public function test_no_duplicate_protected_types() {
+		$existing_types  = array( 'documentate_document' );
+		$protected_types = $this->protection->add_document_to_protected_types( $existing_types );
+
+		$count = array_count_values( $protected_types );
+		$this->assertEquals(
+			1,
+			$count['documentate_document'],
+			'documentate_document should not be duplicated.'
+		);
+	}
+
+	// =========================================================================
+	// REST API PROTECTION TESTS
+	// =========================================================================
+
+	/**
+	 * Test that REST API blocks anonymous access to document route.
+	 */
+	public function test_rest_api_blocks_anonymous_document_access() {
+		wp_set_current_user( 0 );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/documentate_document' );
+		$result  = $this->protection->block_rest_access( null, new WP_REST_Server(), $request );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertEquals( 'rest_forbidden', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that REST API blocks subscriber access to document route.
+	 */
+	public function test_rest_api_blocks_subscriber_document_access() {
+		wp_set_current_user( $this->subscriber_user_id );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/documentate_document' );
+		$result  = $this->protection->block_rest_access( null, new WP_REST_Server(), $request );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertEquals( 'rest_forbidden', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that REST API allows editor access to document route.
+	 */
+	public function test_rest_api_allows_editor_document_access() {
+		wp_set_current_user( $this->editor_user_id );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/documentate_document' );
+		$result  = $this->protection->block_rest_access( null, new WP_REST_Server(), $request );
+
+		$this->assertNull( $result, 'Editors should not be blocked from document REST routes.' );
+	}
+
+	/**
+	 * Test that REST API blocks anonymous access to single document by ID.
+	 */
+	public function test_rest_api_blocks_anonymous_single_document_access() {
+		wp_set_current_user( 0 );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $this->document_id );
+		$result  = $this->protection->block_rest_access( null, new WP_REST_Server(), $request );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertEquals( 'rest_forbidden', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that REST API does not block access to regular posts.
+	 */
+	public function test_rest_api_allows_regular_post_access() {
+		wp_set_current_user( 0 );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $this->regular_post_id );
+		$result  = $this->protection->block_rest_access( null, new WP_REST_Server(), $request );
+
+		$this->assertNull( $result, 'Regular posts should not be blocked.' );
+	}
+
+	/**
+	 * Test REST post query filtering excludes documents for anonymous users.
+	 */
+	public function test_rest_post_query_excludes_documents_for_anonymous() {
+		wp_set_current_user( 0 );
+
+		$args = array(
+			'post_type' => 'documentate_document',
+		);
+
+		$filtered_args = $this->protection->filter_rest_post_query( $args, new WP_REST_Request() );
+
+		$this->assertArrayHasKey( 'post__in', $filtered_args );
+		$this->assertEquals( array( 0 ), $filtered_args['post__in'] );
+	}
+
+	/**
+	 * Test REST post query filtering excludes documents from array for anonymous users.
+	 */
+	public function test_rest_post_query_excludes_documents_from_array() {
+		wp_set_current_user( 0 );
+
+		$args = array(
+			'post_type' => array( 'post', 'documentate_document', 'page' ),
+		);
+
+		$filtered_args = $this->protection->filter_rest_post_query( $args, new WP_REST_Request() );
+
+		$this->assertIsArray( $filtered_args['post_type'] );
+		$this->assertNotContains( 'documentate_document', $filtered_args['post_type'] );
+		$this->assertContains( 'post', $filtered_args['post_type'] );
+		$this->assertContains( 'page', $filtered_args['post_type'] );
+	}
+
+	/**
+	 * Test REST post query filtering allows documents for editors.
+	 */
+	public function test_rest_post_query_allows_documents_for_editor() {
+		wp_set_current_user( $this->editor_user_id );
+
+		$args = array(
+			'post_type' => 'documentate_document',
+		);
+
+		$filtered_args = $this->protection->filter_rest_post_query( $args, new WP_REST_Request() );
+
+		$this->assertEquals( 'documentate_document', $filtered_args['post_type'] );
+		$this->assertArrayNotHasKey( 'post__in', $filtered_args );
+	}
+}


### PR DESCRIPTION
This pull request introduces a comprehensive access protection system for the `documentate_document` custom post type, ensuring that only authorized users (those with the `edit_posts` capability) can view documents and their comments, both via the frontend and the REST API. It also updates the unit tests to properly handle user roles for document access.

**Access Protection Implementation:**

* Added a new class `Documentate_Document_Access_Protection` in `includes/class-documentate-document-access-protection.php` that:
  - Blocks unauthorized frontend and REST API access to documents.
  - Filters queries to exclude documents for unauthorized users.
  - Protects document comments from unauthorized access and display.
* Registered the new protection class in the plugin’s dependency loader (`includes/class-documentate.php`).

**Testing Improvements:**

* Updated `DocumentateDemoDocumentsTest` to create and use an admin user for tests, ensuring proper access to documents and cleaning up user state after each test.