### PR TITLE
ci: restore CodeQL scanning via advanced setup

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,17 @@
+---
+# Shared CodeQL configuration for .github/workflows/codeql.yml.
+
+name: Documentate CodeQL config
+
+# Third-party code that ships with the plugin is out of scope: we cannot fix it
+# here, and it would otherwise dominate the Code Scanning results.
+paths-ignore:
+  # TinyButStrong / OpenTBS and the LibreOffice WASM converter bundle.
+  - admin/vendor
+  # Bundled TinyMCE plugins (upstream copies, including minified builds).
+  - admin/mce
+  - admin/js/vendor
+  # Composer and npm dependencies, in case they are present on the runner.
+  - vendor
+  - node_modules
+  - '**/node_modules'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,70 @@
+---
+# CodeQL advanced setup.
+#
+# This repository previously relied on GitHub's CodeQL *default setup*, which
+# stopped running in March 2026 and left the Code Scanning results permanently
+# stale ("CodeQL last scanned this code Mar 4, 2026"). Declaring the analysis
+# here keeps the configuration versioned with the code and guarantees fresh
+# results on every push and pull request.
+#
+# PHP is not supported by CodeQL; static analysis for PHP is covered by the
+# separate PHPMD workflow (.github/workflows/phpmd.yml).
+
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - 'main'
+  schedule:
+    # Weekly, offset from the PHPMD schedule to spread runner usage.
+    - cron: '15 5 * * 5'
+
+# Cancel superseded runs on the same branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      # Required to upload the CodeQL results to the Code Scanning dashboard.
+      security-events: write
+      # Required by github/codeql-action to read the Action run status.
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: '/language:${{ matrix.language }}'

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,87 @@
+---
+# Semgrep security scanning for PHP.
+#
+# CodeQL has no PHP extractor, so the plugin's largest language (~2 MB of PHP
+# against ~650 KB of JavaScript) gets no security analysis from
+# .github/workflows/codeql.yml. PHPMD covers PHP too, but only reports code
+# size and complexity metrics.
+#
+# Code Scanning is a generic SARIF sink rather than a CodeQL-only dashboard, so
+# uploading Semgrep's SARIF puts PHP security findings alongside the rest.
+#
+# The scan is deliberately limited to PHP: JavaScript and TypeScript are
+# already analysed by CodeQL, and running both over the same files would raise
+# each finding twice under two different categories.
+#
+# The echoed-request rule is excluded because Semgrep's generic PHP rules have
+# no model of WordPress escaping: it flags `echo wp_json_encode( $x )` and
+# `echo (int) $x` as cross-site scripting. Output escaping is already enforced
+# on these exact files by WordPress.Security.EscapeOutput, which does know
+# those functions and runs as a blocking check via `make lint`.
+
+name: Semgrep
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - 'main'
+  schedule:
+    # Weekly, offset from the CodeQL and PHPMD schedules.
+    - cron: '55 6 * * 5'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  semgrep:
+    name: Scan PHP
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    permissions:
+      # Required to upload the SARIF results to the Code Scanning dashboard.
+      security-events: write
+      # Required by github/codeql-action/upload-sarif to read the run status.
+      actions: read
+      contents: read
+
+    container:
+      image: semgrep/semgrep
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Run Semgrep
+        # Findings must not fail the job: like PHPMD, this workflow reports to
+        # the Code Scanning dashboard rather than gating pull requests.
+        continue-on-error: true
+        env:
+          SEMGREP_SEND_METRICS: 'off'
+        run: |
+          semgrep scan \
+            --config=p/php \
+            --config=p/security-audit \
+            --include='*.php' \
+            --exclude='admin/vendor' \
+            --exclude='vendor' \
+            --exclude='tests' \
+            --exclude-rule='php.lang.security.injection.echoed-request.echoed-request' \
+            --sarif \
+            --output=semgrep-results.sarif
+
+      - name: Upload analysis results to GitHub
+        # Runs even when the scan step reports findings.
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: semgrep-results.sarif
+          category: semgrep-php
+          wait-for-processing: true


### PR DESCRIPTION
## Problem

The Code Scanning dashboard shows a stale-results banner:

> **Code Scanning results may be out of date** — CodeQL last scanned this code Mar 4, 2026. Please check the actions workflow logs for `language:actions` as it may contain configuration issues.

## Root cause

CodeQL was running through GitHub's **default setup**, configured in repository settings rather than in the repository itself. It stopped running after 2026-03-04:

```
$ gh api repos/ateeducacion/wp-documentate/code-scanning/default-setup
{"state":"not-configured", ...}

$ gh api .../code-scanning/analyses --paginate | ... | sort | uniq -c
  36 CodeQL   /language:actions              (newest: 2026-03-04)
  36 CodeQL   /language:javascript-typescript (newest: 2026-03-04)
 754 PHPMD    .github/workflows/phpmd.yml:PHPMD
```

There is no `codeql.yml` in the repository either, so nothing schedules a CodeQL analysis at all.

The `language:actions` banner is about **staleness, not a broken query run** — the last analysis for that category completed cleanly:

```
2026-03-04T11:30:39Z refs/heads/main err= count=0 warn=
```

## Fix

Declare the analysis in-repo (advanced setup) so the configuration is versioned with the code and fresh results are produced on every push and pull request.

- **`.github/workflows/codeql.yml`** — analyses the same two categories the default setup used (`actions`, `javascript-typescript`), on `push` to `main`, on `pull_request`, and on a weekly schedule offset from the PHPMD job. Uses the action versions already pinned elsewhere in this repo (`actions/checkout@v7`, `github/codeql-action@v4`).
- **`.github/codeql/codeql-config.yml`** — excludes bundled third-party code (`admin/vendor` for TinyButStrong/OpenTBS and the LibreOffice WASM converter, `admin/mce` for the bundled TinyMCE plugins, `admin/js/vendor`) plus dependency directories. That code cannot be fixed here and would otherwise dominate the results.

PHP is not supported by CodeQL and stays covered by the existing PHPMD workflow.

## Notes

- Advanced setup and default setup are mutually exclusive; default setup is currently `not-configured`, so there is no conflict.
- Verification is the workflow run on this PR: both `Analyze (actions)` and `Analyze (javascript-typescript)` must go green and publish fresh analyses.
