### PR TITLE
Added demo users

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -9,8 +9,9 @@
     "mappings": {
         "wp-content/plugins/documentate": "./"
     },
-    "plugins":  [ 
+    "plugins":  [
         "https://downloads.wordpress.org/plugins/tinymce-advanced.zip",
-        "https://downloads.wordpress.org/plugins/sql-buddy.zip"
+        "https://downloads.wordpress.org/plugins/sql-buddy.zip",
+        "https://downloads.wordpress.org/plugins/user-switching.zip"
     ]
 }

--- a/blueprint.json
+++ b/blueprint.json
@@ -14,15 +14,25 @@
     },
     {
       "step": "runPHP",
-      "code": "<?php require_once('/wordpress/wp-load.php'); wp_insert_user(array('user_login' => 'test_user_1', 'user_email' => 'test1@example.com', 'user_pass' => wp_generate_password(), 'role' => 'editor')); ?>"
+      "code": "<?php require_once('/wordpress/wp-load.php'); wp_insert_user(array('user_login' => 'editor1', 'user_email' => 'editor1@example.com', 'user_pass' => 'password', 'role' => 'editor', 'display_name' => 'María García', 'first_name' => 'María', 'last_name' => 'García')); ?>"
     },
     {
       "step": "runPHP",
-      "code": "<?php require_once('/wordpress/wp-load.php'); wp_insert_user(array('user_login' => 'test_user_2', 'user_email' => 'test2@example.com', 'user_pass' => wp_generate_password(), 'role' => 'editor')); ?>"
+      "code": "<?php require_once('/wordpress/wp-load.php'); wp_insert_user(array('user_login' => 'author1', 'user_email' => 'author1@example.com', 'user_pass' => 'password', 'role' => 'author', 'display_name' => 'Carlos López', 'first_name' => 'Carlos', 'last_name' => 'López')); ?>"
     },
     {
       "step": "runPHP",
-      "code": "<?php require_once('/wordpress/wp-load.php'); wp_insert_post(array( 'post_title' => 'Created by a Blueprint', 'post_content' => '<!-- wp:paragraph --><p>How do you update the meta fields?</p><!-- /wp:paragraph --><!-- wp:list --><ol><!-- wp:list-item --><li>Open the <strong>Settings</strong> sidebar by clicking the window icon next to the blue <strong>Update</strong> button.</li><!-- /wp:list-item --><!-- wp:list-item --><li>Click the <strong>Meta Block Sidebar</strong> menu (below the <strong>Summary</strong> menu).</li><!-- /wp:list-item --><!-- wp:list-item --><li>Type the <strong>Team name</strong> and the <strong>date</strong> the person joined the company in the respective fields.</li><!-- /wp:list-item --><!-- wp:list-item --><li>Click the blue <strong>Update</strong> button.</li><!-- /wp:list-item --></ol><!-- /wp:list -->','post_status' => 'publish' ));"
+      "code": "<?php require_once('/wordpress/wp-load.php'); wp_insert_user(array('user_login' => 'subscriber1', 'user_email' => 'subscriber1@example.com', 'user_pass' => 'password', 'role' => 'subscriber', 'display_name' => 'Ana Martínez', 'first_name' => 'Ana', 'last_name' => 'Martínez')); ?>"
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "user-switching"
+      },
+      "options": {
+        "activate": true
+      }
     },
     {
       "step": "installPlugin",

--- a/includes/class-documentate-demo-data.php
+++ b/includes/class-documentate-demo-data.php
@@ -35,6 +35,8 @@ class Documentate_Demo_Data {
 		self::$plugin_dir = plugin_dir_path( $plugin_file );
 
 		add_action( 'init', array( __CLASS__, 'maybe_seed_default_doc_types' ), 40 );
+		add_action( 'init', array( __CLASS__, 'maybe_seed_demo_categories' ), 45 );
+		add_action( 'init', array( __CLASS__, 'maybe_seed_demo_users' ), 50 );
 		add_action( 'init', array( __CLASS__, 'maybe_seed_demo_documents' ), 60 );
 	}
 
@@ -480,7 +482,217 @@ class Documentate_Demo_Data {
 			}
 		}
 
+		self::assign_demo_document_metadata();
+
 		delete_option( 'documentate_seed_demo_documents' );
+	}
+
+	/**
+	 * Seed a hierarchical category structure for scope filtering demo.
+	 *
+	 * @return void
+	 */
+	public static function maybe_seed_demo_categories() {
+		$should_seed = (bool) get_option( 'documentate_seed_demo_documents', false );
+		if ( ! $should_seed ) {
+			return;
+		}
+
+		if ( term_exists( 'Organización', 'category' ) ) {
+			return;
+		}
+
+		$tree = array(
+			'Organización' => array(
+				'Dirección General'                => array(
+					'Secretaría General' => array(),
+					'Gabinete'           => array(),
+				),
+				'Subdirección de Administración'   => array(
+					'Departamento de Personal'     => array(),
+					'Departamento de Contabilidad' => array(),
+				),
+				'Subdirección Técnica'             => array(
+					'Departamento de Proyectos' => array(),
+					'Departamento de Sistemas'  => array(),
+				),
+			),
+		);
+
+		self::create_category_tree( $tree, 0 );
+	}
+
+	/**
+	 * Recursively create categories from a nested array.
+	 *
+	 * @param array $tree     Associative array of name => children.
+	 * @param int   $parent_id Parent term ID (0 for top-level).
+	 * @return void
+	 */
+	private static function create_category_tree( $tree, $parent_id = 0 ) {
+		foreach ( $tree as $name => $children ) {
+			$result = wp_insert_term(
+				$name,
+				'category',
+				array( 'parent' => $parent_id )
+			);
+
+			if ( is_wp_error( $result ) ) {
+				continue;
+			}
+
+			$term_id = intval( $result['term_id'] );
+
+			if ( ! empty( $children ) ) {
+				self::create_category_tree( $children, $term_id );
+			}
+		}
+	}
+
+	/**
+	 * Seed demo users with scope category assignments.
+	 *
+	 * @return void
+	 */
+	public static function maybe_seed_demo_users() {
+		$should_seed = (bool) get_option( 'documentate_seed_demo_documents', false );
+		if ( ! $should_seed ) {
+			return;
+		}
+
+		$users = array(
+			array(
+				'user_login'   => 'editor1',
+				'user_email'   => 'editor1@example.com',
+				'user_pass'    => 'password',
+				'role'         => 'editor',
+				'display_name' => 'María García',
+				'first_name'   => 'María',
+				'last_name'    => 'García',
+				'scope'        => 'Subdirección de Administración',
+			),
+			array(
+				'user_login'   => 'author1',
+				'user_email'   => 'author1@example.com',
+				'user_pass'    => 'password',
+				'role'         => 'author',
+				'display_name' => 'Carlos López',
+				'first_name'   => 'Carlos',
+				'last_name'    => 'López',
+				'scope'        => 'Departamento de Proyectos',
+			),
+			array(
+				'user_login'   => 'subscriber1',
+				'user_email'   => 'subscriber1@example.com',
+				'user_pass'    => 'password',
+				'role'         => 'subscriber',
+				'display_name' => 'Ana Martínez',
+				'first_name'   => 'Ana',
+				'last_name'    => 'Martínez',
+				'scope'        => 'Departamento de Personal',
+			),
+		);
+
+		foreach ( $users as $user_data ) {
+			$scope_name = $user_data['scope'];
+			unset( $user_data['scope'] );
+
+			// Skip if user already exists.
+			if ( username_exists( $user_data['user_login'] ) ) {
+				continue;
+			}
+
+			$user_id = wp_insert_user( $user_data );
+			if ( is_wp_error( $user_id ) ) {
+				continue;
+			}
+
+			// Assign scope category.
+			$scope_term = get_term_by( 'name', $scope_name, 'category' );
+			if ( $scope_term instanceof WP_Term ) {
+				update_user_meta( $user_id, Documentate_User_Scope::META_KEY, $scope_term->term_id );
+			}
+		}
+	}
+
+	/**
+	 * Assign categories and authors to demo documents for scope filtering.
+	 *
+	 * @return void
+	 */
+	private static function assign_demo_document_metadata() {
+		// Get the root "Organización" term.
+		$root = get_term_by( 'name', 'Organización', 'category' );
+		if ( ! $root instanceof WP_Term ) {
+			return;
+		}
+
+		// Get all descendant categories (excluding root and Uncategorized).
+		$all_cats = get_terms(
+			array(
+				'taxonomy'   => 'category',
+				'child_of'   => $root->term_id,
+				'hide_empty' => false,
+				'fields'     => 'ids',
+			)
+		);
+
+		if ( is_wp_error( $all_cats ) || empty( $all_cats ) ) {
+			return;
+		}
+
+		// Get all demo documents.
+		$demo_docs = get_posts(
+			array(
+				'post_type'      => 'documentate_document',
+				'post_status'    => 'any',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'meta_query'     => array(
+					'relation' => 'OR',
+					array(
+						'key'     => '_documentate_demo_key',
+						'compare' => 'EXISTS',
+					),
+					array(
+						'key'     => '_documentate_demo_type_id',
+						'compare' => 'EXISTS',
+					),
+				),
+			)
+		);
+
+		if ( empty( $demo_docs ) ) {
+			return;
+		}
+
+		// Build list of authors to round-robin: admin + editor1 + author1.
+		$author_ids   = array( get_current_user_id() );
+		$editor_user  = get_user_by( 'login', 'editor1' );
+		$author_user  = get_user_by( 'login', 'author1' );
+		if ( $editor_user ) {
+			$author_ids[] = $editor_user->ID;
+		}
+		if ( $author_user ) {
+			$author_ids[] = $author_user->ID;
+		}
+
+		$cat_count    = count( $all_cats );
+		$author_count = count( $author_ids );
+
+		foreach ( $demo_docs as $index => $post_id ) {
+			// Round-robin category assignment.
+			$cat_id = $all_cats[ $index % $cat_count ];
+			wp_set_post_terms( $post_id, array( $cat_id ), 'category', false );
+
+			// Round-robin author assignment.
+			wp_update_post(
+				array(
+					'ID'          => $post_id,
+					'post_author' => $author_ids[ $index % $author_count ],
+				)
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
This pull request introduces improvements to the demo data seeding process for the plugin, focusing on better user, category, and document setup for scope filtering and demonstration purposes. The most significant updates include the creation of a hierarchical category structure, seeding demo users with assigned scopes, and assigning categories and authors to demo documents. Additionally, the changes ensure the necessary plugins are installed and activated for user switching functionality.

**Demo data seeding enhancements:**

* Added hierarchical category structure under `Organización` to support scope filtering in demo environments, using a recursive method to create nested categories.
* Implemented demo user seeding with assigned scope categories, including three users (`editor1`, `author1`, `subscriber1`) each mapped to a specific department/category.
* Assigned categories and authors to demo documents in a round-robin fashion, ensuring each document is linked to a category and author for better demonstration of scope filtering.

**Plugin and environment setup:**

* Added the `user-switching` plugin to `.wp-env.json` and ensured its installation and activation in the blueprint, enabling easy switching between demo users for testing purposes. [[1]](diffhunk://#diff-9fd21b09a0144355cfd001e3952767df08b2e04241994470aa1d627f797b171eL14-R15) [[2]](diffhunk://#diff-e668b96a5d707415a7de0d144069d796b1a7b07f16f0ec5c484a94ee434c7c6eL17-R35)

**Initialization improvements:**

* Registered new initialization hooks for seeding categories and users, ensuring these steps are executed during the demo data setup process.