### PR TITLE
Fix scoped document admin list counts and filters

### DIFF
--- a/includes/class-documentate-scope-filter.php
+++ b/includes/class-documentate-scope-filter.php
@@ -8,6 +8,10 @@
  * `documentate_scope_term_id`) including all descendant terms. Admins see all
  * documents.
  *
+ * The same visibility rules are reused to recalculate the admin list "views"
+ * counters (All, Mine, Published, Drafts, Pending, ...) so the counters always
+ * match the rows the list table actually shows.
+ *
  * @package    Documentate
  * @subpackage Documentate/includes
  */
@@ -17,7 +21,8 @@ defined('ABSPATH') || exit();
 /**
  * Class Documentate_Scope_Filter
  *
- * Hooks into pre_get_posts to restrict visible documents by user scope.
+ * Hooks into pre_get_posts to restrict visible documents by user scope and into
+ * views_edit-documentate_document to keep the view counters consistent.
  */
 class Documentate_Scope_Filter {
 	/**
@@ -42,10 +47,55 @@ class Documentate_Scope_Filter {
 	const SCOPE_META_KEY = 'documentate_scope_term_id';
 
 	/**
+	 * Statuses shown in the default "All"/"Mine" admin list views.
+	 *
+	 * Mirrors the default post_status set applied to the main list query in
+	 * Documentate_Documents::apply_admin_filters() (archived and trash are
+	 * intentionally excluded; they have their own views).
+	 *
+	 * @var string[]
+	 */
+	const ALL_LIST_STATUSES = array('publish', 'future', 'draft', 'pending', 'private');
+
+	/**
 	 * Register hooks.
 	 */
 	public function __construct() {
 		add_action('pre_get_posts', array($this, 'filter_documents_by_scope'));
+		// Recalculate the admin list view counters using the same scope rules.
+		// Priority 20 so it runs after add_archived_view() has added its link.
+		add_filter('views_edit-' . self::POST_TYPE, array($this, 'filter_view_counts'), 20);
+	}
+
+	/**
+	 * Resolve the scope term IDs that constrain the current user's documents.
+	 *
+	 * @return int[]|null Array of term IDs (scope term plus descendants) the user
+	 *                    is restricted to; an empty array when the user is
+	 *                    restricted but has no scope assigned (sees nothing); or
+	 *                    null when the user is unrestricted (administrator).
+	 */
+	public function get_scope_term_ids() {
+		// Administrators (anyone who can manage options) are unrestricted.
+		if (current_user_can('manage_options')) {
+			return null;
+		}
+
+		$user_id = get_current_user_id();
+		$scope_term = absint(get_user_meta($user_id, self::SCOPE_META_KEY, true));
+
+		// Restricted user without a scope assigned: nothing is visible.
+		if (0 === $scope_term) {
+			return array();
+		}
+
+		$term_ids = array($scope_term);
+		$children = get_term_children($scope_term, self::SCOPE_TAXONOMY);
+		if (!is_wp_error($children) && !empty($children)) {
+			$term_ids = array_merge($term_ids, $children);
+		}
+
+		return array_map('absint', $term_ids);
 	}
 
 	/**
@@ -64,35 +114,181 @@ class Documentate_Scope_Filter {
 			return;
 		}
 
-		// Admins see everything.
-		if (current_user_can('manage_options')) {
+		$term_ids = $this->get_scope_term_ids();
+
+		// Unrestricted user (administrator): leave the query untouched.
+		if (null === $term_ids) {
 			return;
 		}
 
-		$user_id = get_current_user_id();
-		$scope_term = absint(get_user_meta($user_id, self::SCOPE_META_KEY, true));
-
-		// No scope assigned: show nothing.
-		if (0 === $scope_term) {
+		// Restricted user without a scope assigned: show nothing.
+		if (empty($term_ids)) {
 			$query->set('post__in', array(0));
 			return;
 		}
 
-		// Build list of scope term and its descendants.
-		$term_ids = array($scope_term);
-		$children = get_term_children($scope_term, self::SCOPE_TAXONOMY);
-		if (!is_wp_error($children) && !empty($children)) {
-			$term_ids = array_merge($term_ids, $children);
+		// Merge the scope restriction with any taxonomy filter already on the
+		// query (e.g. an explicitly selected category) using AND, so explicit
+		// filters narrow the scope instead of replacing it.
+		$tax_query = $query->get('tax_query');
+		if (!is_array($tax_query)) {
+			$tax_query = array();
 		}
 
-		$query->set('tax_query', array(
-			array(
-				'taxonomy' => self::SCOPE_TAXONOMY,
-				'field' => 'term_id',
-				'terms' => $term_ids,
-				'include_children' => false,
-			),
-		));
+		$tax_query[] = array(
+			'taxonomy' => self::SCOPE_TAXONOMY,
+			'field' => 'term_id',
+			'terms' => $term_ids,
+			'include_children' => false,
+		);
+
+		// If more than one taxonomy clause is present (besides any existing
+		// 'relation' key), combine them with AND so the scope always applies.
+		$clause_count = count($tax_query) - (isset($tax_query['relation']) ? 1 : 0);
+		if ($clause_count > 1) {
+			$tax_query['relation'] = 'AND';
+		}
+
+		$query->set('tax_query', $tax_query);
+	}
+
+	/**
+	 * Count the documents visible to the current user for a given status set.
+	 *
+	 * Applies exactly the same scope restriction used by the admin list query,
+	 * so the resulting count matches the rows the list table would show.
+	 *
+	 * @param string|string[] $post_status Status or statuses to count.
+	 * @param int             $author      Optional author ID to restrict to (0 = any author).
+	 * @return int Number of visible documents.
+	 */
+	public function count_visible_documents($post_status, $author = 0) {
+		$term_ids = $this->get_scope_term_ids();
+
+		// Restricted user without a scope assigned: nothing is visible.
+		if (is_array($term_ids) && empty($term_ids)) {
+			return 0;
+		}
+
+		$args = array(
+			'post_type' => self::POST_TYPE,
+			'post_status' => $post_status,
+			'fields' => 'ids',
+			'posts_per_page' => 1,
+			'no_found_rows' => false,
+			'ignore_sticky_posts' => true,
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+		);
+
+		if ($author > 0) {
+			$args['author'] = (int) $author;
+		}
+
+		// Apply the scope restriction (null = unrestricted, so no tax_query).
+		if (!empty($term_ids)) {
+			$args['tax_query'] = array(
+				array(
+					'taxonomy' => self::SCOPE_TAXONOMY,
+					'field' => 'term_id',
+					'terms' => $term_ids,
+					'include_children' => false,
+				),
+			);
+		}
+
+		$query = new WP_Query($args);
+
+		return (int) $query->found_posts;
+	}
+
+	/**
+	 * Recalculate the admin list "views" counters using the scope rules.
+	 *
+	 * For unrestricted users (administrators) the native WordPress counters are
+	 * returned untouched. For scoped users each counter is recomputed so it
+	 * matches the rows the list table shows; status views that drop to zero are
+	 * removed (mirroring how WordPress hides empty status filters), except the
+	 * "All" view and whichever view is currently selected.
+	 *
+	 * @param string[] $views View links keyed by status/view name.
+	 * @return string[] Filtered view links.
+	 */
+	public function filter_view_counts($views) {
+		// Unrestricted users keep WordPress' native counters.
+		if (null === $this->get_scope_term_ids()) {
+			return $views;
+		}
+
+		$current_user = get_current_user_id();
+
+		$status_map = array(
+			'all' => self::ALL_LIST_STATUSES,
+			'mine' => self::ALL_LIST_STATUSES,
+			'publish' => 'publish',
+			'future' => 'future',
+			'draft' => 'draft',
+			'pending' => 'pending',
+			'private' => 'private',
+			'archived' => 'archived',
+			'trash' => 'trash',
+		);
+
+		foreach ($views as $key => $view) {
+			if (!isset($status_map[$key])) {
+				continue;
+			}
+
+			$author = ('mine' === $key) ? $current_user : 0;
+			$count = $this->count_visible_documents($status_map[$key], $author);
+
+			// Drop empty status views, but keep "All" and the active view.
+			if (0 === $count && 'all' !== $key && !$this->is_current_view($key)) {
+				unset($views[$key]);
+				continue;
+			}
+
+			$views[$key] = $this->replace_view_count($view, $count);
+		}
+
+		return $views;
+	}
+
+	/**
+	 * Determine whether the given view is the one currently being displayed.
+	 *
+	 * @param string $key View key (all, mine, draft, ...).
+	 * @return bool
+	 */
+	private function is_current_view($key) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$status = isset($_GET['post_status']) ? sanitize_key(wp_unslash($_GET['post_status'])) : '';
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$author = isset($_GET['author']) ? absint(wp_unslash($_GET['author'])) : 0;
+
+		if ('mine' === $key) {
+			return 0 !== $author && $author === get_current_user_id();
+		}
+
+		if ('all' === $key) {
+			return '' === $status && 0 === $author;
+		}
+
+		return $status === $key;
+	}
+
+	/**
+	 * Replace the numeric counter inside a view link with a new value.
+	 *
+	 * @param string $view  The view link HTML.
+	 * @param int    $count The new count.
+	 * @return string Updated view link.
+	 */
+	private function replace_view_count($view, $count) {
+		$replacement = '<span class="count">(' . number_format_i18n($count) . ')</span>';
+		$updated = preg_replace('#<span class="count">\([^)]*\)</span>#', $replacement, $view, 1);
+
+		return null === $updated ? $view : $updated;
 	}
 }
 

--- a/includes/custom-post-types/class-documentate-documents.php
+++ b/includes/custom-post-types/class-documentate-documents.php
@@ -112,6 +112,9 @@ class Documentate_Documents {
 		// Admin list table filters and columns.
 		add_action('restrict_manage_posts', array($this, 'add_admin_filters'), 10, 2);
 		add_action('pre_get_posts', array($this, 'apply_admin_filters'));
+		// Suppress the native category dropdown so it does not duplicate our
+		// custom category_name filter (both target the 'category' taxonomy).
+		add_filter('disable_categories_dropdown', array($this, 'disable_native_categories_dropdown'), 10, 2);
 		add_filter('manage_documentate_document_posts_columns', array($this, 'add_admin_columns'));
 		add_action('manage_documentate_document_posts_custom_column', array($this, 'render_admin_column'), 10, 2);
 		add_filter('manage_edit-documentate_document_sortable_columns', array($this, 'add_sortable_columns'));
@@ -2866,6 +2869,28 @@ class Documentate_Documents {
 		};
 
 		return (string) preg_replace_callback('/u([0-9a-fA-F]{4})/i', $callback, $text);
+	}
+
+	/**
+	 * Disable WordPress' native category dropdown for the documents list table.
+	 *
+	 * The 'category' taxonomy is attached to documentate_document, so WordPress
+	 * core renders a native `cat` dropdown (numeric term IDs). The plugin also
+	 * renders its own `category_name` dropdown (slugs). Keeping both duplicates
+	 * the control and can build conflicting taxonomy queries, so the native one
+	 * is suppressed and the plugin's `category_name` filter is the single source
+	 * of category filtering.
+	 *
+	 * @param bool   $disable   Whether to disable the categories dropdown.
+	 * @param string $post_type Post type slug for the current list table.
+	 * @return bool True to disable the native dropdown for our post type.
+	 */
+	public function disable_native_categories_dropdown($disable, $post_type) {
+		if ('documentate_document' === $post_type) {
+			return true;
+		}
+
+		return $disable;
 	}
 
 	/**

--- a/tests/unit/includes/DocumentateScopeCountsTest.php
+++ b/tests/unit/includes/DocumentateScopeCountsTest.php
@@ -1,0 +1,385 @@
+<?php
+/**
+ * Tests for scope-consistent admin list counters.
+ *
+ * Verifies that the documentate_document admin "view" counters (All, Mine,
+ * Published, Drafts, Pending, ...) are calculated with the SAME scope
+ * visibility rules used by the admin list query, so the counters and the
+ * listed rows always match for scoped non-administrator users.
+ *
+ * @package Documentate
+ */
+
+/**
+ * @covers Documentate_Scope_Filter
+ */
+class DocumentateScopeCountsTest extends WP_UnitTestCase {
+
+	/**
+	 * Scope filter instance.
+	 *
+	 * @var Documentate_Scope_Filter
+	 */
+	protected $filter;
+
+	/**
+	 * Admin user ID (also used as the "other" author).
+	 *
+	 * @var int
+	 */
+	protected $admin_id;
+
+	/**
+	 * Scoped editor user ID.
+	 *
+	 * @var int
+	 */
+	protected $editor_id;
+
+	/**
+	 * Scope parent category term ID (assigned to the editor).
+	 *
+	 * @var int
+	 */
+	protected $cat_a;
+
+	/**
+	 * Scope child category term ID (descendant of cat_a).
+	 *
+	 * @var int
+	 */
+	protected $cat_a_child;
+
+	/**
+	 * Out-of-scope category term ID.
+	 *
+	 * @var int
+	 */
+	protected $cat_b;
+
+	/**
+	 * Document type term ID (classification, required to hold non-draft status).
+	 *
+	 * @var int
+	 */
+	protected $doc_type_id;
+
+	/**
+	 * Set up fixtures.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		require_once plugin_dir_path( DOCUMENTATE_PLUGIN_FILE ) . 'includes/class-documentate-scope-filter.php';
+		$this->filter = new Documentate_Scope_Filter();
+
+		$this->admin_id  = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$this->editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		$parent = wp_insert_term( 'Scope A', 'category' );
+		$child  = wp_insert_term( 'Scope A Child', 'category', array( 'parent' => $parent['term_id'] ) );
+		$other  = wp_insert_term( 'Scope B', 'category' );
+
+		$this->cat_a       = (int) $parent['term_id'];
+		$this->cat_a_child = (int) $child['term_id'];
+		$this->cat_b       = (int) $other['term_id'];
+
+		$doc_type          = wp_insert_term( 'Resolution', 'documentate_doc_type' );
+		$this->doc_type_id = (int) $doc_type['term_id'];
+
+		// Build the data set (see assertions for the expected scoped counts):
+		//   In scope (A or A-child):
+		$this->make_doc( 'publish', $this->admin_id, $this->cat_a );        // 1
+		$this->make_doc( 'draft', $this->editor_id, $this->cat_a );         // 2 (editor)
+		$this->make_doc( 'pending', $this->admin_id, $this->cat_a_child );  // 3
+		$this->make_doc( 'private', $this->editor_id, $this->cat_a );       // 4 (editor)
+		//   Out of scope (B / uncategorized) -- some authored by the editor:
+		$this->make_doc( 'publish', $this->admin_id, $this->cat_b );        // 5
+		$this->make_doc( 'draft', $this->editor_id, $this->cat_b );         // 6 (editor, out of scope)
+		$this->make_doc( 'draft', $this->editor_id, 0 );                    // 7 (editor, uncategorized)
+		$this->make_doc( 'publish', $this->admin_id, 0 );                   // 8 (uncategorized)
+
+		set_current_screen( 'edit-documentate_document' );
+	}
+
+	/**
+	 * Tear down fixtures.
+	 */
+	public function tear_down(): void {
+		wp_set_current_user( 0 );
+		$_GET = array();
+		set_current_screen( 'front' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Status set that the default "All"/"Mine" admin list views display.
+	 *
+	 * @var string[]
+	 */
+	private const ALL_VIEW_STATUSES = array( 'publish', 'future', 'draft', 'pending', 'private' );
+
+	/**
+	 * Create a documentate_document with a fixed status, author and category.
+	 *
+	 * Assigns a document type so the workflow does not force the status to
+	 * draft for unclassified documents.
+	 *
+	 * @param string $status Post status.
+	 * @param int    $author Author user ID.
+	 * @param int    $cat_id Category term ID (0 = uncategorized).
+	 * @return int Post ID.
+	 */
+	private function make_doc( $status, $author, $cat_id ) {
+		$previous = get_current_user_id();
+		wp_set_current_user( $this->admin_id );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => 'documentate_document',
+				'post_title'  => 'Doc ' . $status . '-' . $author . '-' . $cat_id,
+				'post_status' => $status,
+				'post_author' => $author,
+				'tax_input'   => array( 'documentate_doc_type' => array( $this->doc_type_id ) ),
+			)
+		);
+
+		if ( $cat_id ) {
+			wp_set_object_terms( $post_id, array( $cat_id ), 'category' );
+		}
+
+		wp_set_current_user( $previous );
+
+		// Guard: the fixture must really have the requested status, otherwise
+		// the counter assertions below would be meaningless.
+		$this->assertSame( $status, get_post_status( $post_id ), 'Fixture status was altered on insert.' );
+
+		return (int) $post_id;
+	}
+
+	/**
+	 * Extract the integer inside the `<span class="count">(N)</span>` of a view link.
+	 *
+	 * @param string $view View link HTML.
+	 * @return int|null
+	 */
+	private function extract_count( $view ) {
+		if ( preg_match( '#<span class="count">\((\d+)\)</span>#', $view, $m ) ) {
+			return (int) $m[1];
+		}
+		return null;
+	}
+
+	/**
+	 * Build a simulated main-query WP_Query object.
+	 *
+	 * @param string $post_type Post type.
+	 * @return WP_Query
+	 */
+	private function build_main_query( $post_type ) {
+		$query = new WP_Query();
+		$query->set( 'post_type', $post_type );
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$GLOBALS['wp_the_query'] = $query;
+		return $query;
+	}
+
+	/**
+	 * The "All" counter counts only documents inside the user's scope.
+	 */
+	public function test_all_count_matches_scope() {
+		update_user_meta( $this->editor_id, Documentate_Scope_Filter::SCOPE_META_KEY, $this->cat_a );
+		wp_set_current_user( $this->editor_id );
+
+		$count = $this->filter->count_visible_documents( self::ALL_VIEW_STATUSES );
+
+		$this->assertSame( 4, $count, 'Scoped All count should include only in-scope documents.' );
+	}
+
+	/**
+	 * The scoped count equals the number of rows the equivalent list query returns.
+	 */
+	public function test_count_matches_actual_list_query() {
+		update_user_meta( $this->editor_id, Documentate_Scope_Filter::SCOPE_META_KEY, $this->cat_a );
+		wp_set_current_user( $this->editor_id );
+
+		$count = $this->filter->count_visible_documents( self::ALL_VIEW_STATUSES );
+
+		// Reproduce the actual scoped list query independently.
+		$list = new WP_Query(
+			array(
+				'post_type'      => 'documentate_document',
+				'post_status'    => self::ALL_VIEW_STATUSES,
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'tax_query'      => array(
+					array(
+						'taxonomy'         => 'category',
+						'field'            => 'term_id',
+						'terms'            => array_merge(
+							array( $this->cat_a ),
+							get_term_children( $this->cat_a, 'category' )
+						),
+						'include_children' => false,
+					),
+				),
+			)
+		);
+
+		$this->assertSame( count( $list->posts ), $count, 'Counter must equal the scoped list rows.' );
+	}
+
+	/**
+	 * The "Mine" counter respects scope: documents the editor authored OUTSIDE
+	 * their scope must not be counted (regression for "Mine (N) shows 0 rows").
+	 */
+	public function test_mine_count_respects_scope() {
+		update_user_meta( $this->editor_id, Documentate_Scope_Filter::SCOPE_META_KEY, $this->cat_a );
+		wp_set_current_user( $this->editor_id );
+
+		$mine = $this->filter->count_visible_documents( self::ALL_VIEW_STATUSES, $this->editor_id );
+
+		// The editor authored docs 2,4 (in scope) and 6,7 (out of scope).
+		$this->assertSame( 2, $mine, 'Mine must only count in-scope documents authored by the user.' );
+	}
+
+	/**
+	 * Draft and pending counters are scope-consistent.
+	 */
+	public function test_status_counts_respect_scope() {
+		update_user_meta( $this->editor_id, Documentate_Scope_Filter::SCOPE_META_KEY, $this->cat_a );
+		wp_set_current_user( $this->editor_id );
+
+		$this->assertSame( 1, $this->filter->count_visible_documents( 'draft' ), 'Scoped Drafts.' );
+		$this->assertSame( 1, $this->filter->count_visible_documents( 'pending' ), 'Scoped Pending.' );
+		$this->assertSame( 1, $this->filter->count_visible_documents( 'publish' ), 'Scoped Published.' );
+	}
+
+	/**
+	 * A user with no scope assigned sees (and counts) nothing.
+	 */
+	public function test_no_scope_counts_zero() {
+		wp_set_current_user( $this->editor_id );
+
+		$this->assertSame( 0, $this->filter->count_visible_documents( self::ALL_VIEW_STATUSES ) );
+	}
+
+	/**
+	 * Administrators are unrestricted: counts cover every document.
+	 */
+	public function test_admin_counts_unrestricted() {
+		wp_set_current_user( $this->admin_id );
+
+		$this->assertSame( 8, $this->filter->count_visible_documents( self::ALL_VIEW_STATUSES ) );
+	}
+
+	/**
+	 * The views filter rewrites each counter to its scoped value.
+	 */
+	public function test_filter_view_counts_rewrites_counts() {
+		update_user_meta( $this->editor_id, Documentate_Scope_Filter::SCOPE_META_KEY, $this->cat_a );
+		wp_set_current_user( $this->editor_id );
+		$_GET = array();
+
+		$views = array(
+			'all'     => '<a href="edit.php?post_type=documentate_document" class="current">All <span class="count">(8)</span></a>',
+			'mine'    => '<a href="edit.php?post_type=documentate_document&author=' . $this->editor_id . '">Mine <span class="count">(4)</span></a>',
+			'publish' => '<a href="edit.php?post_status=publish">Published <span class="count">(3)</span></a>',
+			'draft'   => '<a href="edit.php?post_status=draft">Drafts <span class="count">(3)</span></a>',
+			'pending' => '<a href="edit.php?post_status=pending">Pending <span class="count">(1)</span></a>',
+		);
+
+		$result = $this->filter->filter_view_counts( $views );
+
+		$this->assertSame( 4, $this->extract_count( $result['all'] ) );
+		$this->assertSame( 2, $this->extract_count( $result['mine'] ) );
+		$this->assertSame( 1, $this->extract_count( $result['publish'] ) );
+		$this->assertSame( 1, $this->extract_count( $result['draft'] ) );
+		$this->assertSame( 1, $this->extract_count( $result['pending'] ) );
+	}
+
+	/**
+	 * Status views that drop to zero under scope are removed (mirroring how
+	 * WordPress hides empty status filters), while "All" is kept.
+	 */
+	public function test_filter_view_counts_drops_empty_status_views() {
+		update_user_meta( $this->editor_id, Documentate_Scope_Filter::SCOPE_META_KEY, $this->cat_a );
+		wp_set_current_user( $this->editor_id );
+		$_GET = array();
+
+		$views = array(
+			'all'    => '<a href="edit.php">All <span class="count">(8)</span></a>',
+			'future' => '<a href="edit.php?post_status=future">Scheduled <span class="count">(5)</span></a>',
+		);
+
+		$result = $this->filter->filter_view_counts( $views );
+
+		$this->assertArrayHasKey( 'all', $result );
+		$this->assertArrayNotHasKey( 'future', $result, 'Empty status view should be removed.' );
+	}
+
+	/**
+	 * Administrators keep WordPress' native counters untouched.
+	 */
+	public function test_filter_view_counts_leaves_admin_untouched() {
+		wp_set_current_user( $this->admin_id );
+
+		$views = array(
+			'all'   => '<a href="edit.php">All <span class="count">(8)</span></a>',
+			'draft' => '<a href="edit.php?post_status=draft">Drafts <span class="count">(3)</span></a>',
+		);
+
+		$this->assertSame( $views, $this->filter->filter_view_counts( $views ) );
+	}
+
+	/**
+	 * An explicit category filter narrows WITHIN the scope instead of replacing
+	 * it: the existing tax_query clause is preserved and AND-combined with the
+	 * scope clause.
+	 */
+	public function test_explicit_category_narrows_within_scope() {
+		update_user_meta( $this->editor_id, Documentate_Scope_Filter::SCOPE_META_KEY, $this->cat_a );
+		wp_set_current_user( $this->editor_id );
+
+		$query = $this->build_main_query( 'documentate_document' );
+		$query->set(
+			'tax_query',
+			array(
+				array(
+					'taxonomy' => 'category',
+					'field'    => 'term_id',
+					'terms'    => array( $this->cat_b ),
+				),
+			)
+		);
+
+		$this->filter->filter_documents_by_scope( $query );
+
+		$tax_query = $query->get( 'tax_query' );
+
+		$this->assertSame( 'AND', $tax_query['relation'], 'Scope and explicit filter must be AND-combined.' );
+
+		$terms_seen = array();
+		foreach ( $tax_query as $key => $clause ) {
+			if ( 'relation' === $key ) {
+				continue;
+			}
+			$terms_seen[] = $clause['terms'];
+		}
+
+		// One clause keeps the explicit category (B); the other adds the scope (A).
+		$flat = array_merge( ...$terms_seen );
+		$this->assertContains( $this->cat_b, $flat, 'Explicit category filter must be preserved.' );
+		$this->assertContains( $this->cat_a, $flat, 'Scope restriction must be applied.' );
+	}
+
+	/**
+	 * The exposed status constant matches the documented "All" view status set.
+	 */
+	public function test_all_list_statuses_constant() {
+		$this->assertSame(
+			array( 'publish', 'future', 'draft', 'pending', 'private' ),
+			Documentate_Scope_Filter::ALL_LIST_STATUSES
+		);
+	}
+}

--- a/tests/unit/includes/custom-post-types/DocumentateDocumentsTest.php
+++ b/tests/unit/includes/custom-post-types/DocumentateDocumentsTest.php
@@ -3043,6 +3043,34 @@ HTML;
 	}
 
 	/**
+	 * The native WordPress category dropdown is suppressed for documents, so it
+	 * does not duplicate the plugin's own category (category_name) filter.
+	 */
+	public function test_disable_native_categories_dropdown_hook_registered() {
+		$this->assertNotFalse(
+			has_filter( 'disable_categories_dropdown', array( $this->documents, 'disable_native_categories_dropdown' ) )
+		);
+	}
+
+	/**
+	 * The native category dropdown is disabled for the documents screen.
+	 */
+	public function test_disable_native_categories_dropdown_for_documents() {
+		$this->assertTrue(
+			$this->documents->disable_native_categories_dropdown( false, 'documentate_document' )
+		);
+	}
+
+	/**
+	 * Other post types keep their native category dropdown.
+	 */
+	public function test_disable_native_categories_dropdown_ignores_other_post_types() {
+		$this->assertFalse(
+			$this->documents->disable_native_categories_dropdown( false, 'post' )
+		);
+	}
+
+	/**
 	 * Test apply_admin_filters ignores non-admin context.
 	 */
 	public function test_apply_admin_filters_ignores_non_admin() {


### PR DESCRIPTION
## Summary

Fixes inconsistent admin list counts and visible rows for `documentate_document`
when non-administrator users have a configured scope/category (área).

Closes #196.

## Root cause

`Documentate_Scope_Filter::filter_documents_by_scope()` restricts the **main
admin list query** with a `tax_query` limited to the user's scope category (and
descendants). The admin **view counters** (`All`, `Mine`, `Published`, `Drafts`,
`Pending`), however, are produced by WordPress core helpers
(`wp_count_posts( 'documentate_document', 'readable' )` for the status links and
a direct author `COUNT(*)` for `Mine`) which **do not** apply that scope
restriction. The two paths therefore used different visibility rules, so the
counters reported more documents than the list actually showed, and `Mine`
could report a positive count while listing zero rows (when the user authored
documents outside their scope).

Two secondary problems compounded it:

- The `category` taxonomy is attached to the CPT, so WordPress core renders its
  native `cat` dropdown (term IDs) **in addition to** the plugin's custom
  `category_name` dropdown (slugs) — two controls for the same taxonomy.
- The scope `tax_query` was assigned with `$query->set()`, overwriting any
  taxonomy filter the user explicitly selected instead of narrowing within it.

## Changes

- **Single source of truth for visibility.** Added
  `Documentate_Scope_Filter::get_scope_term_ids()` and
  `count_visible_documents()`, used by both the list query and a new
  `views_edit-documentate_document` filter (`filter_view_counts()`) that
  recomputes every counter with the same scope rules. Counters now match the
  rows the list table shows; status views that drop to zero are hidden (as core
  does), keeping `All` and the active view.
- **Explicit category narrows within scope.** `filter_documents_by_scope()` now
  merges the scope clause with any pre-existing `tax_query` using `AND` instead
  of replacing it.
- **No duplicate category control.** A `disable_categories_dropdown` filter
  suppresses the native `cat` dropdown for `documentate_document`, leaving the
  plugin's `category_name` filter as the single category control.

Administrators remain unrestricted, and the existing scope/permission policy is
unchanged — counters are corrected **down** to the already-restricted list (the
fix never widens visibility).

## Tests

New regression coverage (`tests/unit/includes/DocumentateScopeCountsTest.php`,
plus three cases in `DocumentateDocumentsTest.php`):

- Scoped `All` counter equals the in-scope documents and the actual scoped list
  query result.
- `Mine` counter respects scope (documents authored outside scope are not
  counted — the "Mine (N) shows 0 rows" regression).
- `Drafts`, `Pending`, `Published` counters are scope-consistent.
- Explicit category filter narrows within scope (tax_query is merged with `AND`,
  not overwritten).
- Superadmin counters are left untouched; a user with no scope counts zero.
- The native category dropdown is disabled for documents but not for other post
  types.

## Test plan

- `make test` — full suite: **1622 tests, 12553 assertions, OK**.
- `make lint` (mago) — **No issues found**.
- `make check-plugin` — **No errors found**.

## Checklist

- [x] Tests pass.
- [x] WordPress Coding Standards (mago lint) pass.
- [x] Plugin Check passes with no errors.
- [x] The issue is linked.
- [x] The fix does not weaken permission restrictions.
