### PR TITLE
Notify coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,16 +158,51 @@ jobs:
       - name: Run code linting (PHPCS)
         run: ./vendor/bin/phpcs --standard=.phpcs.xml.dist -q .
 
-      # === START ENVIRONMENT ===
-      - name: Start wp-env
-        run: npx wp-env start
+      # === START ENVIRONMENT (with Xdebug for coverage) ===
+      - name: Start wp-env with coverage
+        run: npx wp-env start --xdebug=coverage
 
       - name: Run plugin check
         run: make check-plugin
 
-      # === TESTS ===
-      - name: Run unit tests
-        run: make test
+      # === TESTS WITH COVERAGE ===
+      - name: Run unit tests with coverage
+        run: make test-coverage
+
+      - name: Extract coverage percentage
+        id: coverage
+        if: always()
+        run: |
+          if [ -f artifacts/coverage/coverage.txt ]; then
+            COVERAGE=$(grep -oP 'Lines:\s+\K[\d.]+(?=%)' artifacts/coverage/coverage.txt | head -1 || echo "0")
+            echo "percentage=${COVERAGE}" >> $GITHUB_OUTPUT
+            # Determine badge color based on coverage
+            if (( $(echo "$COVERAGE >= 80" | bc -l) )); then
+              echo "color=brightgreen" >> $GITHUB_OUTPUT
+            elif (( $(echo "$COVERAGE >= 60" | bc -l) )); then
+              echo "color=yellow" >> $GITHUB_OUTPUT
+            elif (( $(echo "$COVERAGE >= 40" | bc -l) )); then
+              echo "color=orange" >> $GITHUB_OUTPUT
+            else
+              echo "color=red" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "percentage=0" >> $GITHUB_OUTPUT
+            echo "color=red" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Add coverage to job summary
+        if: always()
+        run: |
+          echo "## 📊 Code Coverage" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ -f artifacts/coverage/coverage.txt ]; then
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            grep -E "^\s*(Lines|Functions|Classes|Methods):" artifacts/coverage/coverage.txt >> $GITHUB_STEP_SUMMARY || echo "No coverage data"
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          else
+            echo "⚠️ Coverage report not generated" >> $GITHUB_STEP_SUMMARY
+          fi
 
       - name: Run E2E tests
         run: make test-e2e
@@ -176,6 +211,14 @@ jobs:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
 
       # === ARTIFACTS ===
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: artifacts/coverage/html/
+          retention-days: 30
+
       - name: Upload E2E artifacts on failure
         uses: actions/upload-artifact@v4
         if: failure()
@@ -183,3 +226,15 @@ jobs:
           name: playwright-report
           path: artifacts/
           retention-days: 7
+
+      # === UPDATE COVERAGE BADGE (only on main) ===
+      - name: Update coverage badge
+        if: github.ref == 'refs/heads/main' && always()
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: ${{ vars.COVERAGE_GIST_ID }}
+          filename: coverage.json
+          label: coverage
+          message: ${{ steps.coverage.outputs.percentage }}%
+          color: ${{ steps.coverage.outputs.color }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Documentate
 
+![CI](https://img.shields.io/github/actions/workflow/status/erseco/wp-documentate/ci.yml?label=CI)
+![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/erseco/COVERAGE_GIST_ID/raw/coverage.json)
 ![WordPress Version](https://img.shields.io/badge/WordPress-6.1-blue)
 ![Language](https://img.shields.io/badge/Language-PHP-orange)
 ![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)


### PR DESCRIPTION
This pull request enhances the CI workflow to include code coverage reporting and badge updates, making it easier to track and visualize test coverage directly from the repository. The main improvements involve generating coverage reports, extracting and displaying coverage metrics, uploading artifacts, and updating a dynamic coverage badge. Additionally, the `README.md` now displays the CI and coverage badges for better project visibility.

**CI workflow improvements:**

* Added steps to start the environment with Xdebug for coverage, run tests with coverage, extract coverage percentage, and display coverage metrics in the job summary. (`.github/workflows/ci.yml`)
* Uploaded the coverage report as a workflow artifact for easier access and historical retention. (`.github/workflows/ci.yml`)

**Coverage badge automation:**

* Automatically updates a dynamic coverage badge in a GitHub Gist when changes are pushed to the `main` branch, reflecting the latest coverage percentage and color. (`.github/workflows/ci.yml`)

**Documentation and visibility:**

* Added CI and coverage badges to the top of the `README.md` to provide instant feedback on build status and code coverage. (`README.md`)