### PR TITLE
rename to ateedcacion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Documentate
 
-![CI](https://img.shields.io/github/actions/workflow/status/erseco/wp-documentate/ci.yml?label=CI)
-[![codecov](https://codecov.io/gh/erseco/wp-documentate/graph/badge.svg)](https://codecov.io/gh/erseco/wp-documentate)
+![CI](https://img.shields.io/github/actions/workflow/status/ateeducacion/wp-documentate/ci.yml?label=CI)
+[![codecov](https://codecov.io/gh/ateeducacion/wp-documentate/graph/badge.svg)](https://codecov.io/gh/ateeducacion/wp-documentate)
 ![WordPress Version](https://img.shields.io/badge/WordPress-6.1-blue)
 ![Language](https://img.shields.io/badge/Language-PHP-orange)
 ![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)
-![Downloads](https://img.shields.io/github/downloads/erseco/wp-documentate/total)
-![Last Commit](https://img.shields.io/github/last-commit/erseco/wp-documentate)
-![Open Issues](https://img.shields.io/github/issues/erseco/wp-documentate)
+![Downloads](https://img.shields.io/github/downloads/ateeducacion/wp-documentate/total)
+![Last Commit](https://img.shields.io/github/last-commit/ateeducacion/wp-documentate)
+![Open Issues](https://img.shields.io/github/issues/ateeducacion/wp-documentate)
 
 **Documentate** es un plugin de WordPress para la generación de resoluciones oficiales con estructura de secciones y exportación a DOCX.
 
@@ -15,7 +15,7 @@
 
 Try Documentate instantly in your browser using WordPress Playground! The demo includes sample data to help you explore the features. Note that all changes will be lost when you close the browser window, as everything runs locally in your browser.
 
-[<kbd> <br> Preview in WordPress Playground <br> </kbd>](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/erseco/wp-documentate/refs/heads/main/blueprint.json)
+[<kbd> <br> Preview in WordPress Playground <br> </kbd>](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/ateeducacion/wp-documentate/refs/heads/main/blueprint.json)
 
 
 ### Key Features
@@ -28,7 +28,7 @@ Try Documentate instantly in your browser using WordPress Playground! The demo i
 
 ## Installation
 
-1. **Download the latest release** from the [GitHub Releases page](https://github.com/erseco/wp-documentate/releases).
+1. **Download the latest release** from the [GitHub Releases page](https://github.com/ateeducacion/wp-documentate/releases).
 2. Upload the downloaded ZIP file to your WordPress site via **Plugins > Add New > Upload Plugin**.
 3. Activate the plugin through the 'Plugins' menu in WordPress.
 4. Configure the plugin under 'Settings' by providing the necessary Nextcloud API details.

--- a/blueprint.json
+++ b/blueprint.json
@@ -28,7 +28,7 @@
       "step": "installPlugin",
       "pluginData": {
         "resource": "url",
-        "url": "https://github.com/erseco/wp-documentate/archive/refs/heads/main.zip"
+        "url": "https://github.com/ateeducacion/wp-documentate/archive/refs/heads/main.zip"
       },
       "options": {
         "activate": true

--- a/documentate.php
+++ b/documentate.php
@@ -3,12 +3,12 @@
  *
  * Documentate – Document Generator.
  *
- * @link              https://github.com/erseco/wp-documentate
+ * @link              https://github.com/ateeducacion/wp-documentate
  * @package           Documentate
  *
  * @wordpress-plugin
  * Plugin Name:       Documentate – Document Generator
- * Plugin URI:        https://github.com/erseco/wp-documentate
+ * Plugin URI:        https://github.com/ateeducacion/wp-documentate
  * Description:       Digital document generator. Defines a custom post type for structured documents with customizable sections and allows exporting to Word (DOCX) and PDF.
  * Version:           0.0.0
  * Author:            Área de Tecnología Educativa

--- a/includes/custom-post-types/class-documentate-documents.php
+++ b/includes/custom-post-types/class-documentate-documents.php
@@ -6,7 +6,7 @@
  * sections stored as post meta and a document type taxonomy that defines
  * the available template fields.
  *
- * @link       https://github.com/erseco/wp-documentate
+ * @link       https://github.com/ateeducacion/wp-documentate
  * @since      0.1.0
  *
  * @package    documentate

--- a/languages/documentate-es_ES.po
+++ b/languages/documentate-es_ES.po
@@ -19,8 +19,8 @@ msgid "Documentate – Document Generator"
 msgstr "Documentate – Generador de Documentos"
 
 #. Plugin URI of the plugin
-msgid "https://github.com/erseco/wp-documentate"
-msgstr "https://github.com/erseco/wp-documentate"
+msgid "https://github.com/ateeducacion/wp-documentate"
+msgstr "https://github.com/ateeducacion/wp-documentate"
 
 #. Description of the plugin
 msgid "Digital document generator. Defines a custom post type for structured documents with customizable sections and allows exporting to Word (DOCX) and PDF."

--- a/languages/documentate.pot
+++ b/languages/documentate.pot
@@ -18,7 +18,7 @@ msgid "Documentate – Document Generator"
 msgstr ""
 
 #. Plugin URI of the plugin
-msgid "https://github.com/erseco/wp-documentate"
+msgid "https://github.com/ateeducacion/wp-documentate"
 msgstr ""
 
 #. Description of the plugin

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,13 +2,13 @@ site_name: Documentate
 site_description: A WordPress plugin that provides a Kanban board interface with a unique priority system for managing tasks
 
 site_author: ATE
-repo_url: https://github.com/erseco/wp-documentate
+repo_url: https://github.com/ateeducacion/wp-documentate
 edit_uri: edit/main/docs/
 
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/erseco/wp-documentate
+      link: https://github.com/ateeducacion/wp-documentate
 
 theme:
   name: material

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Documentate – Generador de resoluciones ===
-Contributors: erseco
+Contributors: ateeducacion
 Tags: ate, tasks, board, kanban
 Requires at least: 6.1
 Tested up to: 6.8


### PR DESCRIPTION
This pull request updates all references to the GitHub repository from `erseco/wp-documentate` to `ateeducacion/wp-documentate` throughout the project. This change ensures that badges, links, installation instructions, documentation, and plugin metadata now point to the new repository location.

Repository reference updates:

* `README.md`, `blueprint.json`, `documentate.php`, `includes/custom-post-types/class-documentate-documents.php`, `languages/documentate-es_ES.po`, `languages/documentate.pot`, `mkdocs.yml`, `readme.txt`: All URLs, badges, and contributor names referencing the old repository (`erseco/wp-documentate`) have been updated to the new repository (`ateeducacion/wp-documentate`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R18) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R31) [[3]](diffhunk://#diff-e668b96a5d707415a7de0d144069d796b1a7b07f16f0ec5c484a94ee434c7c6eL31-R31) [[4]](diffhunk://#diff-289269a08e31c2b9571b7de57e62378c66fb800255b5b00f4a6b0dccf1f2f3b4L6-R11) [[5]](diffhunk://#diff-51f1d98b203139ef4c651e89be6c72f6e8d4aa47ed7326bd7868cd59d61e75c8L9-R9) [[6]](diffhunk://#diff-d056b277343ed40921b00d513869000584ad307a99a409b4d37fb5f201bfa84aL22-R23) [[7]](diffhunk://#diff-4f59005bb384b683a2e1543961376d1d18ae3a7a91f31a67f29ce36c3cc95ba9L21-R21) [[8]](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2L5-R11) [[9]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L2-R2)