### PR TITLE
chore(deps): pin Composer dependency ranges

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,20 +1,20 @@
 {
     "require": {
-        "tinybutstrong/tinybutstrong": "*",
-        "tinybutstrong/opentbs": "*"
+        "tinybutstrong/tinybutstrong": "^3.15.3",
+        "tinybutstrong/opentbs": "^1.12.3"
     },
     "require-dev": {
         "brianium/paratest": "^6.11",
         "carthage-software/mago": "^1.13",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.1",
         "phpmd/phpmd": "^2.15",
-        "phpunit/phpunit": "*",
+        "phpunit/phpunit": "^9.6.35",
         "squizlabs/php_codesniffer": "^3.13.5",
-        "wp-cli/i18n-command": "*",
+        "wp-cli/i18n-command": "^2.7.0",
         "wp-coding-standards/wpcs": "^3.4",
-        "wp-phpunit/wp-phpunit": "*",
-        "yoast/phpunit-polyfills": "*",
-        "yoast/wp-test-utils": "*"
+        "wp-phpunit/wp-phpunit": "^7.0.2",
+        "yoast/phpunit-polyfills": "^1.1.5",
+        "yoast/wp-test-utils": "^1.2.1"
     },
     "scripts": {
         "post-install-cmd": [


### PR DESCRIPTION
## Summary

- replace wildcard production constraints with compatible ranges based on the versions currently locked
- pin direct development dependencies that previously used `*`
- keep `composer.lock` to preserve reproducible installations

## Dependency ranges

- `tinybutstrong/tinybutstrong`: `^3.15.3`
- `tinybutstrong/opentbs`: `^1.12.3`
- `phpunit/phpunit`: `^9.6.35`
- `wp-cli/i18n-command`: `^2.7.0`
- `wp-phpunit/wp-phpunit`: `^7.0.2`
- `yoast/phpunit-polyfills`: `^1.1.5`
- `yoast/wp-test-utils`: `^1.2.1`

## Validation

- ranges were selected from the versions already present in `composer.lock`
- no locked package versions were changed
- local Composer validation and tests could not be run because Composer and external network access are unavailable in the execution environment

## Follow-up

The lockfile should be refreshed with `composer update --lock` if CI reports that its content hash is stale. This should only update lock metadata, not package versions.