### PR TITLE
Cover Cloudflare Worker dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,3 +41,12 @@ updates:
       - dependency-name: "@wordpress/scripts"
         versions: [">=32.3.0"]
 
+  # 4. npm (Cloudflare Worker)
+  - package-ecosystem: "npm"
+    directory: "/cloudflare-worker"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

- keep the existing root npm, Composer and GitHub Actions update rules
- add weekly npm updates for the independent `/cloudflare-worker` package
- preserve the existing WordPress package compatibility ignores

This ensures the Worker lockfile is maintained separately from the root project.