### PR TITLE
chore(env): add wp-mail-logging to wp-env and blueprint

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -12,6 +12,7 @@
     "plugins":  [
         "https://downloads.wordpress.org/plugins/tinymce-advanced.zip",
         "https://downloads.wordpress.org/plugins/sql-buddy.zip",
-        "https://downloads.wordpress.org/plugins/user-switching.zip"
+        "https://downloads.wordpress.org/plugins/user-switching.zip",
+        "https://downloads.wordpress.org/plugin/wp-mail-logging.zip"
     ]
 }

--- a/blueprint.json
+++ b/blueprint.json
@@ -37,6 +37,16 @@
     {
       "step": "installPlugin",
       "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "wp-mail-logging"
+      },
+      "options": {
+        "activate": true
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
         "resource": "url",
         "url": "https://github.com/ateeducacion/wp-documentate/archive/refs/heads/main.zip"
       },


### PR DESCRIPTION
## Summary
- Adds `wp-mail-logging` to `.wp-env.json` so it's available in the local Docker stack.
- Adds an `installPlugin` step for `wp-mail-logging` in `blueprint.json` so the Playground demo also installs and activates it.

Useful for inspecting outgoing emails when working with the new document state notification flow (#169).

## Test plan
- [x] `make up` y verificar que `wp-mail-logging` aparece activo en `wp-admin/plugins.php`.
- [x] Cargar el blueprint en Playground y comprobar que el plugin queda instalado y activo.
- [x] Disparar una notificación de cambio de estado y verificar que el log de correos la registra.