### PR TITLE
chore(deps): cap @wordpress/scripts & e2e-test-utils to keep E2E green

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,4 +29,15 @@ updates:
       prefix: "chore"
       include: "scope"
     open-pull-requests-limit: 5
+    # These two packages must stay below the versions where @wordpress switched
+    # their package "exports" to TypeScript source (./src/index.ts), which the
+    # Playwright runner cannot load under node_modules and breaks the E2E job:
+    #   @wordpress/e2e-test-utils-playwright >= 1.47.0
+    #   @wordpress/scripts >= 32.3.0 (depends on e2e-test-utils >= 1.47.0)
+    # Remove these ignores once upstream ships a compiled (CJS) entry point again.
+    ignore:
+      - dependency-name: "@wordpress/e2e-test-utils-playwright"
+        versions: [">=1.47.0"]
+      - dependency-name: "@wordpress/scripts"
+        versions: [">=32.3.0"]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,9 @@
     "": {
       "hasInstallScript": true,
       "devDependencies": {
-        "@wordpress/e2e-test-utils-playwright": "^1.46.0",
+        "@wordpress/e2e-test-utils-playwright": "~1.46.0",
         "@wordpress/env": "^11.8.0",
-        "@wordpress/scripts": "^32.2.0",
+        "@wordpress/scripts": "~32.2.0",
         "zetajs": "^1.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "devDependencies": {
-    "@wordpress/e2e-test-utils-playwright": "^1.46.0",
+    "@wordpress/e2e-test-utils-playwright": "~1.46.0",
     "@wordpress/env": "^11.8.0",
-    "@wordpress/scripts": "^32.2.0",
+    "@wordpress/scripts": "~32.2.0",
     "zetajs": "^1.0.0"
   },
   "scripts": {


### PR DESCRIPTION
## Why the Dependabot PRs fail

Both failing PRs hit the same error in the E2E job:

```
Error: Stripping types is currently unsupported for files under node_modules,
for ".../@wordpress/e2e-test-utils-playwright/src/index.ts"
    at .../@wordpress/scripts/config/playwright/global-setup.js:9
```

In **`@wordpress/e2e-test-utils-playwright` 1.47.0** the package `exports` changed from compiled CJS (`./build/index.cjs`) to **TypeScript source** (`./src/index.ts`). `wp-scripts test-playwright` loads it through Node, which refuses to strip types for files under `node_modules`, so it dies in `global-setup.js`.

- **#182** (`e2e-test-utils-playwright` 1.46.0 → 1.48.0) hits it directly.
- **#184** (`@wordpress/scripts` 32.2.0 → 32.4.0) hits it indirectly: `@wordpress/scripts` ≥ 32.3.0 depends on `e2e-test-utils-playwright` ≥ 1.47.0 and pulls the broken version in (nested), invoked from its Playwright `global-setup.js`.

There is **no fixed upstream release** yet — the latest stable `e2e-test-utils-playwright` (1.48.0) still exports `./src/index.ts`. So the only option is to hold these two packages back.

## What this PR does

- Tightens the two ranges to `~` (`~1.46.0`, `~32.2.0`) so `npm update` / `make update` can't resolve into the broken range. **Installed versions are unchanged** (32.2.0 / 1.46.0 — same as current `main`, which is green).
- Adds **Dependabot `ignore`** rules (`>=1.47.0`, `>=32.3.0`) so it stops opening PRs that fail E2E.

After merge, Dependabot will auto-close **#182** and **#184** on its next run (they target ignored versions); they can also be closed manually now.

> `@wordpress/env` and `zetajs` are left free — they are unaffected.

Revert this once upstream ships a compiled entry point again.

## Validation
- Resolved tree: `npm ls @wordpress/e2e-test-utils-playwright` → single `1.46.0`, `@wordpress/scripts@32.2.0` deduped to it (no nested ≥1.47).
- Installed versions identical to the green `main`; E2E confirmed via CI on this PR.