### PR TITLE
Improved codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,14 +227,10 @@ jobs:
           path: artifacts/
           retention-days: 7
 
-      # === UPDATE COVERAGE BADGE (only on main) ===
-      - name: Update coverage badge
-        if: github.ref == 'refs/heads/main' && always()
-        uses: schneegans/dynamic-badges-action@v1.7.0
+      # === UPLOAD COVERAGE TO CODECOV ===
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
         with:
-          auth: ${{ secrets.GIST_TOKEN }}
-          gistID: ${{ vars.COVERAGE_GIST_ID }}
-          filename: coverage.json
-          label: coverage
-          message: ${{ steps.coverage.outputs.percentage }}%
-          color: ${{ steps.coverage.outputs.color }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: artifacts/coverage/clover.xml
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Documentate
 
 ![CI](https://img.shields.io/github/actions/workflow/status/erseco/wp-documentate/ci.yml?label=CI)
-![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/erseco/COVERAGE_GIST_ID/raw/coverage.json)
+[![codecov](https://codecov.io/gh/erseco/wp-documentate/graph/badge.svg)](https://codecov.io/gh/erseco/wp-documentate)
 ![WordPress Version](https://img.shields.io/badge/WordPress-6.1-blue)
 ![Language](https://img.shields.io/badge/Language-PHP-orange)
 ![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)


### PR DESCRIPTION
This pull request updates the project's code coverage reporting workflow and documentation. The main change is switching from a custom coverage badge using a GitHub Gist to using Codecov for coverage reporting and badge generation.

**Continuous Integration and Coverage Reporting:**

* Replaced the step that updated a coverage badge via GitHub Gist with a step that uploads coverage results to Codecov in the `.github/workflows/ci.yml` workflow file. This uses the official Codecov GitHub Action and uploads the `clover.xml` coverage report.

**Documentation and Badges:**

* Updated the coverage badge in `README.md` to use Codecov's badge and link, replacing the previous badge that referenced a GitHub Gist.