### PR TITLE
fix(security): patch two XSS sinks, and stabilise the document types E2E test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,10 +131,16 @@ jobs:
       - name: Run WordPress Coding Standards
         run: make lint
 
+      - name: Install npm dependencies
+        run: npm ci
+
+      # Runs before wp-env so a JS regression fails in seconds rather than
+      # after the container boot and the PHP suite.
+      - name: Run JavaScript unit tests
+        run: npm run test:unit-js
+
       - name: Start wp-env with coverage
-        run: |
-          npm ci
-          npx wp-env start --config=.wp-env.docker.json --xdebug=coverage
+        run: npx wp-env start --config=.wp-env.docker.json --xdebug=coverage
 
       - name: Run plugin check
         run: make check-plugin

--- a/admin/js/documentate-admin.js
+++ b/admin/js/documentate-admin.js
@@ -2,6 +2,35 @@
 	'use strict';
 
 	/**
+	 * Extract the visible text of an HTML fragment.
+	 *
+	 * Parsed with DOMParser rather than assigned to innerHTML. A detached node
+	 * still belongs to the active document, so it fetches resources and
+	 * <img src=x onerror=...> stored in an editor used to run here. A document
+	 * from parseFromString has no browsing context: it neither runs scripts nor
+	 * loads resources.
+	 *
+	 * Real parsing is required, not a tag-stripping regex: callers compare the
+	 * result against '' to detect an empty field, and only a parser decodes
+	 * entities (&#160;) and understands '>' inside an attribute value.
+	 *
+	 * @param {string} html Raw field value, possibly containing markup.
+	 * @return {string} Trimmed visible text.
+	 */
+	function extractPlainText(html) {
+		var parsed = new DOMParser().parseFromString(String(html), 'text/html');
+		return (parsed.body.textContent || '').trim();
+	}
+
+	// Expose the extraction helper to the unit tests. WordPress serves this
+	// file as a plain script, where `module` is undefined, so the browser
+	// never takes this branch and the handler below is always registered.
+	if (typeof module !== 'undefined' && module.exports) {
+		module.exports = { extractPlainText: extractPlainText };
+		return;
+	}
+
+	/**
 	 * Get the text content of a TinyMCE or textarea rich editor.
 	 *
 	 * @param {HTMLElement} el The textarea or container element.
@@ -21,12 +50,7 @@
 			}
 		}
 
-		// Strip HTML tags and trim whitespace. Parse into an inert document
-		// rather than assigning to innerHTML: a detached node still loads
-		// resources, so markup such as <img src=x onerror=...> stored in the
-		// editor would run here.
-		var parsed = new DOMParser().parseFromString(textarea.value, 'text/html');
-		return (parsed.body.textContent || '').trim();
+		return extractPlainText(textarea.value);
 	}
 
 	/**
@@ -119,4 +143,7 @@
 		}
 	});
 
-})(jQuery);
+// jQuery is always present in the admin, where WordPress enqueues it as a
+// dependency. The guard is for the unit tests, which require this file
+// directly to reach extractPlainText() and never touch the jQuery handlers.
+})(typeof jQuery !== 'undefined' ? jQuery : undefined);

--- a/admin/js/documentate-admin.js
+++ b/admin/js/documentate-admin.js
@@ -4,11 +4,13 @@
 	/**
 	 * Extract the visible text of an HTML fragment.
 	 *
-	 * Parsed with DOMParser rather than assigned to innerHTML. A detached node
-	 * still belongs to the active document, so it fetches resources and
-	 * <img src=x onerror=...> stored in an editor used to run here. A document
-	 * from parseFromString has no browsing context: it neither runs scripts nor
-	 * loads resources.
+	 * Parsed with DOMParser rather than assigned to innerHTML. The parsed
+	 * document has no browsing context, so scripting is disabled: neither
+	 * scripts nor inline event handlers run. Assigning to innerHTML on a
+	 * detached node gives no such guarantee — the node still belongs to the
+	 * active document, so <img src=x onerror=...> stored in an editor executed
+	 * its handler here. The parsed tree is never inserted anywhere; only
+	 * body.textContent is read.
 	 *
 	 * Real parsing is required, not a tag-stripping regex: callers compare the
 	 * result against '' to detect an empty field, and only a parser decodes

--- a/admin/js/documentate-admin.js
+++ b/admin/js/documentate-admin.js
@@ -21,10 +21,12 @@
 			}
 		}
 
-		// Strip HTML tags and trim whitespace.
-		var tmp = document.createElement('div');
-		tmp.innerHTML = textarea.value;
-		return (tmp.textContent || tmp.innerText || '').trim();
+		// Strip HTML tags and trim whitespace. Parse into an inert document
+		// rather than assigning to innerHTML: a detached node still loads
+		// resources, so markup such as <img src=x onerror=...> stored in the
+		// editor would run here.
+		var parsed = new DOMParser().parseFromString(textarea.value, 'text/html');
+		return (parsed.body.textContent || '').trim();
 	}
 
 	/**

--- a/admin/js/documentate-collaborative-editor.js
+++ b/admin/js/documentate-collaborative-editor.js
@@ -875,12 +875,6 @@
 	}
 
 	/**
-	 * Render user avatars in the metabox.
-	 *
-	 * @param {HTMLElement} container - Container element for avatars
-	 * @param {Map}         users     - Map of unique users (keyed by userId)
-	 */
-	/**
 	 * Build a collaborator avatar image.
 	 *
 	 * Both values come from Yjs awareness state, which every peer in the room
@@ -898,6 +892,12 @@
 		return img;
 	}
 
+	/**
+	 * Render user avatars in the metabox.
+	 *
+	 * @param {HTMLElement} container - Container element for avatars
+	 * @param {Map}         users     - Map of unique users (keyed by userId)
+	 */
 	async function renderUserAvatars(container, users) {
 		container.innerHTML = '';
 

--- a/admin/js/documentate-collaborative-editor.js
+++ b/admin/js/documentate-collaborative-editor.js
@@ -880,6 +880,24 @@
 	 * @param {HTMLElement} container - Container element for avatars
 	 * @param {Map}         users     - Map of unique users (keyed by userId)
 	 */
+	/**
+	 * Build a collaborator avatar image.
+	 *
+	 * Both values come from Yjs awareness state, which every peer in the room
+	 * sets for itself, so they are attacker controlled. Assign them as
+	 * properties rather than interpolating into markup.
+	 *
+	 * @param {string} src - Avatar URL.
+	 * @param {string} alt - Collaborator name.
+	 * @return {HTMLImageElement} The avatar image element.
+	 */
+	function buildAvatarImage(src, alt) {
+		const img = document.createElement('img');
+		img.src = src;
+		img.alt = alt || '';
+		return img;
+	}
+
 	async function renderUserAvatars(container, users) {
 		container.innerHTML = '';
 
@@ -908,9 +926,9 @@
 
 			const cached = metaboxState.avatarCache.get(user.userId);
 			if (cached && cached.avatar) {
-				avatarEl.innerHTML = `<img src="${cached.avatar}" alt="${cached.name || user.name}" />`;
+				avatarEl.appendChild(buildAvatarImage(cached.avatar, cached.name || user.name));
 			} else if (user.avatar) {
-				avatarEl.innerHTML = `<img src="${user.avatar}" alt="${user.name}" />`;
+				avatarEl.appendChild(buildAvatarImage(user.avatar, user.name));
 			} else {
 				// Fallback: initial letter with cursor color
 				const initial = (user.name || 'U').charAt(0).toUpperCase();

--- a/tests/e2e/page-objects/document-types.page.js
+++ b/tests/e2e/page-objects/document-types.page.js
@@ -144,12 +144,19 @@ class DocumentTypesPage {
 
 	/**
 	 * Navigate to the document types list page.
+	 *
+	 * @param {string} [search] - Restrict the list to terms matching this text.
+	 *                            The list paginates at 20, so assertions that
+	 *                            look for one term must narrow it rather than
+	 *                            rely on the term landing on the first page.
 	 */
-	async navigate() {
-		await this.admin.visitAdminPage(
-			'edit-tags.php',
-			'taxonomy=documentate_doc_type&post_type=documentate_document'
-		);
+	async navigate( search ) {
+		let query = 'taxonomy=documentate_doc_type&post_type=documentate_document';
+		if ( search ) {
+			query += `&s=${ encodeURIComponent( search ) }`;
+		}
+
+		await this.admin.visitAdminPage( 'edit-tags.php', query );
 		await this.page.waitForLoadState( 'domcontentloaded' );
 	}
 
@@ -189,14 +196,24 @@ class DocumentTypesPage {
 			await this.descriptionField.fill( description );
 		}
 
-		await this.submitButton.click();
-
-		// Wait for AJAX response
-		await this.page.waitForResponse(
-			( response ) =>
-				response.url().includes( 'admin-ajax.php' ) ||
-				response.url().includes( 'edit-tags.php' )
+		// Start listening before the click. waitForResponse() only sees
+		// responses that arrive after it is called, so registering it
+		// afterwards loses the race whenever the server answers quickly.
+		const response = this.page.waitForResponse(
+			( res ) =>
+				res.url().includes( 'admin-ajax.php' ) ||
+				res.url().includes( 'edit-tags.php' )
 		);
+
+		await this.submitButton.click();
+		await response;
+
+		// The row is appended by the AJAX handler after the response lands.
+		await this.page
+			.locator( '#the-list' )
+			.getByRole( 'link', { name, exact: true } )
+			.first()
+			.waitFor( { state: 'attached' } );
 	}
 
 	/**

--- a/tests/e2e/specs/document-types.spec.js
+++ b/tests/e2e/specs/document-types.spec.js
@@ -14,7 +14,7 @@ test.describe( 'Document Types Management', () => {
 		await documentTypes.expectOnListPage( expect );
 	} );
 
-	test( 'can create new document type with name', async ( { documentTypes, page } ) => {
+	test( 'can create new document type with name', async ( { documentTypes } ) => {
 		await documentTypes.navigate();
 
 		const typeName = `Test Type ${ Date.now() }`;
@@ -22,8 +22,11 @@ test.describe( 'Document Types Management', () => {
 		// Create the document type
 		await documentTypes.create( { name: typeName } );
 
-		// Reload and verify the new type appears in the list
-		await page.reload();
+		// Reload filtered by name: the list paginates at 20, so a fresh term
+		// is not guaranteed to appear on the first page once the site has a
+		// realistic number of document types. Asserting on the unfiltered
+		// first page is what made this test fail as data accumulated.
+		await documentTypes.navigate( typeName );
 
 		await documentTypes.expectTermExists( expect, typeName );
 	} );

--- a/tests/js/documentate-admin-rich-text.test.js
+++ b/tests/js/documentate-admin-rich-text.test.js
@@ -1,0 +1,63 @@
+/**
+ * Regression tests for the rich editor emptiness check.
+ *
+ * The required-field validation in documentate-admin.js treats a field as
+ * empty when this returns ''. Getting that wrong lets a visually empty field
+ * pass a `required` check, so the cases below pin the behaviour that a
+ * tag-stripping regex silently got wrong: numeric entities, '>' inside an
+ * attribute value, and comments.
+ */
+const { extractPlainText } = require( '../../admin/js/documentate-admin.js' );
+
+describe( 'extractPlainText', () => {
+	describe( 'treats visually empty markup as empty', () => {
+		it.each( [
+			[ 'empty string', '' ],
+			[ 'empty paragraph', '<p></p>' ],
+			[ 'TinyMCE bogus break', '<p><br data-mce-bogus="1"></p>' ],
+			[ 'named entity', '<p>&nbsp;</p>' ],
+			[ 'decimal numeric entity', '<p>&#160;</p>' ],
+			[ 'hex numeric entity', '<p>&#xA0;</p>' ],
+			[ 'attribute containing >', '<p title="1 > 0"></p>' ],
+			[ 'comment only', '<!-- nota interna -->' ],
+			[ 'nested empty blocks', '<div><p></p><p>&#160;</p></div>' ],
+			[ 'whitespace only', '   \n\t  ' ],
+			[ 'image with onerror', '<img src=x onerror=alert(1)>' ],
+		] )( '%s', ( _label, html ) => {
+			expect( extractPlainText( html ) ).toBe( '' );
+		} );
+	} );
+
+	describe( 'preserves real content', () => {
+		it.each( [
+			[ 'plain paragraph', '  <p>Hola</p> ', 'Hola' ],
+			[ 'adjacent paragraphs', '<p>a</p><p>b</p>', 'ab' ],
+			[ 'decoded ampersand', '<p>&amp;</p>', '&' ],
+			[ 'text beside an attribute containing >', '<p title="1 > 0">Texto</p>', 'Texto' ],
+			[ 'text after a comment', '<!-- nota --><p>Visible</p>', 'Visible' ],
+			[ 'nested markup', '<div><strong>Negrita</strong></div>', 'Negrita' ],
+		] )( '%s', ( _label, html, expected ) => {
+			expect( extractPlainText( html ) ).toBe( expected );
+		} );
+	} );
+
+	describe( 'tolerates non-string input', () => {
+		it( 'coerces null and undefined without throwing', () => {
+			expect( extractPlainText( null ) ).toBe( 'null' );
+			expect( extractPlainText( undefined ) ).toBe( 'undefined' );
+		} );
+	} );
+
+	it( 'does not execute scripts in the parsed markup', () => {
+		const spy = jest.fn();
+		global.__documentateXssProbe = spy;
+
+		extractPlainText(
+			'<script>global.__documentateXssProbe()</script>' +
+				'<img src=x onerror="global.__documentateXssProbe()">'
+		);
+
+		expect( spy ).not.toHaveBeenCalled();
+		delete global.__documentateXssProbe;
+	} );
+} );


### PR DESCRIPTION
Two independent fixes, one commit each.

## 1. Cross-site scripting

### The reported one — `documentate-admin.js`

`getRichEditorText()` assigned the editor's raw value to `innerHTML` on a detached `div`, purely to strip tags and read the text back:

```js
var tmp = document.createElement('div');
tmp.innerHTML = textarea.value;
return (tmp.textContent || tmp.innerText || '').trim();
```

Being detached does **not** make this inert — the node still belongs to the active document, with scripting enabled, so the `onerror` handler of `<img src=x onerror=...>` saved in a document fires the moment an editor triggers form validation. That is a stored XSS reachable by any contributor who can save content, and it is the CodeQL `js/xss-through-dom` alert.

Replaced with `DOMParser`, extracted into `extractPlainText()`:

```js
var parsed = new DOMParser().parseFromString(String(html), 'text/html');
return (parsed.body.textContent || '').trim();
```

A document from `parseFromString` has **no browsing context, so scripting is disabled**: neither scripts nor inline event handlers run. That is precisely the difference from `innerHTML` on a detached node, which still belongs to the active document and did fire the `onerror` handler. The parsed tree is never inserted anywhere; only `body.textContent` is read.

(Note the guarantee is scoped deliberately: the spec disables *scripting*, it does not promise that no subresource is ever fetched. The fix rests on handlers not executing.)

**CodeQL flags this line, and that flag is a false positive** — dismissed as such on alert #521. The rule fires on any HTML parse of untrusted text without distinguishing the inert case. Two alternatives were tried and rejected:

- **A tag-stripping regex.** It removed the sink but broke correctness. `<p>&#160;</p>`, `<p>&#xA0;</p>` and `<p title="1 > 0"></p>` all came back non-empty, so a visually empty field would pass a `required` check. Real parsing is the only thing that decodes entities and understands `>` inside an attribute value.
- **`editor.getContent({ format: 'text' })`.** Asking TinyMCE for its own text looked cleanest and **broke saving**: `getContent()` fires TinyMCE's `SaveContent` handlers, and WordPress's integration writes that result back into the textarea, overwriting the HTML `save()` had just put there. Documents saved empty. Caught by two rich-content E2E specs.

Correctness wins over silencing the linter.

### A second one, not reported — `documentate-collaborative-editor.js`

Found while auditing the other `innerHTML` sites. CodeQL does not flag it, and it is the more serious of the two:

```js
avatarEl.innerHTML = `<img src="${user.avatar}" alt="${user.name}" />`;
```

`user` comes from `awareness.getStates()` — Yjs state that **every peer in the room publishes about itself** via the signaling server. The default signaling server is `wss://signaling.yjs.dev`, which is public, so the room is not private either. A peer whose display name is `"><img src=x onerror=...>` breaks out of the quoted attribute and runs code in every other editor's browser.

Fixed by building the element and assigning `src` and `alt` as properties.

### Checked and left alone

- `escapeHtml()` in `documentate-revisions.js` and `documentate-actions.js` — the safe idiom (`textContent` in, `innerHTML` out).
- `createToolbarHTML()` — interpolates only an internal DOM id.

### Regression test

`tests/js/documentate-admin-rich-text.test.js` pins the emptiness contract this validation depends on — 19 cases covering exactly what the regex attempt got wrong:

| Input | Expected |
|---|---|
| `<p>&nbsp;</p>`, `<p>&#160;</p>`, `<p>&#xA0;</p>` | `""` — empty |
| `<p title="1 > 0"></p>` | `""` — empty |
| `<!-- nota interna -->` | `""` — empty |
| `<img src=x onerror=alert(1)>` | `""`, and never executed |
| `<p>&amp;</p>` | `"&"` — decoded |
| `<p title="1 > 0">Texto</p>` | `"Texto"` |

**The tests were verified to catch the bug**: swapping the regex implementation back in makes 6 of them fail.

`extractPlainText` is exported under CommonJS so the tests can reach it, and the IIFE argument tolerates a missing jQuery. WordPress serves this file as a plain script where `module` is undefined, so neither branch is taken in the browser and runtime behaviour is unchanged.

## 2. The flaky document-types E2E test

`document-types.spec.js` "can create new document type with name" failed intermittently, and reliably once enough test data existed.

**Root cause.** The test creates `Test Type <timestamp>` and never removes it, while the assertion looked for the new row on the *unfiltered first page* of a list WordPress paginates at 20. Every run leaks one term; after enough runs the new term lands on page 2. The environment where this was investigated had 35 document types, **18 of them left over from earlier runs**. That also explains why CI, which starts from a fresh site, mostly passed.

Fixed by reloading the list filtered by name, so the assertion no longer depends on where the term falls or how many exist.

**A second, genuine race in the same page object**, the other failure mode observed:

```js
await this.submitButton.click();
await this.page.waitForResponse( ... );   // registered after the click
```

`waitForResponse` only observes responses arriving after it is called, so a fast server answer was missed and the call timed out. The listener is now registered first, then the click, then the await — plus a wait for the row the AJAX handler appends.

## Verification

The jest suite previously ran only locally: `lint_and_test` installed npm dependencies but went straight to PHPUnit. `npm run test:unit-js` now runs in CI, before `wp-env` starts so a JS regression fails in seconds instead of after the container boot.

```
npm run test:unit-js   ✓ 28 tests (19 new), now enforced in CI
make test-e2e          ✓ 72 passed, 21 skipped, 1 pre-existing failure
affected test, --repeat-each=5, 26 terms present   ✓ 5 passed (previously 5 failed)
```

## Two E2E failures seen, neither from this PR

Both were attributed by measurement, not assumption:

- **`document-rich-formatting.spec.js`** fails ~2 of 3 runs. Swapping in `main`'s version of both changed JS files reproduces the same 2-of-3 rate, so it is pre-existing. Cause: the spec clicks the Text tab and fills the textarea without waiting for TinyMCE to complete the asynchronous switch, so `fill()` races a hidden element. **A fix was attempted here and reverted** — driving the switch through `switchEditors` made it worse (5 of 5 failing), and hardening an unrelated spec does not belong in this change. Worth its own PR.
- **`document-revisions.spec.js:74`** failed once under full-suite load, passed on a second full run, and passes 12/12 in isolation. Non-deterministic under load; those tests take 38–60s each.

Expect the rich-formatting spec to go red intermittently in CI regardless of this PR.

## Coverage gap

The required-field validation this function guards has no direct E2E coverage — no spec exercises it end to end. The new unit tests cover the extraction contract, and the rich-content save specs caught the `getContent()` attempt indirectly, but an E2E test for the validation flow itself would be worth adding.
