### PR TITLE
Prevent fork pull requests from running CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ env:
 
 jobs:
   playground:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -95,6 +96,7 @@ jobs:
             }
 
   lint_and_test:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -193,6 +195,7 @@ jobs:
           fail_ci_if_error: false
 
   e2e:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/phpmd.yml
+++ b/.github/workflows/phpmd.yml
@@ -30,6 +30,7 @@ permissions:
 jobs:
   PHPMD:
     name: Run PHPMD scanning
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read # for checkout to fetch code


### PR DESCRIPTION
## Summary

- skip the Playground, lint/test, and Playwright jobs for pull requests originating from forks
- skip the PHPMD scan for pull requests originating from forks
- preserve pushes, scheduled scans, and same-repository pull requests

## Security rationale

These workflows install Composer and npm dependencies, start Docker-based WordPress environments, execute tests, and use write-capable permissions for checks, deployments, pull requests, and security events. Restricting fork-originated jobs prevents untrusted code from consuming runner resources or executing in write-capable jobs.