### PR TITLE
Cleanup: harden demo seeding, security fixes, small perf & simplification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,8 @@ node_modules/
 *.sql.gz
 *.tar.gz
 *.zip
-wp-resolate*/
-resolate*/
+wp-documentate*/
+documentate*/
 *.swp
 *.swo
 *.bak

--- a/.wp-env.docker.json
+++ b/.wp-env.docker.json
@@ -6,6 +6,7 @@
         "SCRIPT_DEBUG": true,
         "WP_DEBUG_LOG": true,
         "WP_DEBUG_DISPLAY": false,
+        "WP_ENVIRONMENT_TYPE": "local",
         "WPLANG": "es_ES"
     },
     "mappings": {

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -5,6 +5,7 @@
         "SCRIPT_DEBUG": true,
         "WP_DEBUG_LOG": true,
         "WP_DEBUG_DISPLAY": true,
+        "WP_ENVIRONMENT_TYPE": "local",
         "WPLANG": "es_ES"
     },
     "mappings": {

--- a/admin/class-documentate-admin.php
+++ b/admin/class-documentate-admin.php
@@ -161,7 +161,7 @@ class Documentate_Admin {
 	public static function get_collaborative_settings() {
 		$options = get_option('documentate_settings', array());
 		return array(
-			'enabled' => isset($options['collaborative_enabled']) && '1' === $options['collaborative_enabled'],
+			'enabled' => self::is_collaborative_enabled(),
 			'signalingServer' => isset($options['collaborative_signaling']) && '' !== $options['collaborative_signaling']
 				? $options['collaborative_signaling']
 				: 'wss://signaling.yjs.dev',
@@ -297,6 +297,13 @@ class Documentate_Admin {
 	 */
 	public function ajax_get_user_avatars() {
 		check_ajax_referer('documentate_collab_avatars', 'nonce');
+
+		if (!current_user_can('edit_posts')) {
+			wp_send_json_error(
+				array('message' => __('You are not authorized to access this resource.', 'documentate')),
+				403,
+			);
+		}
 
 		$user_ids = isset($_POST['user_ids']) ? array_map('intval', (array) $_POST['user_ids']) : array();
 		$avatars = array();

--- a/documentate.php
+++ b/documentate.php
@@ -12,6 +12,8 @@
  * Plugin URI:        https://github.com/ateeducacion/wp-documentate
  * Description:       Digital document generator. Defines a custom post type for structured documents with customizable sections and allows exporting to Word (DOCX) and PDF.
  * Version:           0.0.0
+ * Requires at least: 6.1
+ * Requires PHP:      8.3
  * Author:            Área de Tecnología Educativa
  * Author URI:        https://www3.gobiernodecanarias.org/medusa/ecoescuela/ate/
  * License:           GPL-3.0+
@@ -59,7 +61,12 @@ function documentate_activate_plugin() {
 
 	update_option('documentate_flush_rewrites', true);
 	update_option('documentate_version', DOCUMENTATE_VERSION);
-	update_option('documentate_seed_demo_documents', true);
+
+	// Only request demo seeding in non-production environments (and Playground).
+	// This prevents demo login accounts from ever being created on production.
+	if (Documentate_Demo_Data::should_allow_demo_seeding()) {
+		update_option('documentate_seed_demo_documents', true);
+	}
 
 	// Ensure default fixtures (templates) are available in Media Library and settings.
 	Documentate_Demo_Data::ensure_default_media();

--- a/includes/class-documentate-collabora-converter.php
+++ b/includes/class-documentate-collabora-converter.php
@@ -333,6 +333,13 @@ class Documentate_Collabora_Converter {
 	 * @return bool
 	 */
 	private static function is_ssl_verification_disabled() {
+		// Never skip TLS certificate verification on production, even if the
+		// option is enabled — official documents must not travel over an
+		// unverified connection. The toggle stays available for local testing.
+		if ('production' === wp_get_environment_type()) {
+			return false;
+		}
+
 		$options = get_option('documentate_settings', array());
 		return isset($options['collabora_disable_ssl']) && '1' === $options['collabora_disable_ssl'];
 	}

--- a/includes/class-documentate-demo-data.php
+++ b/includes/class-documentate-demo-data.php
@@ -41,6 +41,28 @@ class Documentate_Demo_Data {
 	}
 
 	/**
+	 * Whether demo content may be seeded in the current environment.
+	 *
+	 * Demo data — most importantly the demo login accounts — must never be
+	 * created on production sites. Seeding is permitted inside WordPress
+	 * Playground and in any non-production environment (local, development,
+	 * staging), as reported by wp_get_environment_type().
+	 *
+	 * @return bool True when demo seeding is permitted.
+	 */
+	public static function should_allow_demo_seeding() {
+		if (!class_exists('Documentate_Collabora_Converter')) {
+			require_once plugin_dir_path(__FILE__) . 'class-documentate-collabora-converter.php';
+		}
+
+		if (Documentate_Collabora_Converter::is_playground()) {
+			return true;
+		}
+
+		return 'production' !== wp_get_environment_type();
+	}
+
+	/**
 	 * Import a fixture file to the Media Library if not already imported.
 	 *
 	 * Looks for the file under plugin fixtures directory and root as fallback.
@@ -66,7 +88,7 @@ class Documentate_Demo_Data {
 			return 0;
 		}
 
-		$hash = @md5_file($source);
+		$hash = md5_file($source);
 		if ($hash) {
 			$found = get_posts(array(
 				'post_type' => 'attachment',
@@ -81,7 +103,7 @@ class Documentate_Demo_Data {
 			}
 		}
 
-		$contents = @file_get_contents($source);
+		$contents = file_get_contents($source);
 		if (false === $contents) {
 			return 0;
 		}
@@ -606,6 +628,11 @@ class Documentate_Demo_Data {
 	public static function maybe_seed_demo_users() {
 		$should_seed = (bool) get_option('documentate_seed_demo_documents', false);
 		if (!$should_seed) {
+			return;
+		}
+
+		// Defence in depth: never create real login accounts on production.
+		if (!self::should_allow_demo_seeding()) {
 			return;
 		}
 

--- a/includes/class-documentate-opentbs.php
+++ b/includes/class-documentate-opentbs.php
@@ -1520,38 +1520,7 @@ class Documentate_OpenTBS {
 	 * @return array{int,string,string}|false Position, matched key for length, raw HTML for parsing.
 	 */
 	private static function find_next_html_match($text, $lookup, $position) {
-		$found_pos = false;
-		$found_key = '';
-		$found_raw = '';
-
-		// Normalize the search text newlines to match replace_odt_text_node_html() behavior.
-		$normalized_text = self::normalize_text_newlines($text);
-
-		foreach ($lookup as $html => $raw) {
-			// Normalize lookup HTML to ensure CRLF/CR mismatches don't prevent matches.
-			$normalized_html = self::normalize_text_newlines($html);
-
-			$pos = strpos($normalized_text, $normalized_html, $position);
-			if (false === $pos) {
-				continue;
-			}
-
-			if (
-				false === $found_pos
-				|| $pos < $found_pos
-				|| $pos === $found_pos && strlen($normalized_html) > strlen($found_key)
-			) {
-				$found_pos = $pos;
-				$found_key = $normalized_html;
-				$found_raw = $raw;
-			}
-		}
-
-		if (false === $found_pos) {
-			return false;
-		}
-
-		return array($found_pos, $found_key, $found_raw);
+		return OpenTBS_HTML_Parser::find_next_html_match($text, $lookup, $position);
 	}
 
 	/**

--- a/includes/class-documentate-rest-comment-protection.php
+++ b/includes/class-documentate-rest-comment-protection.php
@@ -17,7 +17,7 @@ defined('ABSPATH') || exit();
  * Class Documentate_REST_Comment_Protection
  *
  * Adds REST API protections for reading and writing comments associated with
- * protected custom post types (e.g., documentate_task). Ensures unauthenticated
+ * protected custom post types (e.g., documentate_document). Ensures unauthenticated
  * users cannot list, read, create, update, or delete such comments via REST.
  */
 class Documentate_REST_Comment_Protection {
@@ -64,9 +64,9 @@ class Documentate_REST_Comment_Protection {
 		/**
 		 * Filters the list of post types whose comments are protected from unauthenticated access.
 		 *
-		 * @param array $post_types An array of post type slugs. Default: ['documentate_task'].
+		 * @param array $post_types An array of post type slugs. Default: ['documentate_document'].
 		 */
-		return apply_filters('documentate/protected_comment_post_types', array('documentate_task'));
+		return apply_filters('documentate/protected_comment_post_types', array('documentate_document'));
 	}
 
 	/**

--- a/includes/class-documentate-workflow.php
+++ b/includes/class-documentate-workflow.php
@@ -359,7 +359,7 @@ class Documentate_Workflow {
 			'documentate-workflow',
 			plugins_url('admin/js/documentate-workflow.js', __DIR__),
 			array('jquery'),
-			filemtime(plugin_dir_path(__DIR__) . 'admin/js/documentate-workflow.js'),
+			DOCUMENTATE_VERSION,
 			true,
 		);
 
@@ -368,7 +368,7 @@ class Documentate_Workflow {
 			'documentate-workflow',
 			plugins_url('admin/css/documentate-workflow.css', __DIR__),
 			array(),
-			filemtime(plugin_dir_path(__DIR__) . 'admin/css/documentate-workflow.css'),
+			DOCUMENTATE_VERSION,
 		);
 
 		// Get post data for JavaScript.

--- a/includes/class-documentate.php
+++ b/includes/class-documentate.php
@@ -67,10 +67,6 @@ class Documentate {
 
 		$this->load_dependencies();
 		$this->define_admin_hooks();
-		$this->define_public_hooks();
-
-		// Hook demo data creation to init.
-		add_action('init', array($this, 'maybe_create_demo_data'));
 	}
 
 	/**
@@ -93,8 +89,6 @@ class Documentate {
 		 * core plugin.
 		 */
 		require_once plugin_dir_path(__DIR__) . 'includes/class-documentate-loader.php';
-
-		// Removed legacy AJAX handlers for Kanban/Tasks.
 
 		/**
 		 * Refactored document classes following Single Responsibility Principle.
@@ -122,9 +116,7 @@ class Documentate {
 		/**
 		 * The classes responsible for defining the custom-post-types.
 		 */
-		// Keep boards/labels for KB; remove tasks/events/actions (Kanban removal).
-
-		// Documentate: Documents CPT and taxonomies (non-breaking addition).
+		// Documentate: Documents CPT and taxonomies.
 		require_once plugin_dir_path(__DIR__) . 'includes/custom-post-types/class-documentate-documents.php';
 		require_once plugin_dir_path(__DIR__) . 'includes/document/meta/class-document-meta-box.php';
 		require_once plugin_dir_path(__DIR__) . 'includes/document/meta/class-document-meta.php';
@@ -149,8 +141,6 @@ class Documentate {
 			$attachments_meta_box = new \Documentate\Document\Meta\Document_Attachments_Meta_Box();
 			$attachments_meta_box->register();
 		}
-
-		// Removed email-to-post, mailer/notification, and calendar modules.
 
 		require_once plugin_dir_path(__DIR__) . 'includes/class-documentate-disable-comment-notifications.php';
 
@@ -185,11 +175,6 @@ class Documentate {
 		require_once plugin_dir_path(__DIR__) . 'includes/class-documentate-user-scope.php';
 
 		/**
-		 * The class responsible for defining the MVC.
-		 */
-		// Remove Task MVC models/managers; not needed for Documentate/KB.
-
-		/**
 		 * The class responsible for defining all actions that occur in the admin area.
 		 */
 		require_once plugin_dir_path(__DIR__) . 'admin/class-documentate-admin.php';
@@ -204,12 +189,6 @@ class Documentate {
 		// Workflow management (role-based restrictions, read-only published state).
 		require_once plugin_dir_path(__DIR__) . 'includes/class-documentate-workflow.php';
 		new Documentate_Workflow();
-
-		/**
-		 * The class responsible for defining all actions that occur in the public-facing
-		 * side of the site.
-		 */
-		// Public-facing hooks disabled because the plugin does not expose front-end features.
 
 		$this->loader = new Documentate_Loader();
 	}
@@ -248,16 +227,6 @@ class Documentate {
 	}
 
 	/**
-	 * Register all of the hooks related to the public-facing functionality
-	 * of the plugin.
-	 *
-	 * @access   private
-	 */
-	private function define_public_hooks() {
-		// $plugin_public = new Documentate_Public( $this->get_plugin_name(), $this->get_version() );
-	}
-
-	/**
 	 * Run the loader to execute all of the hooks with WordPress.
 	 */
 	public function run() {
@@ -281,13 +250,5 @@ class Documentate {
 	 */
 	public function get_version() {
 		return $this->version;
-	}
-
-	/**
-	 * Create demo data if the version is 0.0.0
-	 */
-	public function maybe_create_demo_data() {
-		// Demo task data disabled in Documentate.
-		return;
 	}
 }

--- a/includes/custom-post-types/class-documentate-documents.php
+++ b/includes/custom-post-types/class-documentate-documents.php
@@ -60,8 +60,7 @@ class Documentate_Documents {
 	 * @return bool True if collaborative editing is enabled.
 	 */
 	private function is_collaborative_editing_enabled() {
-		$options = get_option('documentate_settings', array());
-		return isset($options['collaborative_enabled']) && '1' === $options['collaborative_enabled'];
+		return Documentate_Admin::is_collaborative_enabled();
 	}
 
 	/**
@@ -2905,12 +2904,17 @@ class Documentate_Documents {
 			return;
 		}
 
-		// Author filter.
-		$authors = get_users(array(
-			'has_published_posts' => array('documentate_document'),
-			'fields' => array('ID', 'display_name'),
-			'orderby' => 'display_name',
-		));
+		// Author filter. The has_published_posts query joins on the posts table,
+		// so cache it briefly; a slightly stale author dropdown is acceptable.
+		$authors = get_transient('documentate_admin_author_filter');
+		if (false === $authors) {
+			$authors = get_users(array(
+				'has_published_posts' => array('documentate_document'),
+				'fields' => array('ID', 'display_name'),
+				'orderby' => 'display_name',
+			));
+			set_transient('documentate_admin_author_filter', $authors, 5 * MINUTE_IN_SECONDS);
+		}
 
 		if (!empty($authors)) {
 			$current_author = isset($_GET['author']) ? absint($_GET['author']) : 0;
@@ -2950,10 +2954,12 @@ class Documentate_Documents {
 			echo '</select>';
 		}
 
-		// Category filter (if taxonomy exists).
+		// Category filter (if taxonomy exists). Cap the number of options so the
+		// dropdown never materialises an unbounded list of site categories.
 		$categories = get_terms(array(
 			'taxonomy' => 'category',
 			'hide_empty' => false,
+			'number' => 200,
 		));
 
 		if (!is_wp_error($categories) && !empty($categories)) {

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Documentate – Generador de resoluciones ===
 Contributors: ateeducacion
-Tags: documentos, resoluciones, docx, pdf, opentbs
+Tags: documents, resolutions, docx, pdf, opentbs
 Requires at least: 6.1
 Tested up to: 7.0
 Requires PHP: 8.3
@@ -8,42 +8,42 @@ Stable tag: 0.0.0
 License: GPL-3.0
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
-Generador de resoluciones y documentos administrativos estructurados a partir de plantillas ODT/DOCX, con exportación a DOCX y PDF.
+Generate official resolutions and structured administrative documents from ODT/DOCX templates, with export to DOCX and PDF.
 
 == Description ==
 
-Documentate es un plugin de WordPress desarrollado en el ATE para crear resoluciones y documentos administrativos estructurados a partir de plantillas ODT/DOCX.
+Documentate is a WordPress plugin developed by the ATE to create official resolutions and structured administrative documents from ODT/DOCX templates.
 
-Utiliza OpenTBS para combinar los datos del documento con la plantilla y permite convertir a PDF/DOCX mediante Collabora Online (en el servidor) o LibreOffice WASM (en el navegador).
+It uses OpenTBS to merge the document data into the template and can optionally convert the result to PDF/DOCX with Collabora Online (server-side) or LibreOffice WASM (in the browser).
 
-### Características
+### Features
 
-– **Tipos de documento (plantillas)**: definidos como taxonomía con campos basados en un esquema.
-– **Generación de ODT/DOCX** a partir de plantillas mediante OpenTBS.
-– **Conversión opcional a PDF** (y entre formatos ofimáticos) con Collabora Online (servidor) o LibreOffice WASM (navegador, experimental).
-– **Filtrado por ámbito de usuario** (categorías jerárquicas) para controlar la visibilidad de los documentos.
-– **Flujo de trabajo, revisiones, adjuntos y edición colaborativa.**
-– **Compatible con multisitio.**
+- **Document types (templates)** defined as a custom taxonomy with schema-driven fields.
+- **ODT/DOCX generation** from templates via OpenTBS.
+- **Optional conversion to PDF** (and between office formats) with Collabora Online (server) or LibreOffice WASM (browser, experimental).
+- **Per-user scope filtering** (hierarchical categories) to control document visibility.
+- **Workflow, revisions, attachments and collaborative editing.**
+- **Multisite compatible.**
 
 == Installation ==
 
-1. Descarga la última versión desde la página de *releases* de GitHub.
-2. Sube el plugin a tu sitio mediante **Plugins > Añadir nuevo > Subir plugin**.
-3. Activa el plugin desde el menú 'Plugins'.
-4. Configura el motor de conversión y las demás opciones en **Ajustes > Documentate**.
+1. Download the latest release from the GitHub releases page.
+2. Upload the plugin to your site via **Plugins > Add New > Upload Plugin**.
+3. Activate the plugin from the 'Plugins' menu.
+4. Configure the conversion engine and other options under **Settings > Documentate**.
 
 == Frequently Asked Questions ==
 
-= ¿Qué motores de conversión admite? =
-Collabora Online (en el servidor, recomendado) y LibreOffice WASM (en el navegador, experimental).
+= Which conversion engines are supported? =
+Collabora Online (server-side, recommended) and LibreOffice WASM (in the browser, experimental).
 
-= ¿Cómo se controla quién ve cada documento? =
-Mediante un ámbito por usuario (categorías jerárquicas). Los administradores ven todos los documentos; el resto solo los de su ámbito y sus subcategorías.
+= How is document visibility controlled? =
+Through a per-user scope (hierarchical categories). Administrators see every document; other users only see documents in their scope and its subcategories.
 
 == Screenshots ==
 
-1. **Editor de resolución**
-   Campos meta para las distintas secciones del documento.
+1. **Resolution editor**
+   Meta fields for the different sections of the document.
 
-2. **Exportación DOCX/PDF**
-   Genera documentos a partir de plantillas ODT/DOCX.
+2. **DOCX/PDF export**
+   Generates documents from ODT/DOCX templates.

--- a/readme.txt
+++ b/readme.txt
@@ -1,46 +1,49 @@
 === Documentate – Generador de resoluciones ===
 Contributors: ateeducacion
-Tags: ate, tasks, board, kanban
+Tags: documentos, resoluciones, docx, pdf, opentbs
 Requires at least: 6.1
 Tested up to: 7.0
-Requires PHP: 8.4
+Requires PHP: 8.3
 Stable tag: 0.0.0
 License: GPL-3.0
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
-Official resolution generator with structured sections and DOCX export.
+Generador de resoluciones y documentos administrativos estructurados a partir de plantillas ODT/DOCX, con exportación a DOCX y PDF.
 
 == Description ==
 
-Documentate es un plugin de WordPress desarrollado en el ATE para crear resoluciones digitales con estructura de secciones, taxonomías de ámbitos y leyes, y exportación a DOCX (y próximamente PDF).
+Documentate es un plugin de WordPress desarrollado en el ATE para crear resoluciones y documentos administrativos estructurados a partir de plantillas ODT/DOCX.
 
-### Key Features
+Utiliza OpenTBS para combinar los datos del documento con la plantilla y permite convertir a PDF/DOCX mediante Collabora Online (en el servidor) o LibreOffice WASM (en el navegador).
 
-– **Import from Nextcloud Deck through API**: Imports boards and cards from Nextcloud.  
-– **Customization**: Adjustable settings available in the WordPress admin panel.  
-– **Multisite Support**: Fully compatible with WordPress multisite installations.  
-– **WordPress Coding Standards Compliance**: Adheres to [WordPress Coding Standards](https://github.com/WordPress/WordPress-Coding-Standards).  
-– **Continuous Integration Pipeline**: Set up for automated code verification and release generation on GitHub.  
+### Características
+
+– **Tipos de documento (plantillas)**: definidos como taxonomía con campos basados en un esquema.
+– **Generación de ODT/DOCX** a partir de plantillas mediante OpenTBS.
+– **Conversión opcional a PDF** (y entre formatos ofimáticos) con Collabora Online (servidor) o LibreOffice WASM (navegador, experimental).
+– **Filtrado por ámbito de usuario** (categorías jerárquicas) para controlar la visibilidad de los documentos.
+– **Flujo de trabajo, revisiones, adjuntos y edición colaborativa.**
+– **Compatible con multisitio.**
 
 == Installation ==
 
-1. Download the plugin from the WordPress Plugin Directory.
-2. Upload the plugin to your WordPress site via **Plugins > Add New > Upload Plugin**.
-3. Activate the plugin through the 'Plugins' menu in WordPress.
-4. Configure the plugin under 'Settings'.
+1. Descarga la última versión desde la página de *releases* de GitHub.
+2. Sube el plugin a tu sitio mediante **Plugins > Añadir nuevo > Subir plugin**.
+3. Activa el plugin desde el menú 'Plugins'.
+4. Configura el motor de conversión y las demás opciones en **Ajustes > Documentate**.
 
 == Frequently Asked Questions ==
 
-= How do I connect the plugin to Nextcloud Deck? =  
-Go to the Import from NextCloud page, and enter your Nextcloud API credentials (URL and API token).
+= ¿Qué motores de conversión admite? =
+Collabora Online (en el servidor, recomendado) y LibreOffice WASM (en el navegador, experimental).
 
-= Can I use this plugin without Nextcloud Deck? =  
-Yes, the plugin independant, Nextcloud is only to oneway import.
+= ¿Cómo se controla quién ve cada documento? =
+Mediante un ámbito por usuario (categorías jerárquicas). Los administradores ven todos los documentos; el resto solo los de su ámbito y sus subcategorías.
 
 == Screenshots ==
 
-1. **Editor de resolución**  
-   Campos meta para Objeto, Antecedentes, Fundamentos, Parte dispositiva y Firma.  
+1. **Editor de resolución**
+   Campos meta para las distintas secciones del documento.
 
-2. **Exportación DOCX**  
-   Genera documentos Word con formato básico (Times 12).  
+2. **Exportación DOCX/PDF**
+   Genera documentos a partir de plantillas ODT/DOCX.

--- a/tests/unit/admin/DocumentateAvatarsAjaxTest.php
+++ b/tests/unit/admin/DocumentateAvatarsAjaxTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * AJAX tests for Documentate_Admin::ajax_get_user_avatars().
+ *
+ * @package Documentate
+ */
+
+/**
+ * @covers Documentate_Admin::ajax_get_user_avatars
+ */
+class DocumentateAvatarsAjaxTest extends WP_Ajax_UnitTestCase {
+
+	/**
+	 * The avatar AJAX handler rejects users who cannot edit posts.
+	 */
+	public function test_ajax_get_user_avatars_denies_users_without_edit_posts() {
+		$subscriber = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber );
+
+		$_POST['nonce']    = wp_create_nonce( 'documentate_collab_avatars' );
+		$_REQUEST['nonce'] = $_POST['nonce'];
+		$_POST['user_ids'] = array( $subscriber );
+
+		try {
+			$this->_handleAjax( 'documentate_get_collab_avatars' );
+			$this->fail( 'The handler should have terminated the request for an unauthorized user.' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		$response = json_decode( $this->_last_response, true );
+
+		$this->assertIsArray( $response );
+		$this->assertFalse( $response['success'] );
+	}
+
+	/**
+	 * The avatar AJAX handler returns data for users who can edit posts.
+	 */
+	public function test_ajax_get_user_avatars_allows_editors() {
+		$editor = $this->factory->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor );
+
+		$_POST['nonce']    = wp_create_nonce( 'documentate_collab_avatars' );
+		$_REQUEST['nonce'] = $_POST['nonce'];
+		$_POST['user_ids'] = array( $editor );
+
+		try {
+			$this->_handleAjax( 'documentate_get_collab_avatars' );
+			$this->fail( 'The handler should have terminated the request after sending JSON.' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		$response = json_decode( $this->_last_response, true );
+
+		$this->assertIsArray( $response );
+		$this->assertTrue( $response['success'] );
+		$this->assertArrayHasKey( (string) $editor, $response['data'] );
+	}
+}

--- a/tests/unit/includes/DocumentateDemoDataTest.php
+++ b/tests/unit/includes/DocumentateDemoDataTest.php
@@ -127,4 +127,48 @@ class DocumentateDemoDataTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( '<strong>', $options['alert_message'] );
 		$this->assertStringContainsString( '</strong>', $options['alert_message'] );
 	}
+
+	/**
+	 * Demo seeding is permitted in the test (non-production) environment.
+	 */
+	public function test_should_allow_demo_seeding_in_non_production() {
+		$this->assertTrue( Documentate_Demo_Data::should_allow_demo_seeding() );
+	}
+
+	/**
+	 * Demo seeding is permitted inside WordPress Playground.
+	 */
+	public function test_should_allow_demo_seeding_in_playground() {
+		$_SERVER['HTTP_X_WORDPRESS_PLAYGROUND'] = '1';
+
+		$this->assertTrue( Documentate_Demo_Data::should_allow_demo_seeding() );
+
+		unset( $_SERVER['HTTP_X_WORDPRESS_PLAYGROUND'] );
+	}
+
+	/**
+	 * Demo login accounts are created when the seed flag is set and seeding is allowed.
+	 */
+	public function test_maybe_seed_demo_users_creates_accounts_when_allowed() {
+		update_option( 'documentate_seed_demo_documents', true );
+
+		Documentate_Demo_Data::maybe_seed_demo_users();
+
+		$this->assertNotEmpty( username_exists( 'editor1' ) );
+		$this->assertNotEmpty( username_exists( 'author1' ) );
+		$this->assertNotEmpty( username_exists( 'subscriber1' ) );
+
+		delete_option( 'documentate_seed_demo_documents' );
+	}
+
+	/**
+	 * No demo accounts are created when the seed flag is absent.
+	 */
+	public function test_maybe_seed_demo_users_skips_without_seed_flag() {
+		delete_option( 'documentate_seed_demo_documents' );
+
+		Documentate_Demo_Data::maybe_seed_demo_users();
+
+		$this->assertEmpty( username_exists( 'editor1' ) );
+	}
 }

--- a/tests/unit/includes/DocumentateRestCommentProtectionTest.php
+++ b/tests/unit/includes/DocumentateRestCommentProtectionTest.php
@@ -77,6 +77,15 @@ class DocumentateRestCommentProtectionTest extends WP_UnitTestCase {
 
 		wp_set_current_user( 0 );
 
+		// Pin protection to this test's fixture CPT so the suite is independent of
+		// the production default (which targets 'documentate_document').
+		add_filter(
+			'documentate/protected_comment_post_types',
+			static function () {
+				return array( 'documentate_task' );
+			}
+		);
+
 		require_once plugin_dir_path( DOCUMENTATE_PLUGIN_FILE ) . 'includes/class-documentate-rest-comment-protection.php';
 		$this->protection = new Documentate_REST_Comment_Protection();
 	}


### PR DESCRIPTION
## Summary

A focused optimization & simplification pass from a full read-only audit (correctness/security, performance, tech-debt). Small, self-contained changes only — the larger refactors (splitting the 4273-line OpenTBS god object, autoloading, ZIP-rewrite consolidation) are intentionally **deferred**. Net change is a slight reduction in code (−114 / +112).

## Security

- **Demo seeding is now gated to non-production + Playground.** Production activation no longer creates the `editor1`/`author1`/`subscriber1` login accounts (which shipped with the password `password`). A new `Documentate_Demo_Data::should_allow_demo_seeding()` reuses the existing `is_playground()` detection plus `wp_get_environment_type()`. `WP_ENVIRONMENT_TYPE=local` is set in the wp-env configs so local/dev/Playground keep seeding.
  - ⚠️ **Operator action:** on any site where the plugin was already activated, delete/rotate any existing `editor1`/`author1`/`subscriber1` accounts — a shipped credential is burned even after this fix.
- **REST comment protection** now defaults to the real CPT `documentate_document` instead of the removed `documentate_task`, so the control is self-sufficient (previously it only worked via a second class's filter).
- **AJAX `ajax_get_user_avatars`** now checks `current_user_can('edit_posts')` (it only verified the nonce before — a user-enumeration gap).
- **Collabora "disable SSL verification"** toggle is now inert on `production`, so official documents can't be sent over an unverified connection there.
- Dropped `@`-error-suppression on the demo fixture import path.

## Performance

- Admin document-list filter bar: cache the `has_published_posts` author query in a short transient and cap the category dropdown (`number => 200`) so it can't materialise an unbounded list.
- Workflow assets use `DOCUMENTATE_VERSION` instead of `filemtime()` for cache-busting (removes 2 `stat()` calls per edit-screen render; consistent with the rest of the plugin).

## Simplification / cleanup

- Removed the no-op `maybe_create_demo_data` hook+method, the empty `define_public_hooks`, and stale "Removed …" scar comments in the bootstrap.
- Routed all `collaborative_enabled` reads through the existing `Documentate_Admin::is_collaborative_enabled()` accessor.
- Delegated the byte-duplicate `find_next_html_match` to `OpenTBS_HTML_Parser`.
- Renamed stale `resolate*` `.gitignore` patterns to `documentate*`.
- Added `Requires PHP: 8.3` / `Requires at least: 6.1` to the plugin header; rewrote the stale `readme.txt` (`Requires PHP: 8.4` → `8.3`; removed leftover Kanban / Nextcloud Deck copy from the old *Resolate* plugin).

## Tests

- Pinned the REST comment-protection test to its fixture CPT via the `documentate/protected_comment_post_types` filter so it's independent of the production default.

## Deferred (follow-ups, not in this PR)

- **TD-01 / TD-02** — wiring the tested SRP handler classes as delegators / collapsing the field wrappers: the god-object and handler bodies are functionally equivalent but not byte-identical, so it needs the CPT/revision suites to validate.
- **PERF-04 / PERF-05** — per-request memoization: relies on PHP static caches that need test validation.
- **PERF-01/02, TD-04, uninstall.php cleanup** — larger/riskier structural work.

## Verification

- `mago lint` (whole tree) passes locally (exit 0).
- The Docker suites (`make test`, `make check-plugin`, `make test-e2e`) were **not** run locally due to a wp-env port conflict with other local projects — relying on CI for those.
