### PR TITLE
Fix: Set static OpenTBS locale property for Spanish dates

### DIFF
--- a/includes/class-documentate-opentbs.php
+++ b/includes/class-documentate-opentbs.php
@@ -16,6 +16,13 @@ use Documentate\OpenTBS\OpenTBS_HTML_Parser;
  */
 class Documentate_OpenTBS {
 
+	/**
+	 * Locale to be used for date formatting in OpenTBS.
+	 *
+	 * @var string
+	 */
+	public static $tbs_locale = 'es_ES';
+
 
 
 	/**
@@ -267,9 +274,10 @@ class Documentate_OpenTBS {
 		}
 		try {
 			// Set locale for TBS date formatting (month/day names in local language).
-			$wp_locale = get_locale();
+
 			$old_locale = setlocale( LC_TIME, 0 );
-			setlocale( LC_TIME, $wp_locale . '.UTF-8', $wp_locale . '.utf8', $wp_locale, 0 );
+			$tbs_locale = self::$tbs_locale;
+			setlocale( LC_TIME, $tbs_locale . '.UTF-8', $tbs_locale . '.utf8', $tbs_locale, substr( $tbs_locale, 0, 2 ), 0 );
 
 			$tbs_engine = new clsTinyButStrong();
 			$tbs_engine->Plugin( TBS_INSTALL, OPENTBS_PLUGIN );


### PR DESCRIPTION
Added a static property \`$tbs_locale\` to \`Documentate_OpenTBS\` with a default of \`'es_ES'\`. Replaced the reliance on \`get_locale()\` (which defaults to the WordPress language) in \`render_template_to_file\` with this static property to enforce date formatting in Spanish for all generated documents. This change ensures that formatting changes apply only to the intended file, resolving the previous issue where the code formatter affected multiple files unnecessarily.

This meets the requirement:
> A la hora de pintar las fechas, siempre tienes que ponerlas en español, es decir, que salgan los nombre de los meses en los documentos opentbs en español, y los dias de la semna tambine, si por lo que sea se especifica formato largo

---
*PR created automatically by Jules for task [13392315742750427899](https://jules.google.com/task/13392315742750427899) started by @erseco*