### PR TITLE
Harden comment handling: whitelist comment_type, gate REST by capability

### DIFF
--- a/includes/class-documentate-rest-comment-protection.php
+++ b/includes/class-documentate-rest-comment-protection.php
@@ -70,6 +70,19 @@ class Documentate_REST_Comment_Protection {
 	}
 
 	/**
+	 * Whether the current user may bypass the comment protection.
+	 *
+	 * Only users who can edit posts (contributors and above) are allowed to
+	 * read or modify comments on protected post types via REST. Being merely
+	 * logged in (e.g. a subscriber) is not sufficient.
+	 *
+	 * @return bool
+	 */
+	private function current_user_can_bypass() {
+		return current_user_can('edit_posts');
+	}
+
+	/**
 	 * Prepares to filter the comment collection query for unauthenticated users.
 	 *
 	 * This function hooks into `comments_clauses` only when a REST API request for comments
@@ -80,7 +93,7 @@ class Documentate_REST_Comment_Protection {
 	 * @return array The original arguments.
 	 */
 	public function prepare_comment_collection_query($args, $request) {
-		if (!is_user_logged_in()) {
+		if (!$this->current_user_can_bypass()) {
 			add_filter('comments_clauses', array($this, 'filter_comment_collection_query'));
 		}
 		return $args;
@@ -126,7 +139,7 @@ class Documentate_REST_Comment_Protection {
 	 * @return mixed A WP_Error if access is denied, otherwise the original $result.
 	 */
 	public function protect_single_comment_access($result, $server, $request) {
-		if (is_user_logged_in()) {
+		if ($this->current_user_can_bypass()) {
 			return $result;
 		}
 
@@ -188,7 +201,7 @@ class Documentate_REST_Comment_Protection {
 	 * @return array|WP_Error The comment data or a WP_Error if denied.
 	 */
 	public function protect_comment_creation($prepared_comment, $request) {
-		if (is_user_logged_in() || is_wp_error($prepared_comment)) {
+		if ($this->current_user_can_bypass() || is_wp_error($prepared_comment)) {
 			return $prepared_comment;
 		}
 
@@ -212,7 +225,7 @@ class Documentate_REST_Comment_Protection {
 	 */
 	public function protect_comment_modification($result) {
 		// Let existing errors through, and allow authenticated users.
-		if (is_user_logged_in() || is_wp_error($result)) {
+		if ($this->current_user_can_bypass() || is_wp_error($result)) {
 			return $result;
 		}
 

--- a/includes/documents/class-documents-comments-handler.php
+++ b/includes/documents/class-documents-comments-handler.php
@@ -125,7 +125,7 @@ class Documents_Comments_Handler {
 		}
 
 		$comment_parent = isset($_POST['comment_ID']) ? absint($_POST['comment_ID']) : 0;
-		$comment_type   = isset($_POST['comment_type']) ? sanitize_key(wp_unslash($_POST['comment_type'])) : 'comment';
+		$comment_type   = isset($_POST['comment_type']) ? self::sanitize_comment_type(sanitize_key(wp_unslash($_POST['comment_type']))) : 'comment';
 
 		return array(
 			'comment_post_ID'      => $post->ID,
@@ -138,6 +138,22 @@ class Documents_Comments_Handler {
 			'user_id'              => $user->ID,
 			'comment_approved'     => 1,
 		);
+	}
+
+	/**
+	 * Restrict the comment type to a safe, known set.
+	 *
+	 * Any value outside the allowed list falls back to the default 'comment'
+	 * type, preventing arbitrary comment types from being stored through the
+	 * reply endpoint.
+	 *
+	 * @param string $comment_type Sanitized comment type from the request.
+	 * @return string A whitelisted comment type.
+	 */
+	public static function sanitize_comment_type($comment_type) {
+		$allowed = array('comment', 'pingback', 'trackback');
+
+		return in_array((string) $comment_type, $allowed, true) ? (string) $comment_type : 'comment';
 	}
 
 	/**

--- a/tests/unit/includes/DocumentateCommentTypeTest.php
+++ b/tests/unit/includes/DocumentateCommentTypeTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Tests for comment-type whitelisting in the document reply handler.
+ *
+ * @package Documentate
+ */
+
+use Documentate\Documents\Documents_Comments_Handler;
+
+/**
+ * @covers Documentate\Documents\Documents_Comments_Handler::sanitize_comment_type
+ */
+class DocumentateCommentTypeTest extends WP_UnitTestCase {
+
+	/**
+	 * Load the class under test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		require_once plugin_dir_path( DOCUMENTATE_PLUGIN_FILE ) . 'includes/documents/class-documents-comments-handler.php';
+	}
+
+	/**
+	 * Known comment types are preserved.
+	 */
+	public function test_allowed_types_pass_through() {
+		$this->assertSame( 'comment', Documents_Comments_Handler::sanitize_comment_type( 'comment' ) );
+		$this->assertSame( 'pingback', Documents_Comments_Handler::sanitize_comment_type( 'pingback' ) );
+		$this->assertSame( 'trackback', Documents_Comments_Handler::sanitize_comment_type( 'trackback' ) );
+	}
+
+	/**
+	 * Unknown or empty comment types fall back to the safe default.
+	 */
+	public function test_unknown_type_falls_back_to_comment() {
+		$this->assertSame( 'comment', Documents_Comments_Handler::sanitize_comment_type( 'documentate_evil' ) );
+		$this->assertSame( 'comment', Documents_Comments_Handler::sanitize_comment_type( 'order_note' ) );
+		$this->assertSame( 'comment', Documents_Comments_Handler::sanitize_comment_type( '' ) );
+	}
+}

--- a/tests/unit/includes/DocumentateRestCommentProtectionTest.php
+++ b/tests/unit/includes/DocumentateRestCommentProtectionTest.php
@@ -479,4 +479,44 @@ class DocumentateRestCommentProtectionTest extends WP_UnitTestCase {
 
 		$this->assertNull( $result );
 	}
+
+	/**
+	 * A subscriber is logged in but cannot edit posts, so comment creation on a
+	 * protected post must be blocked (regression: being logged in is not enough).
+	 */
+	public function test_protect_comment_creation_blocks_subscriber() {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'subscriber' ) ) );
+		$this->protection->register_rest_comment_protection_hooks();
+
+		$prepared = array(
+			'comment_post_ID' => $this->protected_post_id,
+			'comment_content' => 'Test',
+		);
+		$request  = new WP_REST_Request();
+		$request['post'] = $this->protected_post_id;
+
+		$result = $this->protection->protect_comment_creation( $prepared, $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_cannot_create_comment', $result->get_error_code() );
+	}
+
+	/**
+	 * An editor can edit posts, so comment creation on a protected post is allowed.
+	 */
+	public function test_protect_comment_creation_allows_editor() {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'editor' ) ) );
+		$this->protection->register_rest_comment_protection_hooks();
+
+		$prepared = array(
+			'comment_post_ID' => $this->protected_post_id,
+			'comment_content' => 'Test',
+		);
+		$request  = new WP_REST_Request();
+		$request['post'] = $this->protected_post_id;
+
+		$result = $this->protection->protect_comment_creation( $prepared, $request );
+
+		$this->assertSame( $prepared, $result );
+	}
 }


### PR DESCRIPTION
## What
Two small security hardenings for the document comment flow:

- **Whitelist `comment_type`** on the reply endpoint (`comment`, `pingback`, `trackback`); any other value falls back to `comment`.
- **Gate the REST comment protection on `current_user_can('edit_posts')`** instead of `is_user_logged_in()` (see ARCHITECTURE.md §4.1), so a logged-in subscriber can no longer read or modify comments on protected post types via REST.

## Tests
- `DocumentateCommentTypeTest` — comment-type whitelist.
- `DocumentateRestCommentProtectionTest` — new subscriber-blocked / editor-allowed cases. The existing admin-based bypass tests are unaffected, since administrators keep `edit_posts`.

## Validation
`mago lint` passes locally. PHPUnit runs in CI (local wp-env could not build the WordPress container on this machine).
