### PR TITLE
refactor: reduce PHPMD complexity in the documents CPT

### DIFF
--- a/includes/custom-post-types/class-documentate-documents.php
+++ b/includes/custom-post-types/class-documentate-documents.php
@@ -1739,206 +1739,249 @@ class Documentate_Documents {
 			echo '>' . esc_html( $label ) . '</label>';
 
 			if ( 'single' === $type ) {
-				$raw_field_type = \Documentate\Documents\Documents_Field_Validator::extract_raw_type( $raw_field );
-				$raw_data_type = isset( $definition['data_type'] ) ? sanitize_key( $definition['data_type'] ) : '';
-				$input_type = $this->map_single_input_type( $raw_field_type, $raw_data_type );
-				$normalized_value = $this->normalize_scalar_value( $value, $input_type );
-				$attributes = $this->build_scalar_input_attributes( $raw_field, $input_type );
-				$before_description = $this->get_before_description_context( $field_id, $item_key, $raw_field );
-				$description = $this->get_field_description( $raw_field );
-				$validation = $this->get_field_validation_message( $raw_field );
-				$description_id = '' !== $description ? $field_id . '-description' : '';
-				$validation_id = '' !== $validation ? $field_id . '-validation' : '';
-				$describedby = $this->build_describedby_ids( $before_description['id'], $description_id, $validation_id );
-				if ( ! empty( $describedby ) ) {
-					$attributes['aria-describedby'] = implode( ' ', $describedby );
-				}
-				if ( '' !== $validation ) {
-					$attributes['data-validation-message'] = $validation;
-				}
-				$attributes['class'] = $this->build_input_class( $input_type );
-				$attribute_string = $this->format_field_attributes( $attributes );
-				$this->render_before_description( $before_description );
-
-				if ( 'select' === $input_type ) {
-					$options = $this->parse_select_options( $raw_field );
-					$placeholder = $this->get_select_placeholder( $raw_field );
-					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Attributes escaped in format_field_attributes().
-					echo '<select id="' . esc_attr( $field_id ) . '" name="' . esc_attr( $field_name ) . '" ' . $attribute_string . '>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					if ( '' !== $placeholder ) {
-						echo '<option value="">' . esc_html( $placeholder ) . '</option>';
-					} elseif ( empty( $attributes['required'] ) ) {
-						echo '<option value="">' . esc_html__( 'Select an option…', 'documentate' ) . '</option>';
-					}
-					foreach ( $options as $option_value => $option_label ) {
-						echo '<option value="'
-								. esc_attr( $option_value )
-								. '" '
-								. selected( $option_value, $normalized_value, false )
-								. '>'
-								. esc_html( $option_label )
-								. '</option>';
-					}
-					echo '</select>';
-				} elseif ( 'checkbox' === $input_type ) {
-					echo '<input type="hidden" name="' . esc_attr( $field_name ) . '" value="0" />';
-					echo '<label class="documentate-checkbox-wrapper">';
-					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Attributes escaped in format_field_attributes().
-					echo '<input type="checkbox" id="'
-							. esc_attr( $field_id )
-							. '" name="'
-							. esc_attr( $field_name )
-							. '" value="1" '
-							. checked( '1', $normalized_value, false )
-							. ' '
-							. $attribute_string // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-							. ' />';
-					echo '<span class="screen-reader-text">' . esc_html( $label ) . '</span>';
-					echo '</label>';
-				} else {
-					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Attributes escaped in format_field_attributes().
-					echo '<input type="'
-							. esc_attr( $input_type )
-							. '" id="'
-							. esc_attr( $field_id )
-							. '" name="'
-							. esc_attr( $field_name )
-							. '" value="'
-							. esc_attr( $normalized_value )
-							. '" '
-							. $attribute_string // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-							. ' />';
-				}
-				if ( '' !== $description ) {
-					echo '<p id="' . esc_attr( $description_id ) . '" class="description">' . esc_html( $description ) . '</p>';
-				}
-				if ( '' !== $validation ) {
-					echo '<p id="'
-							. esc_attr( $validation_id )
-							. '" class="description documentate-field-validation" data-documentate-validation-message="true">'
-							. esc_html( $validation )
-							. '</p>';
-				}
+				$this->render_array_item_single( $item_key, $field_name, $field_id, $label, $raw_field, $value );
 			} elseif ( 'rich' === $type ) {
-				$before_description = $this->get_before_description_context( $field_id, $item_key, $raw_field );
-				$description = $this->get_field_description( $raw_field );
-				$validation = $this->get_field_validation_message( $raw_field );
-				$description_id = '' !== $description ? $field_id . '-description' : '';
-				$validation_id = '' !== $validation ? $field_id . '-validation' : '';
-				$describedby = $this->build_describedby_ids( $before_description['id'], $description_id, $validation_id );
-				$attributes = $this->build_scalar_input_attributes( $raw_field, 'textarea' );
-				if ( ! empty( $describedby ) ) {
-					$attributes['aria-describedby'] = implode( ' ', $describedby );
-				}
-				if ( '' !== $validation ) {
-					$attributes['data-validation-message'] = $validation;
-				}
-				if ( ! isset( $attributes['rows'] ) ) {
-					$attributes['rows'] = 8;
-				}
-
-				// Check if collaborative editing is enabled.
-				$is_collaborative = $this->is_collaborative_editing_enabled();
-				$this->render_before_description( $before_description );
-
-				if ( $is_collaborative ) {
-					// Render TipTap collaborative editor container for array fields.
-					$classes = trim(
-						$this->build_input_class( 'textarea' )
-						. ' documentate-array-rich documentate-collab-textarea'
-						. ( $is_template ? ' documentate-array-rich-template' : '' ),
-					);
-					$attributes['class'] = $classes;
-					$attribute_string = $this->format_field_attributes( $attributes );
-					echo '<div class="documentate-collab-container">';
-					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Attributes escaped in format_field_attributes().
-					echo '<textarea '
-							. $attribute_string // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-							. ' id="'
-							. esc_attr( $field_id )
-							. '" name="'
-							. esc_attr( $field_name )
-							. '">'
-							. esc_textarea( $value )
-							. '</textarea>';
-					echo '</div>';
-				} else {
-					$classes = trim(
-						$this->build_input_class( 'textarea' )
-						. ' documentate-array-rich'
-						. ( $is_template ? ' documentate-array-rich-template' : '' ),
-					);
-					$attributes['class'] = $classes;
-					$attributes['data-editor-initialized'] = 'false';
-					$attribute_string = $this->format_field_attributes( $attributes );
-					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Attributes escaped in format_field_attributes().
-					echo '<textarea '
-							. $attribute_string // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-							. ' id="'
-							. esc_attr( $field_id )
-							. '" name="'
-							. esc_attr( $field_name )
-							. '">'
-							. esc_textarea( $value )
-							. '</textarea>';
-				}
-
-				if ( '' !== $description ) {
-					echo '<p id="' . esc_attr( $description_id ) . '" class="description">' . esc_html( $description ) . '</p>';
-				}
-				if ( '' !== $validation ) {
-					echo '<p id="'
-							. esc_attr( $validation_id )
-							. '" class="description documentate-field-validation" data-documentate-validation-message="true">'
-							. esc_html( $validation )
-							. '</p>';
-				}
+				$this->render_array_item_rich( $item_key, $field_name, $field_id, $raw_field, $value );
 			} else {
-				$attributes = $this->build_scalar_input_attributes( $raw_field, 'textarea' );
-				$before_description = $this->get_before_description_context( $field_id, $item_key, $raw_field );
-				$description = $this->get_field_description( $raw_field );
-				$validation = $this->get_field_validation_message( $raw_field );
-				$description_id = '' !== $description ? $field_id . '-description' : '';
-				$validation_id = '' !== $validation ? $field_id . '-validation' : '';
-				$describedby = $this->build_describedby_ids( $before_description['id'], $description_id, $validation_id );
-				if ( ! empty( $describedby ) ) {
-					$attributes['aria-describedby'] = implode( ' ', $describedby );
-				}
-				if ( '' !== $validation ) {
-					$attributes['data-validation-message'] = $validation;
-				}
-				if ( ! isset( $attributes['rows'] ) ) {
-					$attributes['rows'] = 6;
-				}
-				$attributes['class'] = $this->build_input_class( 'textarea' );
-				$attribute_string = $this->format_field_attributes( $attributes );
-				$this->render_before_description( $before_description );
-				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Attributes escaped in format_field_attributes().
-				echo '<textarea '
-						. $attribute_string // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-						. ' id="'
-						. esc_attr( $field_id )
-						. '" name="'
-						. esc_attr( $field_name )
-						. '">'
-						. esc_textarea( $value )
-						. '</textarea>';
-				if ( '' !== $description ) {
-					echo '<p id="' . esc_attr( $description_id ) . '" class="description">' . esc_html( $description ) . '</p>';
-				}
-				if ( '' !== $validation ) {
-					echo '<p id="'
-							. esc_attr( $validation_id )
-							. '" class="description documentate-field-validation" data-documentate-validation-message="true">'
-							. esc_html( $validation )
-							. '</p>';
-				}
+				$this->render_array_item_textarea( $item_key, $field_name, $field_id, $raw_field, $value );
 			}
 
 			echo '</div>';
 		}
 
 		echo '</div>';
+	}
+
+	/**
+	 * Render a single-line control for one repeater field.
+	 *
+	 * @param string $item_key     Key of the field inside the repeater row.
+	 * @param string $field_name   Submitted input name.
+	 * @param string $field_id     DOM id shared by the control and its descriptions.
+	 * @param string $label        Visible label, reused by the screen-reader text.
+	 * @param array  $raw_field    Raw schema definition for the field.
+	 * @param string $value        Current value.
+	 * @return void
+	 */
+	private function render_array_item_single( $item_key, $field_name, $field_id, $label, $raw_field, $value ) {
+		$raw_field_type = \Documentate\Documents\Documents_Field_Validator::extract_raw_type( $raw_field );
+		$raw_data_type = isset( $definition['data_type'] ) ? sanitize_key( $definition['data_type'] ) : '';
+		$input_type = $this->map_single_input_type( $raw_field_type, $raw_data_type );
+		$normalized_value = $this->normalize_scalar_value( $value, $input_type );
+		$attributes = $this->build_scalar_input_attributes( $raw_field, $input_type );
+		$before_description = $this->get_before_description_context( $field_id, $item_key, $raw_field );
+		$description = $this->get_field_description( $raw_field );
+		$validation = $this->get_field_validation_message( $raw_field );
+		$description_id = '' !== $description ? $field_id . '-description' : '';
+		$validation_id = '' !== $validation ? $field_id . '-validation' : '';
+		$describedby = $this->build_describedby_ids( $before_description['id'], $description_id, $validation_id );
+		if ( ! empty( $describedby ) ) {
+			$attributes['aria-describedby'] = implode( ' ', $describedby );
+		}
+		if ( '' !== $validation ) {
+			$attributes['data-validation-message'] = $validation;
+		}
+		$attributes['class'] = $this->build_input_class( $input_type );
+		$attribute_string = $this->format_field_attributes( $attributes );
+		$this->render_before_description( $before_description );
+
+		if ( 'select' === $input_type ) {
+			$options = $this->parse_select_options( $raw_field );
+			$placeholder = $this->get_select_placeholder( $raw_field );
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Attributes escaped in format_field_attributes().
+			echo '<select id="' . esc_attr( $field_id ) . '" name="' . esc_attr( $field_name ) . '" ' . $attribute_string . '>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			if ( '' !== $placeholder ) {
+				echo '<option value="">' . esc_html( $placeholder ) . '</option>';
+			} elseif ( empty( $attributes['required'] ) ) {
+				echo '<option value="">' . esc_html__( 'Select an option…', 'documentate' ) . '</option>';
+			}
+			foreach ( $options as $option_value => $option_label ) {
+				echo '<option value="'
+						. esc_attr( $option_value )
+						. '" '
+						. selected( $option_value, $normalized_value, false )
+						. '>'
+						. esc_html( $option_label )
+						. '</option>';
+			}
+			echo '</select>';
+		} elseif ( 'checkbox' === $input_type ) {
+			echo '<input type="hidden" name="' . esc_attr( $field_name ) . '" value="0" />';
+			echo '<label class="documentate-checkbox-wrapper">';
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Attributes escaped in format_field_attributes().
+			echo '<input type="checkbox" id="'
+					. esc_attr( $field_id )
+					. '" name="'
+					. esc_attr( $field_name )
+					. '" value="1" '
+					. checked( '1', $normalized_value, false )
+					. ' '
+					. $attribute_string // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					. ' />';
+			echo '<span class="screen-reader-text">' . esc_html( $label ) . '</span>';
+			echo '</label>';
+		} else {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Attributes escaped in format_field_attributes().
+			echo '<input type="'
+					. esc_attr( $input_type )
+					. '" id="'
+					. esc_attr( $field_id )
+					. '" name="'
+					. esc_attr( $field_name )
+					. '" value="'
+					. esc_attr( $normalized_value )
+					. '" '
+					. $attribute_string // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					. ' />';
+		}
+		if ( '' !== $description ) {
+			echo '<p id="' . esc_attr( $description_id ) . '" class="description">' . esc_html( $description ) . '</p>';
+		}
+		if ( '' !== $validation ) {
+			echo '<p id="'
+					. esc_attr( $validation_id )
+					. '" class="description documentate-field-validation" data-documentate-validation-message="true">'
+					. esc_html( $validation )
+					. '</p>';
+		}
+	}
+
+	/**
+	 * Render a rich text control for one repeater field.
+	 *
+	 * @param string $item_key     Key of the field inside the repeater row.
+	 * @param string $field_name   Submitted input name.
+	 * @param string $field_id     DOM id shared by the control and its descriptions.
+	 * @param array  $raw_field    Raw schema definition for the field.
+	 * @param string $value        Current value.
+	 * @return void
+	 */
+	private function render_array_item_rich( $item_key, $field_name, $field_id, $raw_field, $value ) {
+		$before_description = $this->get_before_description_context( $field_id, $item_key, $raw_field );
+		$description = $this->get_field_description( $raw_field );
+		$validation = $this->get_field_validation_message( $raw_field );
+		$description_id = '' !== $description ? $field_id . '-description' : '';
+		$validation_id = '' !== $validation ? $field_id . '-validation' : '';
+		$describedby = $this->build_describedby_ids( $before_description['id'], $description_id, $validation_id );
+		$attributes = $this->build_scalar_input_attributes( $raw_field, 'textarea' );
+		if ( ! empty( $describedby ) ) {
+			$attributes['aria-describedby'] = implode( ' ', $describedby );
+		}
+		if ( '' !== $validation ) {
+			$attributes['data-validation-message'] = $validation;
+		}
+		if ( ! isset( $attributes['rows'] ) ) {
+			$attributes['rows'] = 8;
+		}
+
+		// Check if collaborative editing is enabled.
+		$is_collaborative = $this->is_collaborative_editing_enabled();
+		$this->render_before_description( $before_description );
+
+		if ( $is_collaborative ) {
+			// Render TipTap collaborative editor container for array fields.
+			$classes = trim(
+				$this->build_input_class( 'textarea' )
+				. ' documentate-array-rich documentate-collab-textarea'
+				. ( $is_template ? ' documentate-array-rich-template' : '' ),
+			);
+			$attributes['class'] = $classes;
+			$attribute_string = $this->format_field_attributes( $attributes );
+			echo '<div class="documentate-collab-container">';
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Attributes escaped in format_field_attributes().
+			echo '<textarea '
+					. $attribute_string // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					. ' id="'
+					. esc_attr( $field_id )
+					. '" name="'
+					. esc_attr( $field_name )
+					. '">'
+					. esc_textarea( $value )
+					. '</textarea>';
+			echo '</div>';
+		} else {
+			$classes = trim(
+				$this->build_input_class( 'textarea' )
+				. ' documentate-array-rich'
+				. ( $is_template ? ' documentate-array-rich-template' : '' ),
+			);
+			$attributes['class'] = $classes;
+			$attributes['data-editor-initialized'] = 'false';
+			$attribute_string = $this->format_field_attributes( $attributes );
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Attributes escaped in format_field_attributes().
+			echo '<textarea '
+					. $attribute_string // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					. ' id="'
+					. esc_attr( $field_id )
+					. '" name="'
+					. esc_attr( $field_name )
+					. '">'
+					. esc_textarea( $value )
+					. '</textarea>';
+		}
+
+		if ( '' !== $description ) {
+			echo '<p id="' . esc_attr( $description_id ) . '" class="description">' . esc_html( $description ) . '</p>';
+		}
+		if ( '' !== $validation ) {
+			echo '<p id="'
+					. esc_attr( $validation_id )
+					. '" class="description documentate-field-validation" data-documentate-validation-message="true">'
+					. esc_html( $validation )
+					. '</p>';
+		}
+	}
+
+	/**
+	 * Render a textarea control for one repeater field.
+	 *
+	 * @param string $item_key     Key of the field inside the repeater row.
+	 * @param string $field_name   Submitted input name.
+	 * @param string $field_id     DOM id shared by the control and its descriptions.
+	 * @param array  $raw_field    Raw schema definition for the field.
+	 * @param string $value        Current value.
+	 * @return void
+	 */
+	private function render_array_item_textarea( $item_key, $field_name, $field_id, $raw_field, $value ) {
+		$attributes = $this->build_scalar_input_attributes( $raw_field, 'textarea' );
+		$before_description = $this->get_before_description_context( $field_id, $item_key, $raw_field );
+		$description = $this->get_field_description( $raw_field );
+		$validation = $this->get_field_validation_message( $raw_field );
+		$description_id = '' !== $description ? $field_id . '-description' : '';
+		$validation_id = '' !== $validation ? $field_id . '-validation' : '';
+		$describedby = $this->build_describedby_ids( $before_description['id'], $description_id, $validation_id );
+		if ( ! empty( $describedby ) ) {
+			$attributes['aria-describedby'] = implode( ' ', $describedby );
+		}
+		if ( '' !== $validation ) {
+			$attributes['data-validation-message'] = $validation;
+		}
+		if ( ! isset( $attributes['rows'] ) ) {
+			$attributes['rows'] = 6;
+		}
+		$attributes['class'] = $this->build_input_class( 'textarea' );
+		$attribute_string = $this->format_field_attributes( $attributes );
+		$this->render_before_description( $before_description );
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Attributes escaped in format_field_attributes().
+		echo '<textarea '
+				. $attribute_string // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				. ' id="'
+				. esc_attr( $field_id )
+				. '" name="'
+				. esc_attr( $field_name )
+				. '">'
+				. esc_textarea( $value )
+				. '</textarea>';
+		if ( '' !== $description ) {
+			echo '<p id="' . esc_attr( $description_id ) . '" class="description">' . esc_html( $description ) . '</p>';
+		}
+		if ( '' !== $validation ) {
+			echo '<p id="'
+					. esc_attr( $validation_id )
+					. '" class="description documentate-field-validation" data-documentate-validation-message="true">'
+					. esc_html( $validation )
+					. '</p>';
+		}
 	}
 
 	/**

--- a/includes/custom-post-types/class-documentate-documents.php
+++ b/includes/custom-post-types/class-documentate-documents.php
@@ -2461,99 +2461,175 @@ class Documentate_Documents {
 		$data = $this->preserve_document_dates( $data, $post_id );
 
 		$term_id = $this->get_term_id_from_request_or_post( $post_id );
-
-		$schema = array();
-		$dynamic_schema = array();
-		if ( $term_id > 0 ) {
-			$dynamic_schema = self::get_term_schema( $term_id );
-			$schema = $dynamic_schema;
-		}
+		$schema = $term_id > 0 ? self::get_term_schema( $term_id ) : array();
 
 		$existing_structured = $this->collect_existing_structured_content( $postarr, $post_id );
 
-		$structured_fields = array();
 		$known_slugs = array();
-		$posted_array_fields = array();
-		if ( isset( $_POST['tpl_fields'] ) && is_array( $_POST['tpl_fields'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			$posted_array_fields = wp_unslash( $_POST['tpl_fields'] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		}
+		$structured_fields = $this->compose_schema_fields( $schema, $existing_structured, $known_slugs );
 
-		foreach ( $schema as $row ) {
-			if ( empty( $row['slug'] ) ) {
-				continue;
-			}
-			$slug = sanitize_key( $row['slug'] );
+		// Values the schema no longer declares, then anything else posted.
+		$unknown_fields = $this->compose_carried_over_fields( $existing_structured, $known_slugs );
+		$unknown_fields = $this->compose_posted_fields( $structured_fields, $unknown_fields );
+
+		$data['post_content'] = $this->build_structured_content( $structured_fields, $unknown_fields );
+
+		return $data;
+	}
+
+	/**
+	 * Build the field entries declared by the document type schema.
+	 *
+	 * @param array $schema              Schema rows.
+	 * @param array $existing_structured Values already stored in post_content.
+	 * @param array $known_slugs         Filled with the slugs the schema owns.
+	 * @return array<string,array{type:string,value:string}>
+	 */
+	private function compose_schema_fields( $schema, array $existing_structured, array &$known_slugs ) {
+		$posted_array_fields = $this->read_posted_array_fields();
+		$fields = array();
+
+		foreach ( (array) $schema as $row ) {
+			$slug = ! empty( $row['slug'] ) ? sanitize_key( $row['slug'] ) : '';
 			if ( '' === $slug ) {
 				continue;
 			}
+
 			$type = isset( $row['type'] ) ? sanitize_key( $row['type'] ) : 'textarea';
 			$known_slugs[ $slug ] = true;
 
 			if ( 'array' === $type ) {
-				$items = array();
-				if ( isset( $posted_array_fields[ $slug ] ) && is_array( $posted_array_fields[ $slug ] ) ) {
-					$items = $this->sanitize_array_field_items( $posted_array_fields[ $slug ], $row );
-				} elseif (
-					isset( $existing_structured[ $slug ] )
-					&& isset( $existing_structured[ $slug ]['type'] )
-					&& 'array' === $existing_structured[ $slug ]['type']
-				) {
-					$items = $this->get_array_field_items_from_structured( $existing_structured[ $slug ] );
-				}
-
-				// Use the same JSON_HEX flags as in save_dynamic_fields_meta for consistency.
-				// wp_slash() preserves backslashes (like \n and \uXXXX) through WordPress's wp_unslash() in wp_insert_post().
-				$json_value = ! empty( $items )
-					? wp_json_encode( $items, JSON_HEX_QUOT | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS )
-					: '[]';
-				$structured_fields[ $slug ] = array(
-					'type' => 'array',
-					'value' => wp_slash( $json_value ),
-				);
+				$fields[ $slug ] = $this->compose_array_field( $slug, $row, $existing_structured, $posted_array_fields );
 				continue;
 			}
 
 			if ( ! in_array( $type, array( 'single', 'textarea', 'rich' ), true ) ) {
 				$type = 'textarea';
 			}
+
+			$fields[ $slug ] = $this->process_posted_field_value(
+				$slug,
+				$type,
+				'documentate_field_' . $slug,
+				$existing_structured
+			);
+		}
+
+		return $fields;
+	}
+
+	/**
+	 * Submitted repeater rows, keyed by field slug.
+	 *
+	 * @return array
+	 */
+	private function read_posted_array_fields() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		if ( ! isset( $_POST['tpl_fields'] ) || ! is_array( $_POST['tpl_fields'] ) ) {
+			return array();
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Rows are sanitized against the schema by sanitize_array_field_items().
+		return wp_unslash( $_POST['tpl_fields'] );
+	}
+
+	/**
+	 * Build the entry for a repeater field.
+	 *
+	 * Submitted rows win; otherwise the rows already stored are carried over, so
+	 * a save that does not include the repeater cannot silently empty it.
+	 *
+	 * @param string $slug                Field slug.
+	 * @param array  $row                 Schema row.
+	 * @param array  $existing_structured Values already stored in post_content.
+	 * @param array  $posted_array_fields Submitted repeater rows.
+	 * @return array{type:string,value:string}
+	 */
+	private function compose_array_field( $slug, $row, array $existing_structured, array $posted_array_fields ) {
+		$items = array();
+
+		if ( isset( $posted_array_fields[ $slug ] ) && is_array( $posted_array_fields[ $slug ] ) ) {
+			$items = $this->sanitize_array_field_items( $posted_array_fields[ $slug ], $row );
+		} elseif (
+			isset( $existing_structured[ $slug ]['type'] )
+			&& 'array' === $existing_structured[ $slug ]['type']
+		) {
+			$items = $this->get_array_field_items_from_structured( $existing_structured[ $slug ] );
+		}
+
+		// Encoded with the same flags as the meta copy, so both representations
+		// round-trip identically. wp_slash() preserves backslashes (like \n and
+		// \uXXXX) through the wp_unslash() inside wp_insert_post().
+		$json_value = $this->encode_array_field_items( $items );
+
+		return array(
+			'type' => 'array',
+			'value' => wp_slash( '' === $json_value ? '[]' : $json_value ),
+		);
+	}
+
+	/**
+	 * Carry over stored values the schema no longer declares.
+	 *
+	 * A posted value still wins, so editing a field that survived a document
+	 * type change is not discarded.
+	 *
+	 * @param array $existing_structured Values already stored in post_content.
+	 * @param array $known_slugs         Slugs the schema already handled.
+	 * @return array<string,array{type:string,value:string}>
+	 */
+	private function compose_carried_over_fields( array $existing_structured, array $known_slugs ) {
+		$fields = array();
+
+		foreach ( $existing_structured as $slug => $info ) {
+			$slug = sanitize_key( $slug );
+			if ( '' === $slug || isset( $known_slugs[ $slug ] ) || isset( $fields[ $slug ] ) ) {
+				continue;
+			}
+
 			$meta_key = 'documentate_field_' . $slug;
 
-			$structured_fields[ $slug ] = $this->process_posted_field_value( $slug, $type, $meta_key, $existing_structured );
-		}
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing
+			if ( isset( $_POST[ $meta_key ] ) ) {
+				// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitized below.
+				$val = wp_unslash( $_POST[ $meta_key ] );
+				$val = is_scalar( $val ) ? (string) $val : '';
 
-		$unknown_fields = array();
-
-		if ( ! empty( $existing_structured ) ) {
-			foreach ( $existing_structured as $slug => $info ) {
-				$slug = sanitize_key( $slug );
-				if ( '' === $slug || isset( $known_slugs[ $slug ] ) || isset( $unknown_fields[ $slug ] ) ) {
-					continue;
-				}
-				$meta_key = 'documentate_field_' . $slug;
-				if ( isset( $_POST[ $meta_key ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-					$val = wp_unslash( $_POST[ $meta_key ] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-					$val = is_scalar( $val ) ? (string) $val : '';
-					$unknown_fields[ $slug ] = array(
-						'type' => 'rich',
-						'value' => $this->sanitize_rich_text_value( $val ),
-					);
-				} else {
-					$type = isset( $info['type'] ) ? sanitize_key( $info['type'] ) : 'rich';
-					if ( ! in_array( $type, array( 'single', 'textarea', 'rich' ), true ) ) {
-						$type = 'rich';
-					}
-					$unknown_fields[ $slug ] = array(
-						'type' => $type,
-						'value' => (string) $info['value'],
-					);
-				}
+				$fields[ $slug ] = array(
+					'type' => 'rich',
+					'value' => $this->sanitize_rich_text_value( $val ),
+				);
+				continue;
 			}
+
+			$type = isset( $info['type'] ) ? sanitize_key( $info['type'] ) : 'rich';
+			if ( ! in_array( $type, array( 'single', 'textarea', 'rich' ), true ) ) {
+				$type = 'rich';
+			}
+
+			$fields[ $slug ] = array(
+				'type' => $type,
+				'value' => (string) $info['value'],
+			);
 		}
 
-		foreach ( $_POST as $key => $value ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		return $fields;
+	}
+
+	/**
+	 * Add posted field values that neither the schema nor the stored content knew.
+	 *
+	 * @param array $structured_fields Entries the schema produced.
+	 * @param array $unknown_fields    Entries carried over so far.
+	 * @return array<string,array{type:string,value:string}>
+	 */
+	private function compose_posted_fields( array $structured_fields, array $unknown_fields ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		foreach ( $_POST as $key => $value ) {
 			if ( ! is_string( $key ) || ! str_starts_with( $key, 'documentate_field_' ) ) {
 				continue;
 			}
+
 			$slug = sanitize_key( substr( $key, strlen( 'documentate_field_' ) ) );
 			if ( '' === $slug || isset( $structured_fields[ $slug ] ) || isset( $unknown_fields[ $slug ] ) ) {
 				continue;
@@ -2561,31 +2637,38 @@ class Documentate_Documents {
 			if ( is_array( $value ) ) {
 				continue;
 			}
-			$raw_value = wp_unslash( $value ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+
+			$raw_value = wp_unslash( $value );
 			$raw_value = is_scalar( $raw_value ) ? (string) $raw_value : '';
+
 			$unknown_fields[ $slug ] = array(
 				'type' => 'rich',
 				'value' => $this->sanitize_rich_text_value( $raw_value ),
 			);
 		}
 
-		if ( empty( $structured_fields ) && empty( $unknown_fields ) ) {
-			$data['post_content'] = '';
-			return $data;
-		}
+		return $unknown_fields;
+	}
 
+	/**
+	 * Serialise the composed fields into the stored post_content.
+	 *
+	 * @param array $structured_fields Entries the schema produced.
+	 * @param array $unknown_fields    Entries not declared by the schema.
+	 * @return string Empty string when there is nothing to store.
+	 */
+	private function build_structured_content( array $structured_fields, array $unknown_fields ) {
 		$fragments = array();
+
 		foreach ( $structured_fields as $slug => $info ) {
 			$fragments[] = $this->build_structured_field_fragment( $slug, $info['type'], $info['value'] );
 		}
-		if ( ! empty( $unknown_fields ) ) {
-			foreach ( $unknown_fields as $slug => $info ) {
-				$fragments[] = $this->build_structured_field_fragment( $slug, $info['type'], $info['value'] );
-			}
+
+		foreach ( $unknown_fields as $slug => $info ) {
+			$fragments[] = $this->build_structured_field_fragment( $slug, $info['type'], $info['value'] );
 		}
 
-		$data['post_content'] = implode( "\n\n", $fragments );
-		return $data;
+		return implode( "\n\n", $fragments );
 	}
 
 	/**

--- a/includes/custom-post-types/class-documentate-documents.php
+++ b/includes/custom-post-types/class-documentate-documents.php
@@ -1437,6 +1437,77 @@ class Documentate_Documents {
 	}
 
 	/**
+	 * Collect every piece of help text attached to a field.
+	 *
+	 * The three repeater controls each need the same set: leading text, a
+	 * description, a validation message, and the ids that tie them to the
+	 * control for screen readers.
+	 *
+	 * @param string $field_id   DOM id of the control being described.
+	 * @param string $field_slug Field key, used to build the before-description class.
+	 * @param array  $raw_field  Raw schema definition for the field.
+	 * @return array{before:array,description:string,validation:string,description_id:string,validation_id:string,describedby:array}
+	 */
+	private function build_field_help_context( $field_id, $field_slug, $raw_field ) {
+		$before = $this->get_before_description_context( $field_id, $field_slug, $raw_field );
+		$description = $this->get_field_description( $raw_field );
+		$validation = $this->get_field_validation_message( $raw_field );
+		$description_id = '' !== $description ? $field_id . '-description' : '';
+		$validation_id = '' !== $validation ? $field_id . '-validation' : '';
+
+		return array(
+			'before' => $before,
+			'description' => $description,
+			'validation' => $validation,
+			'description_id' => $description_id,
+			'validation_id' => $validation_id,
+			'describedby' => $this->build_describedby_ids( $before['id'], $description_id, $validation_id ),
+		);
+	}
+
+	/**
+	 * Point a control at its help text and hand the message to the JS validator.
+	 *
+	 * @param array $attributes Attributes collected so far.
+	 * @param array $help       Context from build_field_help_context().
+	 * @return array Attributes with the accessibility wiring applied.
+	 */
+	private function apply_help_attributes( array $attributes, array $help ) {
+		if ( ! empty( $help['describedby'] ) ) {
+			$attributes['aria-describedby'] = implode( ' ', $help['describedby'] );
+		}
+		if ( '' !== $help['validation'] ) {
+			$attributes['data-validation-message'] = $help['validation'];
+		}
+
+		return $attributes;
+	}
+
+	/**
+	 * Render the help paragraphs that follow a control.
+	 *
+	 * Their ids are the ones apply_help_attributes() referenced, so the two must
+	 * stay in step.
+	 *
+	 * @param array $help Context from build_field_help_context().
+	 * @return void
+	 */
+	private function render_help_descriptions( array $help ) {
+		if ( '' !== $help['description'] ) {
+			echo '<p id="' . esc_attr( $help['description_id'] ) . '" class="description">'
+					. esc_html( $help['description'] )
+					. '</p>';
+		}
+		if ( '' !== $help['validation'] ) {
+			echo '<p id="'
+					. esc_attr( $help['validation_id'] )
+					. '" class="description documentate-field-validation" data-documentate-validation-message="true">'
+					. esc_html( $help['validation'] )
+					. '</p>';
+		}
+	}
+
+	/**
 	 * Build the sanitized inline style for the before description block.
 	 *
 	 * @param array $raw_field Raw field definition.
@@ -1770,22 +1841,14 @@ class Documentate_Documents {
 		$raw_data_type = isset( $definition['data_type'] ) ? sanitize_key( $definition['data_type'] ) : '';
 		$input_type = $this->map_single_input_type( $raw_field_type, $raw_data_type );
 		$normalized_value = $this->normalize_scalar_value( $value, $input_type );
-		$attributes = $this->build_scalar_input_attributes( $raw_field, $input_type );
-		$before_description = $this->get_before_description_context( $field_id, $item_key, $raw_field );
-		$description = $this->get_field_description( $raw_field );
-		$validation = $this->get_field_validation_message( $raw_field );
-		$description_id = '' !== $description ? $field_id . '-description' : '';
-		$validation_id = '' !== $validation ? $field_id . '-validation' : '';
-		$describedby = $this->build_describedby_ids( $before_description['id'], $description_id, $validation_id );
-		if ( ! empty( $describedby ) ) {
-			$attributes['aria-describedby'] = implode( ' ', $describedby );
-		}
-		if ( '' !== $validation ) {
-			$attributes['data-validation-message'] = $validation;
-		}
+		$help = $this->build_field_help_context( $field_id, $item_key, $raw_field );
+		$attributes = $this->apply_help_attributes(
+			$this->build_scalar_input_attributes( $raw_field, $input_type ),
+			$help
+		);
 		$attributes['class'] = $this->build_input_class( $input_type );
 		$attribute_string = $this->format_field_attributes( $attributes );
-		$this->render_before_description( $before_description );
+		$this->render_before_description( $help['before'] );
 
 		if ( 'select' === $input_type ) {
 			$options = $this->parse_select_options( $raw_field );
@@ -1836,16 +1899,7 @@ class Documentate_Documents {
 					. $attribute_string // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 					. ' />';
 		}
-		if ( '' !== $description ) {
-			echo '<p id="' . esc_attr( $description_id ) . '" class="description">' . esc_html( $description ) . '</p>';
-		}
-		if ( '' !== $validation ) {
-			echo '<p id="'
-					. esc_attr( $validation_id )
-					. '" class="description documentate-field-validation" data-documentate-validation-message="true">'
-					. esc_html( $validation )
-					. '</p>';
-		}
+		$this->render_help_descriptions( $help );
 	}
 
 	/**
@@ -1861,26 +1915,18 @@ class Documentate_Documents {
 	 * @return void
 	 */
 	private function render_array_item_rich( $item_key, $field_name, $field_id, $raw_field, $value, $is_template ) {
-		$before_description = $this->get_before_description_context( $field_id, $item_key, $raw_field );
-		$description = $this->get_field_description( $raw_field );
-		$validation = $this->get_field_validation_message( $raw_field );
-		$description_id = '' !== $description ? $field_id . '-description' : '';
-		$validation_id = '' !== $validation ? $field_id . '-validation' : '';
-		$describedby = $this->build_describedby_ids( $before_description['id'], $description_id, $validation_id );
-		$attributes = $this->build_scalar_input_attributes( $raw_field, 'textarea' );
-		if ( ! empty( $describedby ) ) {
-			$attributes['aria-describedby'] = implode( ' ', $describedby );
-		}
-		if ( '' !== $validation ) {
-			$attributes['data-validation-message'] = $validation;
-		}
+		$help = $this->build_field_help_context( $field_id, $item_key, $raw_field );
+		$attributes = $this->apply_help_attributes(
+			$this->build_scalar_input_attributes( $raw_field, 'textarea' ),
+			$help
+		);
 		if ( ! isset( $attributes['rows'] ) ) {
 			$attributes['rows'] = 8;
 		}
 
 		// Check if collaborative editing is enabled.
 		$is_collaborative = $this->is_collaborative_editing_enabled();
-		$this->render_before_description( $before_description );
+		$this->render_before_description( $help['before'] );
 
 		if ( $is_collaborative ) {
 			// Render TipTap collaborative editor container for array fields.
@@ -1924,16 +1970,7 @@ class Documentate_Documents {
 					. '</textarea>';
 		}
 
-		if ( '' !== $description ) {
-			echo '<p id="' . esc_attr( $description_id ) . '" class="description">' . esc_html( $description ) . '</p>';
-		}
-		if ( '' !== $validation ) {
-			echo '<p id="'
-					. esc_attr( $validation_id )
-					. '" class="description documentate-field-validation" data-documentate-validation-message="true">'
-					. esc_html( $validation )
-					. '</p>';
-		}
+		$this->render_help_descriptions( $help );
 	}
 
 	/**
@@ -1947,25 +1984,17 @@ class Documentate_Documents {
 	 * @return void
 	 */
 	private function render_array_item_textarea( $item_key, $field_name, $field_id, $raw_field, $value ) {
-		$attributes = $this->build_scalar_input_attributes( $raw_field, 'textarea' );
-		$before_description = $this->get_before_description_context( $field_id, $item_key, $raw_field );
-		$description = $this->get_field_description( $raw_field );
-		$validation = $this->get_field_validation_message( $raw_field );
-		$description_id = '' !== $description ? $field_id . '-description' : '';
-		$validation_id = '' !== $validation ? $field_id . '-validation' : '';
-		$describedby = $this->build_describedby_ids( $before_description['id'], $description_id, $validation_id );
-		if ( ! empty( $describedby ) ) {
-			$attributes['aria-describedby'] = implode( ' ', $describedby );
-		}
-		if ( '' !== $validation ) {
-			$attributes['data-validation-message'] = $validation;
-		}
+		$help = $this->build_field_help_context( $field_id, $item_key, $raw_field );
+		$attributes = $this->apply_help_attributes(
+			$this->build_scalar_input_attributes( $raw_field, 'textarea' ),
+			$help
+		);
 		if ( ! isset( $attributes['rows'] ) ) {
 			$attributes['rows'] = 6;
 		}
 		$attributes['class'] = $this->build_input_class( 'textarea' );
 		$attribute_string = $this->format_field_attributes( $attributes );
-		$this->render_before_description( $before_description );
+		$this->render_before_description( $help['before'] );
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Attributes escaped in format_field_attributes().
 		echo '<textarea '
 				. $attribute_string // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -1976,16 +2005,7 @@ class Documentate_Documents {
 				. '">'
 				. esc_textarea( $value )
 				. '</textarea>';
-		if ( '' !== $description ) {
-			echo '<p id="' . esc_attr( $description_id ) . '" class="description">' . esc_html( $description ) . '</p>';
-		}
-		if ( '' !== $validation ) {
-			echo '<p id="'
-					. esc_attr( $validation_id )
-					. '" class="description documentate-field-validation" data-documentate-validation-message="true">'
-					. esc_html( $validation )
-					. '</p>';
-		}
+		$this->render_help_descriptions( $help );
 	}
 
 	/**

--- a/includes/custom-post-types/class-documentate-documents.php
+++ b/includes/custom-post-types/class-documentate-documents.php
@@ -155,20 +155,12 @@ class Documentate_Documents {
 
 		// If not yet locked, lock to the current assigned term (if any) on first set.
 		if ( $locked <= 0 ) {
-			$assigned = wp_get_post_terms( $object_id, 'documentate_doc_type', array( 'fields' => 'ids' ) );
-			if ( ! is_wp_error( $assigned ) && ! empty( $assigned ) ) {
-				update_post_meta( $object_id, 'documentate_locked_doc_type', intval( $assigned[0] ) );
-			}
+			$this->lock_doc_type_to_current( $object_id );
 			return;
 		}
 
 		// Already locked: ensure the post keeps the locked term.
-		$current = wp_get_post_terms( $object_id, 'documentate_doc_type', array( 'fields' => 'ids' ) );
-		if ( is_wp_error( $current ) ) {
-			return;
-		}
-		$current_one = ! empty( $current ) ? intval( $current[0] ) : 0;
-		if ( $current_one === $locked && count( $current ) === 1 ) {
+		if ( ! $this->doc_type_drifted_from_lock( $object_id, $locked ) ) {
 			return;
 		}
 
@@ -176,6 +168,39 @@ class Documentate_Documents {
 		$lock_guard = true;
 		wp_set_post_terms( $object_id, array( $locked ), 'documentate_doc_type', false );
 		$lock_guard = false;
+	}
+
+	/**
+	 * Record the currently assigned document type as the locked one.
+	 *
+	 * @param int $object_id Post ID.
+	 * @return void
+	 */
+	private function lock_doc_type_to_current( $object_id ) {
+		$assigned = wp_get_post_terms( $object_id, 'documentate_doc_type', array( 'fields' => 'ids' ) );
+		if ( is_wp_error( $assigned ) || empty( $assigned ) ) {
+			return;
+		}
+
+		update_post_meta( $object_id, 'documentate_locked_doc_type', intval( $assigned[0] ) );
+	}
+
+	/**
+	 * Whether the assigned terms differ from the locked document type.
+	 *
+	 * @param int $object_id Post ID.
+	 * @param int $locked    Locked term ID.
+	 * @return bool False when the post already carries exactly the locked term.
+	 */
+	private function doc_type_drifted_from_lock( $object_id, $locked ) {
+		$current = wp_get_post_terms( $object_id, 'documentate_doc_type', array( 'fields' => 'ids' ) );
+		if ( is_wp_error( $current ) ) {
+			return false;
+		}
+
+		$current_one = ! empty( $current ) ? intval( $current[0] ) : 0;
+
+		return ! ( $current_one === $locked && 1 === count( $current ) );
 	}
 
 	/**
@@ -2030,40 +2055,60 @@ class Documentate_Documents {
 				continue;
 			}
 
-			$filtered = array();
-			foreach ( $schema as $key => $settings ) {
-				$raw = isset( $item[ $key ] ) ? $item[ $key ] : '';
-				$raw = is_scalar( $raw ) ? (string) $raw : '';
-				$type = isset( $settings['type'] ) ? $settings['type'] : 'textarea';
+			$filtered = $this->sanitize_array_item( $item, $schema );
 
-				$filtered[ $key ] = $this->sanitize_field_by_type( $raw, $type );
-			}
-
-			$has_content = false;
-			foreach ( $filtered as $key => $value ) {
-				$type = isset( $schema[ $key ]['type'] ) ? $schema[ $key ]['type'] : 'textarea';
-				if ( 'rich' === $type ) {
-					if ( '' !== trim( wp_strip_all_tags( (string) $value ) ) ) {
-						$has_content = true;
-						break;
-					}
-				} elseif ( '' !== trim( (string) $value ) ) {
-					$has_content = true;
-					break;
-				}
-			}
-
-			if ( $has_content ) {
+			if ( $this->array_item_has_content( $filtered, $schema ) ) {
 				$clean[] = $filtered;
 			}
 		}
 
-		if ( empty( $clean ) ) {
-			return array();
+		return array_values( array_slice( $clean, 0, self::ARRAY_FIELD_MAX_ITEMS ) );
+	}
+
+	/**
+	 * Sanitize one repeater row against its item schema.
+	 *
+	 * @param array $item   Raw submitted row.
+	 * @param array $schema Normalized item schema.
+	 * @return array<string,string>
+	 */
+	private function sanitize_array_item( array $item, array $schema ) {
+		$filtered = array();
+
+		foreach ( $schema as $key => $settings ) {
+			$raw = isset( $item[ $key ] ) ? $item[ $key ] : '';
+			$raw = is_scalar( $raw ) ? (string) $raw : '';
+			$type = isset( $settings['type'] ) ? $settings['type'] : 'textarea';
+
+			$filtered[ $key ] = $this->sanitize_field_by_type( $raw, $type );
 		}
 
-		$clean = array_slice( $clean, 0, self::ARRAY_FIELD_MAX_ITEMS );
-		return array_values( $clean );
+		return $filtered;
+	}
+
+	/**
+	 * Whether a sanitized repeater row carries any visible value.
+	 *
+	 * Rich values are stripped of markup first, so a row holding only empty
+	 * tags counts as blank and is dropped.
+	 *
+	 * @param array $filtered Sanitized row.
+	 * @param array $schema   Normalized item schema.
+	 * @return bool
+	 */
+	private function array_item_has_content( array $filtered, array $schema ) {
+		foreach ( $filtered as $key => $value ) {
+			$type = isset( $schema[ $key ]['type'] ) ? $schema[ $key ]['type'] : 'textarea';
+			$text = 'rich' === $type
+				? wp_strip_all_tags( (string) $value )
+				: (string) $value;
+
+			if ( '' !== trim( $text ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**
@@ -2131,6 +2176,25 @@ class Documentate_Documents {
 	 * @param int $post_id Post ID.
 	 */
 	public function save_meta_boxes( $post_id ) {
+		if ( ! $this->can_save_meta_boxes( $post_id ) ) {
+			return;
+		}
+
+		// Handle type selection (lock after set).
+		$this->save_doc_type_selection( $post_id );
+
+		$this->save_dynamic_fields_meta( $post_id );
+
+		// post_content is composed in wp_insert_post_data filter; avoid recursion here.
+	}
+
+	/**
+	 * Whether this request is allowed to persist the sections metabox.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return bool
+	 */
+	private function can_save_meta_boxes( $post_id ) {
 		if (
 			! isset( $_POST['documentate_sections_nonce'] )
 			|| ! wp_verify_nonce(
@@ -2138,15 +2202,15 @@ class Documentate_Documents {
 				'documentate_sections_nonce',
 			)
 		) {
-			return;
+			return false;
 		}
 
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-			return;
+			return false;
 		}
 
 		if ( ! current_user_can( 'edit_post', $post_id ) ) {
-			return;
+			return false;
 		}
 
 		// Server-side lock: non-admins must not persist field meta on locked docs.
@@ -2154,29 +2218,41 @@ class Documentate_Documents {
 			class_exists( 'Documentate_Workflow' )
 			&& ! Documentate_Workflow::current_user_can_modify_document( $post_id )
 		) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Apply the posted document type, keeping an existing assignment locked.
+	 *
+	 * Once a document has a type, it wins over anything posted: the type is
+	 * reapplied rather than replaced.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return void
+	 */
+	private function save_doc_type_selection( $post_id ) {
+		if (
+			! isset( $_POST['documentate_type_nonce'] )
+			|| ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['documentate_type_nonce'] ) ), 'documentate_type_nonce' )
+		) {
 			return;
 		}
 
-		// Handle type selection (lock after set).
-		if (
-			isset( $_POST['documentate_type_nonce'] )
-			&& wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['documentate_type_nonce'] ) ), 'documentate_type_nonce' )
-		) {
-			$assigned = wp_get_post_terms( $post_id, 'documentate_doc_type', array( 'fields' => 'ids' ) );
-			$current = ! is_wp_error( $assigned ) && ! empty( $assigned ) ? intval( $assigned[0] ) : 0;
-			if ( $current > 0 ) {
-				wp_set_post_terms( $post_id, array( $current ), 'documentate_doc_type', false );
-			} elseif ( isset( $_POST['documentate_doc_type'] ) ) {
-				$posted = intval( wp_unslash( $_POST['documentate_doc_type'] ) );
-				if ( $posted > 0 ) {
-					wp_set_post_terms( $post_id, array( $posted ), 'documentate_doc_type', false );
-				}
-			}
+		$assigned = wp_get_post_terms( $post_id, 'documentate_doc_type', array( 'fields' => 'ids' ) );
+		$current = ! is_wp_error( $assigned ) && ! empty( $assigned ) ? intval( $assigned[0] ) : 0;
+
+		if ( $current > 0 ) {
+			wp_set_post_terms( $post_id, array( $current ), 'documentate_doc_type', false );
+			return;
 		}
 
-		$this->save_dynamic_fields_meta( $post_id );
-
-		// post_content is composed in wp_insert_post_data filter; avoid recursion here.
+		$posted = isset( $_POST['documentate_doc_type'] ) ? intval( wp_unslash( $_POST['documentate_doc_type'] ) ) : 0;
+		if ( $posted > 0 ) {
+			wp_set_post_terms( $post_id, array( $posted ), 'documentate_doc_type', false );
+		}
 	}
 
 	/**
@@ -2866,8 +2942,38 @@ class Documentate_Documents {
 			return;
 		}
 
-		// Author filter. The has_published_posts query joins on the posts table,
-		// so cache it briefly; a slightly stale author dropdown is acceptable.
+		$this->render_author_filter();
+
+		$this->render_term_filter(
+			array(
+				'taxonomy' => 'documentate_doc_type',
+				'name' => 'documentate_doc_type',
+				'id' => 'filter-by-doc-type',
+				'all_label' => __( 'All document types', 'documentate' ),
+			)
+		);
+
+		// Cap the number of category options so the dropdown never
+		// materialises an unbounded list of site categories.
+		$this->render_term_filter(
+			array(
+				'taxonomy' => 'category',
+				'name' => 'category_name',
+				'id' => 'filter-by-category',
+				'all_label' => __( 'All categories', 'documentate' ),
+				'number' => 200,
+			)
+		);
+	}
+
+	/**
+	 * Render the author dropdown for the documents list table.
+	 *
+	 * @return void
+	 */
+	private function render_author_filter() {
+		// The has_published_posts query joins on the posts table, so cache it
+		// briefly; a slightly stale author dropdown is acceptable.
 		$authors = get_transient( 'documentate_admin_author_filter' );
 		if ( false === $authors ) {
 			$authors = get_users(
@@ -2880,70 +2986,91 @@ class Documentate_Documents {
 			set_transient( 'documentate_admin_author_filter', $authors, 5 * MINUTE_IN_SECONDS );
 		}
 
-		if ( ! empty( $authors ) ) {
-			$current_author = isset( $_GET['author'] ) ? absint( $_GET['author'] ) : 0;
-			echo '<select name="author" id="filter-by-author">';
-			echo '<option value="">' . esc_html__( 'All authors', 'documentate' ) . '</option>';
-			foreach ( $authors as $author ) {
-				printf(
-					'<option value="%d"%s>%s</option>',
-					absint( $author->ID ),
-					selected( $current_author, $author->ID, false ),
-					esc_html( $author->display_name ),
-				);
-			}
-			echo '</select>';
+		$options = array();
+		foreach ( (array) $authors as $author ) {
+			$options[ absint( $author->ID ) ] = $author->display_name;
 		}
 
-		// Document type filter (taxonomy dropdown).
-		$doc_types = get_terms(
+		$this->render_admin_filter_select(
 			array(
-				'taxonomy' => 'documentate_doc_type',
-				'hide_empty' => false,
+				'name' => 'author',
+				'id' => 'filter-by-author',
+				'all_label' => __( 'All authors', 'documentate' ),
+				'current' => isset( $_GET['author'] ) ? absint( $_GET['author'] ) : 0,
+				'options' => $options,
 			)
 		);
+	}
 
-		if ( ! is_wp_error( $doc_types ) && ! empty( $doc_types ) ) {
-			$current_type = isset( $_GET['documentate_doc_type'] )
-				? sanitize_text_field( wp_unslash( $_GET['documentate_doc_type'] ) )
-				: '';
-			echo '<select name="documentate_doc_type" id="filter-by-doc-type">';
-			echo '<option value="">' . esc_html__( 'All document types', 'documentate' ) . '</option>';
-			foreach ( $doc_types as $doc_type ) {
-				printf(
-					'<option value="%s"%s>%s</option>',
-					esc_attr( $doc_type->slug ),
-					selected( $current_type, $doc_type->slug, false ),
-					esc_html( $doc_type->name ),
-				);
-			}
-			echo '</select>';
+	/**
+	 * Render a taxonomy dropdown for the documents list table.
+	 *
+	 * @param array $args taxonomy, name, id, all_label and an optional number cap.
+	 * @return void
+	 */
+	private function render_term_filter( array $args ) {
+		$query = array(
+			'taxonomy' => $args['taxonomy'],
+			'hide_empty' => false,
+		);
+		if ( isset( $args['number'] ) ) {
+			$query['number'] = $args['number'];
 		}
 
-		// Category filter (if taxonomy exists). Cap the number of options so the
-		// dropdown never materialises an unbounded list of site categories.
-		$categories = get_terms(
+		$terms = get_terms( $query );
+		if ( is_wp_error( $terms ) || empty( $terms ) ) {
+			return;
+		}
+
+		$options = array();
+		foreach ( $terms as $term ) {
+			$options[ $term->slug ] = $term->name;
+		}
+
+		$this->render_admin_filter_select(
 			array(
-				'taxonomy' => 'category',
-				'hide_empty' => false,
-				'number' => 200,
+				'name' => $args['name'],
+				'id' => $args['id'],
+				'all_label' => $args['all_label'],
+				'current' => isset( $_GET[ $args['name'] ] )
+					? sanitize_text_field( wp_unslash( $_GET[ $args['name'] ] ) )
+					: '',
+				'options' => $options,
 			)
 		);
+	}
 
-		if ( ! is_wp_error( $categories ) && ! empty( $categories ) ) {
-			$current_cat = isset( $_GET['category_name'] ) ? sanitize_text_field( wp_unslash( $_GET['category_name'] ) ) : '';
-			echo '<select name="category_name" id="filter-by-category">';
-			echo '<option value="">' . esc_html__( 'All categories', 'documentate' ) . '</option>';
-			foreach ( $categories as $category ) {
-				printf(
-					'<option value="%s"%s>%s</option>',
-					esc_attr( $category->slug ),
-					selected( $current_cat, $category->slug, false ),
-					esc_html( $category->name ),
-				);
-			}
-			echo '</select>';
+	/**
+	 * Render one list table filter dropdown.
+	 *
+	 * Emits nothing when there is nothing to choose from, so an empty taxonomy
+	 * does not leave a stray control in the toolbar.
+	 *
+	 * @param array $args name, id, all_label, current and options (value => label).
+	 * @return void
+	 */
+	private function render_admin_filter_select( array $args ) {
+		if ( empty( $args['options'] ) ) {
+			return;
 		}
+
+		printf(
+			'<select name="%s" id="%s">',
+			esc_attr( $args['name'] ),
+			esc_attr( $args['id'] )
+		);
+		printf( '<option value="">%s</option>', esc_html( $args['all_label'] ) );
+
+		foreach ( $args['options'] as $value => $label ) {
+			printf(
+				'<option value="%s"%s>%s</option>',
+				esc_attr( $value ),
+				selected( (string) $args['current'], (string) $value, false ),
+				esc_html( $label )
+			);
+		}
+
+		echo '</select>';
 	}
 
 	/**

--- a/includes/custom-post-types/class-documentate-documents.php
+++ b/includes/custom-post-types/class-documentate-documents.php
@@ -1739,9 +1739,9 @@ class Documentate_Documents {
 			echo '>' . esc_html( $label ) . '</label>';
 
 			if ( 'single' === $type ) {
-				$this->render_array_item_single( $item_key, $field_name, $field_id, $label, $raw_field, $value );
+				$this->render_array_item_single( $item_key, $field_name, $field_id, $label, $raw_field, $value, $definition );
 			} elseif ( 'rich' === $type ) {
-				$this->render_array_item_rich( $item_key, $field_name, $field_id, $raw_field, $value );
+				$this->render_array_item_rich( $item_key, $field_name, $field_id, $raw_field, $value, $is_template );
 			} else {
 				$this->render_array_item_textarea( $item_key, $field_name, $field_id, $raw_field, $value );
 			}
@@ -1761,9 +1761,10 @@ class Documentate_Documents {
 	 * @param string $label        Visible label, reused by the screen-reader text.
 	 * @param array  $raw_field    Raw schema definition for the field.
 	 * @param string $value        Current value.
+	 * @param array  $definition   Item schema entry, read for its data_type hint.
 	 * @return void
 	 */
-	private function render_array_item_single( $item_key, $field_name, $field_id, $label, $raw_field, $value ) {
+	private function render_array_item_single( $item_key, $field_name, $field_id, $label, $raw_field, $value, $definition ) {
 		$raw_field_type = \Documentate\Documents\Documents_Field_Validator::extract_raw_type( $raw_field );
 		$raw_data_type = isset( $definition['data_type'] ) ? sanitize_key( $definition['data_type'] ) : '';
 		$input_type = $this->map_single_input_type( $raw_field_type, $raw_data_type );
@@ -1854,9 +1855,11 @@ class Documentate_Documents {
 	 * @param string $field_id     DOM id shared by the control and its descriptions.
 	 * @param array  $raw_field    Raw schema definition for the field.
 	 * @param string $value        Current value.
+	 * @param bool   $is_template  Whether this is the hidden row the JS clones,
+	 *                             which must carry the template marker class.
 	 * @return void
 	 */
-	private function render_array_item_rich( $item_key, $field_name, $field_id, $raw_field, $value ) {
+	private function render_array_item_rich( $item_key, $field_name, $field_id, $raw_field, $value, $is_template ) {
 		$before_description = $this->get_before_description_context( $field_id, $item_key, $raw_field );
 		$description = $this->get_field_description( $raw_field );
 		$validation = $this->get_field_validation_message( $raw_field );

--- a/includes/custom-post-types/class-documentate-documents.php
+++ b/includes/custom-post-types/class-documentate-documents.php
@@ -1154,8 +1154,7 @@ class Documentate_Documents {
 			return array();
 		}
 
-		$assigned = wp_get_post_terms( $post_id, 'documentate_doc_type', array( 'fields' => 'ids' ) );
-		$term_id = ! is_wp_error( $assigned ) && ! empty( $assigned ) ? intval( $assigned[0] ) : 0;
+		$term_id = $this->get_assigned_doc_type_id( $post_id );
 		if ( $term_id <= 0 ) {
 			return array();
 		}
@@ -1166,73 +1165,107 @@ class Documentate_Documents {
 			return array();
 		}
 
-		$fields_index = array();
-		$repeaters_index = array();
-		if ( isset( $schema_v2['fields'] ) && is_array( $schema_v2['fields'] ) ) {
-			foreach ( $schema_v2['fields'] as $field ) {
-				if ( ! is_array( $field ) ) {
-					continue;
-				}
-				$slug = '';
-				if ( isset( $field['slug'] ) ) {
-					$slug = sanitize_key( $field['slug'] );
-				} elseif ( isset( $field['name'] ) ) {
-					$slug = sanitize_key( $field['name'] );
-				}
-				if ( '' === $slug ) {
-					continue;
-				}
-				$fields_index[ $slug ] = $field;
-			}
-		}
-
-		if ( isset( $schema_v2['repeaters'] ) && is_array( $schema_v2['repeaters'] ) ) {
-			foreach ( $schema_v2['repeaters'] as $repeater ) {
-				if ( ! is_array( $repeater ) ) {
-					continue;
-				}
-
-				$slug = '';
-				if ( isset( $repeater['slug'] ) ) {
-					$slug = sanitize_key( $repeater['slug'] );
-				} elseif ( isset( $repeater['name'] ) ) {
-					$slug = sanitize_key( $repeater['name'] );
-				}
-
-				if ( '' === $slug ) {
-					continue;
-				}
-
-				$fields = array();
-				if ( isset( $repeater['fields'] ) && is_array( $repeater['fields'] ) ) {
-					foreach ( $repeater['fields'] as $field ) {
-						if ( ! is_array( $field ) ) {
-							continue;
-						}
-						$field_slug = '';
-						if ( isset( $field['slug'] ) ) {
-							$field_slug = sanitize_key( $field['slug'] );
-						} elseif ( isset( $field['name'] ) ) {
-							$field_slug = sanitize_key( $field['name'] );
-						}
-						if ( '' === $field_slug ) {
-							continue;
-						}
-						$fields[ $field_slug ] = $field;
-					}
-				}
-
-				$repeaters_index[ $slug ] = array(
-					'definition' => $repeater,
-					'fields' => $fields,
-				);
-			}
-		}
-
 		return array(
-			'fields' => $fields_index,
-			'repeaters' => $repeaters_index,
+			'fields' => $this->index_schema_entries(
+				isset( $schema_v2['fields'] ) ? $schema_v2['fields'] : array()
+			),
+			'repeaters' => $this->index_schema_repeaters(
+				isset( $schema_v2['repeaters'] ) ? $schema_v2['repeaters'] : array()
+			),
 		);
+	}
+
+	/**
+	 * Document type term assigned to a post.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return int Term ID, or 0 when the post has no type.
+	 */
+	private function get_assigned_doc_type_id( $post_id ) {
+		$assigned = wp_get_post_terms( $post_id, 'documentate_doc_type', array( 'fields' => 'ids' ) );
+
+		return ! is_wp_error( $assigned ) && ! empty( $assigned ) ? intval( $assigned[0] ) : 0;
+	}
+
+	/**
+	 * Slug of a schema entry, taken from its slug or falling back to its name.
+	 *
+	 * @param array $entry Schema field or repeater definition.
+	 * @return string Sanitized slug, or an empty string when it has neither.
+	 */
+	private function schema_entry_slug( array $entry ) {
+		if ( isset( $entry['slug'] ) ) {
+			return sanitize_key( $entry['slug'] );
+		}
+
+		if ( isset( $entry['name'] ) ) {
+			return sanitize_key( $entry['name'] );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Index schema entries by slug, dropping any that cannot be identified.
+	 *
+	 * @param mixed $entries Raw entry list from the stored schema.
+	 * @return array<string,array>
+	 */
+	private function index_schema_entries( $entries ) {
+		$index = array();
+
+		if ( ! is_array( $entries ) ) {
+			return $index;
+		}
+
+		foreach ( $entries as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+
+			$slug = $this->schema_entry_slug( $entry );
+			if ( '' === $slug ) {
+				continue;
+			}
+
+			$index[ $slug ] = $entry;
+		}
+
+		return $index;
+	}
+
+	/**
+	 * Index repeaters by slug, indexing each one's own fields as well.
+	 *
+	 * @param mixed $repeaters Raw repeater list from the stored schema.
+	 * @return array<string,array{definition:array,fields:array}>
+	 */
+	private function index_schema_repeaters( $repeaters ) {
+		$index = array();
+
+		if ( ! is_array( $repeaters ) ) {
+			return $index;
+		}
+
+		foreach ( $repeaters as $repeater ) {
+			if ( ! is_array( $repeater ) ) {
+				continue;
+			}
+
+			$slug = $this->schema_entry_slug( $repeater );
+			if ( '' === $slug ) {
+				continue;
+			}
+
+			$index[ $slug ] = array(
+				'definition' => $repeater,
+				'fields' => $this->index_schema_entries(
+					isset( $repeater['fields'] ) ? $repeater['fields'] : array()
+				),
+			);
+		}
+
+		return $index;
 	}
 
 	/**
@@ -2262,92 +2295,148 @@ class Documentate_Documents {
 	 * @return void
 	 */
 	private function save_dynamic_fields_meta( $post_id ) {
-		$schema = $this->get_dynamic_fields_schema_for_post( $post_id );
+		$post_values = $this->read_posted_values();
 
-		$post_values = array();
-		if ( isset( $_POST ) && is_array( $_POST ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			$post_values = wp_unslash( $_POST ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		}
+		$posted_array_fields = isset( $post_values['tpl_fields'] ) && is_array( $post_values['tpl_fields'] )
+			? $post_values['tpl_fields']
+			: array();
 
 		$known_meta_keys = array();
-		$posted_array_fields = array();
-		if ( isset( $post_values['tpl_fields'] ) && is_array( $post_values['tpl_fields'] ) ) {
-			$posted_array_fields = $post_values['tpl_fields'];
-		}
 
 		// Persist fields defined by the current schema (when available).
-		foreach ( (array) $schema as $definition ) {
-			if ( empty( $definition['slug'] ) ) {
-				continue;
-			}
-
-			$slug = sanitize_key( $definition['slug'] );
+		foreach ( (array) $this->get_dynamic_fields_schema_for_post( $post_id ) as $definition ) {
+			$slug = ! empty( $definition['slug'] ) ? sanitize_key( $definition['slug'] ) : '';
 			if ( '' === $slug ) {
 				continue;
 			}
 
-			$type = isset( $definition['type'] ) ? sanitize_key( $definition['type'] ) : 'textarea';
 			$meta_key = 'documentate_field_' . $slug;
 			$known_meta_keys[ $meta_key ] = true;
 
-			if ( 'array' === $type ) {
-				if ( isset( $posted_array_fields[ $slug ] ) ) {
-					$items = $this->sanitize_array_field_items( $posted_array_fields[ $slug ], $definition );
-					if ( empty( $items ) ) {
-						delete_post_meta( $post_id, $meta_key );
-					} else {
-						// Use JSON_HEX flags to encode quotes and other special chars as \uXXXX sequences.
-						// This avoids issues with WordPress's automatic slashing/unslashing of quotes.
-						// Do NOT use JSON_UNESCAPED_UNICODE so that accented characters are also encoded
-						// as \uXXXX, which allows fix_unescaped_unicode_sequences to handle them consistently.
-						$json_flags = JSON_HEX_QUOT | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS;
-						$json_value = wp_json_encode( $items, $json_flags );
-						update_post_meta( $post_id, $meta_key, $json_value );
-					}
-				}
-				continue;
-			}
-
-			if ( ! in_array( $type, array( 'single', 'textarea', 'rich' ), true ) ) {
-				$type = 'textarea';
-			}
-
-			if ( ! array_key_exists( $meta_key, $post_values ) ) {
-				continue;
-			}
-
-			$raw_value = $post_values[ $meta_key ];
-			$value = $this->sanitize_field_by_type( $raw_value, $type );
-
-			if ( '' === $value ) {
-				delete_post_meta( $post_id, $meta_key );
-			} else {
-				update_post_meta( $post_id, $meta_key, $value );
-			}
+			$this->save_schema_field( $post_id, $definition, $slug, $meta_key, $post_values, $posted_array_fields );
 		}
 
 		// Persist unknown dynamic fields posted that are not part of the schema
 		// (or when no schema is currently available for the post's type).
+		$this->save_unknown_field_meta( $post_id, $post_values, $known_meta_keys );
+	}
+
+	/**
+	 * Unslashed copy of the submitted request body.
+	 *
+	 * @return array
+	 */
+	private function read_posted_values() {
+		if ( ! isset( $_POST ) || ! is_array( $_POST ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			return array();
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce verified in can_save_meta_boxes(); every value is sanitized by type before it is stored.
+		return wp_unslash( $_POST );
+	}
+
+	/**
+	 * Persist one field declared by the document type schema.
+	 *
+	 * @param int    $post_id             Post ID.
+	 * @param array  $definition          Schema field definition.
+	 * @param string $slug                Sanitized field slug.
+	 * @param string $meta_key            Meta key the value is stored under.
+	 * @param array  $post_values         Unslashed request body.
+	 * @param array  $posted_array_fields Submitted repeater rows, keyed by slug.
+	 * @return void
+	 */
+	private function save_schema_field( $post_id, $definition, $slug, $meta_key, array $post_values, array $posted_array_fields ) {
+		$type = isset( $definition['type'] ) ? sanitize_key( $definition['type'] ) : 'textarea';
+
+		if ( 'array' === $type ) {
+			// Absent from the request means "not submitted", which must not
+			// clear rows the document already has.
+			if ( isset( $posted_array_fields[ $slug ] ) ) {
+				$items = $this->sanitize_array_field_items( $posted_array_fields[ $slug ], $definition );
+				$this->write_or_delete_meta( $post_id, $meta_key, $this->encode_array_field_items( $items ) );
+			}
+			return;
+		}
+
+		if ( ! in_array( $type, array( 'single', 'textarea', 'rich' ), true ) ) {
+			$type = 'textarea';
+		}
+
+		if ( ! array_key_exists( $meta_key, $post_values ) ) {
+			return;
+		}
+
+		$this->write_or_delete_meta(
+			$post_id,
+			$meta_key,
+			$this->sanitize_field_by_type( $post_values[ $meta_key ], $type )
+		);
+	}
+
+	/**
+	 * Encode repeater rows for storage.
+	 *
+	 * Uses the JSON_HEX flags so quotes and other special characters become
+	 * \uXXXX sequences, avoiding WordPress's automatic slashing and unslashing
+	 * of quotes. JSON_UNESCAPED_UNICODE is deliberately NOT used, so accented
+	 * characters are encoded the same way and fix_unescaped_unicode_sequences
+	 * can handle them consistently.
+	 *
+	 * @param array $items Sanitized repeater rows.
+	 * @return string JSON payload, or an empty string when there are no rows.
+	 */
+	private function encode_array_field_items( array $items ) {
+		if ( empty( $items ) ) {
+			return '';
+		}
+
+		$json_flags = JSON_HEX_QUOT | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS;
+
+		return (string) wp_json_encode( $items, $json_flags );
+	}
+
+	/**
+	 * Store a meta value, removing the key when the value is empty.
+	 *
+	 * @param int    $post_id  Post ID.
+	 * @param string $meta_key Meta key.
+	 * @param string $value    Sanitized value.
+	 * @return void
+	 */
+	private function write_or_delete_meta( $post_id, $meta_key, $value ) {
+		if ( '' === $value ) {
+			delete_post_meta( $post_id, $meta_key );
+			return;
+		}
+
+		update_post_meta( $post_id, $meta_key, $value );
+	}
+
+	/**
+	 * Persist posted field values the current schema does not declare.
+	 *
+	 * Keeps values written by a previous document type, or by any type when the
+	 * schema cannot be resolved.
+	 *
+	 * @param int   $post_id         Post ID.
+	 * @param array $post_values     Unslashed request body.
+	 * @param array $known_meta_keys Meta keys already handled by the schema pass.
+	 * @return void
+	 */
+	private function save_unknown_field_meta( $post_id, array $post_values, array $known_meta_keys ) {
 		foreach ( $post_values as $key => $value ) {
 			if ( ! is_string( $key ) || ! str_starts_with( $key, 'documentate_field_' ) ) {
 				continue;
 			}
-			if ( isset( $known_meta_keys[ $key ] ) ) {
-				continue;
-			}
-			if ( is_array( $value ) ) {
+			if ( isset( $known_meta_keys[ $key ] ) || is_array( $value ) ) {
 				continue;
 			}
 
 			$raw_value = wp_unslash( $value );
 			$raw_value = is_scalar( $raw_value ) ? (string) $raw_value : '';
-			$sanitized = $this->sanitize_rich_text_value( $raw_value );
 
-			if ( '' === $sanitized ) {
-				delete_post_meta( $post_id, $key );
-			} else {
-				update_post_meta( $post_id, $key, $sanitized );
-			}
+			$this->write_or_delete_meta( $post_id, $key, $this->sanitize_rich_text_value( $raw_value ) );
 		}
 	}
 

--- a/includes/custom-post-types/class-documentate-documents.php
+++ b/includes/custom-post-types/class-documentate-documents.php
@@ -190,7 +190,8 @@ class Documentate_Documents {
 	 *
 	 * @param int $object_id Post ID.
 	 * @param int $locked    Locked term ID.
-	 * @return bool False when the post already carries exactly the locked term.
+	 * @return bool False when the post already carries exactly the locked term, and
+	 *              also when the terms cannot be read, so the caller leaves them be.
 	 */
 	private function doc_type_drifted_from_lock( $object_id, $locked ) {
 		$current = wp_get_post_terms( $object_id, 'documentate_doc_type', array( 'fields' => 'ids' ) );

--- a/includes/custom-post-types/class-documentate-documents.php
+++ b/includes/custom-post-types/class-documentate-documents.php
@@ -2622,57 +2622,84 @@ class Documentate_Documents {
 			return $fields;
 		}
 
-		$fallback = array();
-		$schema = $this->get_dynamic_fields_schema_for_post( $post_id );
-		if ( ! empty( $schema ) ) {
-			foreach ( $schema as $row ) {
-				if ( empty( $row['slug'] ) ) {
-					continue;
-				}
-				$slug = sanitize_key( $row['slug'] );
-				if ( '' === $slug ) {
-					continue;
-				}
-				$meta_key = 'documentate_field_' . $slug;
-				$value = get_post_meta( $post_id, $meta_key, true );
-				if ( '' === $value ) {
-					continue;
-				}
-				$type = isset( $row['type'] ) ? sanitize_key( $row['type'] ) : 'textarea';
-				if ( 'array' === $type ) {
-					$encoded = '';
-					$stored = get_post_meta( $post_id, 'documentate_field_' . $slug, true );
-					if ( is_string( $stored ) && '' !== $stored ) {
-						$encoded = (string) $stored;
-					} else {
-						$legacy = get_post_meta( $post_id, 'documentate_' . $slug, true );
-						if ( empty( $legacy ) && 'annexes' === $slug ) {
-							$legacy = get_post_meta( $post_id, 'documentate_annexes', true );
-						}
-						if ( is_array( $legacy ) && ! empty( $legacy ) ) {
-							$encoded = wp_json_encode( $legacy, JSON_UNESCAPED_UNICODE );
-						}
-					}
+		return $this->build_field_values_from_meta( $post_id );
+	}
 
-					if ( '' !== $encoded ) {
-						$fallback[ $slug ] = array(
-							'value' => $encoded,
-							'type' => 'array',
-						);
-					}
-					continue;
-				}
-				if ( ! in_array( $type, array( 'single', 'textarea', 'rich' ), true ) ) {
-					$type = 'textarea';
-				}
-				$fallback[ $slug ] = array(
-					'value' => (string) $value,
-					'type' => $type,
-				);
+	/**
+	 * Rebuild field values from post meta.
+	 *
+	 * Used for documents saved before the values moved into post_content, so
+	 * the editor still shows what was stored back then.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return array<string, array{value:string,type:string}>
+	 */
+	private function build_field_values_from_meta( $post_id ) {
+		$fallback = array();
+
+		foreach ( $this->get_dynamic_fields_schema_for_post( $post_id ) as $row ) {
+			$slug = ! empty( $row['slug'] ) ? sanitize_key( $row['slug'] ) : '';
+			if ( '' === $slug ) {
+				continue;
 			}
+
+			$value = get_post_meta( $post_id, 'documentate_field_' . $slug, true );
+			if ( '' === $value ) {
+				continue;
+			}
+
+			$type = isset( $row['type'] ) ? sanitize_key( $row['type'] ) : 'textarea';
+
+			if ( 'array' === $type ) {
+				$encoded = $this->read_array_field_from_meta( $post_id, $slug );
+				if ( '' !== $encoded ) {
+					$fallback[ $slug ] = array(
+						'value' => $encoded,
+						'type' => 'array',
+					);
+				}
+				continue;
+			}
+
+			if ( ! in_array( $type, array( 'single', 'textarea', 'rich' ), true ) ) {
+				$type = 'textarea';
+			}
+
+			$fallback[ $slug ] = array(
+				'value' => (string) $value,
+				'type' => $type,
+			);
 		}
 
 		return $fallback;
+	}
+
+	/**
+	 * Read a repeater field from meta as a JSON string.
+	 *
+	 * Falls back to the pre-JSON meta keys, including the historical
+	 * documentate_annexes one, so older documents keep their rows.
+	 *
+	 * @param int    $post_id Post ID.
+	 * @param string $slug    Sanitized field slug.
+	 * @return string JSON payload, or an empty string when nothing is stored.
+	 */
+	private function read_array_field_from_meta( $post_id, $slug ) {
+		$stored = get_post_meta( $post_id, 'documentate_field_' . $slug, true );
+		if ( is_string( $stored ) && '' !== $stored ) {
+			return (string) $stored;
+		}
+
+		$legacy = get_post_meta( $post_id, 'documentate_' . $slug, true );
+		if ( empty( $legacy ) && 'annexes' === $slug ) {
+			$legacy = get_post_meta( $post_id, 'documentate_annexes', true );
+		}
+
+		if ( is_array( $legacy ) && ! empty( $legacy ) ) {
+			return (string) wp_json_encode( $legacy, JSON_UNESCAPED_UNICODE );
+		}
+
+		return '';
 	}
 
 	/**
@@ -3080,24 +3107,11 @@ class Documentate_Documents {
 	 * @return void
 	 */
 	public function apply_admin_filters( $query ) {
-		if ( ! is_admin() || ! $query->is_main_query() ) {
+		if ( ! $this->is_documents_list_query( $query ) ) {
 			return;
 		}
 
-		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
-		if ( ! $screen || 'edit-documentate_document' !== $screen->id ) {
-			return;
-		}
-
-		// Hide archived posts unless specifically requesting them.
-		$post_status = $query->get( 'post_status' );
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$show_archived = isset( $_GET['post_status'] ) && 'archived' === sanitize_key( $_GET['post_status'] );
-
-		if ( empty( $post_status ) && ! $show_archived ) {
-			// Default view: exclude archived.
-			$query->set( 'post_status', array( 'publish', 'pending', 'draft', 'private', 'future' ) );
-		}
+		$this->hide_archived_by_default( $query );
 
 		$orderby = $query->get( 'orderby' );
 
@@ -3106,55 +3120,95 @@ class Documentate_Documents {
 			$query->set( 'orderby', 'author' );
 		}
 
-		// Handle sorting by document type.
-		if ( 'doc_type' === $orderby ) {
-			add_filter(
-				'posts_clauses',
-				function ( $clauses, $wp_query ) {
-					global $wpdb;
+		// Sorting by a term name needs joins the default query cannot express.
+		$sortable_taxonomies = array(
+			'doc_type' => array( 'documentate_doc_type', 'dt' ),
+			'category_name' => array( 'category', 'ct' ),
+		);
 
-					if ( $wp_query->get( 'orderby' ) !== 'doc_type' ) {
-						return $clauses;
-					}
+		if ( isset( $sortable_taxonomies[ $orderby ] ) ) {
+			list( $taxonomy, $alias ) = $sortable_taxonomies[ $orderby ];
+			$this->sort_by_term_name( $orderby, $taxonomy, $alias );
+		}
+	}
 
-					$order = strtoupper( $wp_query->get( 'order' ) ) === 'ASC' ? 'ASC' : 'DESC';
-
-					$clauses['join'] .= " LEFT JOIN {$wpdb->term_relationships} AS dtr ON ({$wpdb->posts}.ID = dtr.object_id)";
-					$clauses['join'] .= " LEFT JOIN {$wpdb->term_taxonomy} AS dtt ON (dtr.term_taxonomy_id = dtt.term_taxonomy_id AND dtt.taxonomy = 'documentate_doc_type')";
-					$clauses['join'] .= " LEFT JOIN {$wpdb->terms} AS dt ON (dtt.term_id = dt.term_id)";
-					$clauses['orderby'] = "dt.name {$order}, " . $clauses['orderby'];
-
-					return $clauses;
-				},
-				10,
-				2,
-			);
+	/**
+	 * Whether this query is the documents list table's main query.
+	 *
+	 * @param WP_Query $query Query object.
+	 * @return bool
+	 */
+	private function is_documents_list_query( $query ) {
+		if ( ! is_admin() || ! $query->is_main_query() ) {
+			return false;
 		}
 
-		// Handle sorting by category.
-		if ( 'category_name' === $orderby ) {
-			add_filter(
-				'posts_clauses',
-				function ( $clauses, $wp_query ) {
-					global $wpdb;
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
 
-					if ( $wp_query->get( 'orderby' ) !== 'category_name' ) {
-						return $clauses;
-					}
+		return $screen && 'edit-documentate_document' === $screen->id;
+	}
 
-					$order = strtoupper( $wp_query->get( 'order' ) ) === 'ASC' ? 'ASC' : 'DESC';
-
-					$clauses['join'] .= " LEFT JOIN {$wpdb->term_relationships} AS ctr ON ({$wpdb->posts}.ID = ctr.object_id)";
-					$clauses['join'] .= " LEFT JOIN {$wpdb->term_taxonomy} AS ctt ON (ctr.term_taxonomy_id = ctt.term_taxonomy_id AND ctt.taxonomy = 'category')";
-					$clauses['join'] .= " LEFT JOIN {$wpdb->terms} AS ct ON (ctt.term_id = ct.term_id)";
-					$clauses['orderby'] = "ct.name {$order}, " . $clauses['orderby'];
-
-					return $clauses;
-				},
-				10,
-				2,
-			);
+	/**
+	 * Exclude archived documents unless the view asks for them.
+	 *
+	 * @param WP_Query $query Query object.
+	 * @return void
+	 */
+	private function hide_archived_by_default( $query ) {
+		if ( ! empty( $query->get( 'post_status' ) ) ) {
+			return;
 		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['post_status'] ) && 'archived' === sanitize_key( $_GET['post_status'] ) ) {
+			return;
+		}
+
+		// Default view: exclude archived.
+		$query->set( 'post_status', array( 'publish', 'pending', 'draft', 'private', 'future' ) );
+	}
+
+	/**
+	 * Order the list table by the name of a term in the given taxonomy.
+	 *
+	 * @param string $orderby  Value of the orderby query var this applies to.
+	 * @param string $taxonomy Taxonomy whose term name to sort on.
+	 * @param string $alias    Short prefix for the SQL table aliases.
+	 * @return void
+	 */
+	private function sort_by_term_name( $orderby, $taxonomy, $alias ) {
+		add_filter(
+			'posts_clauses',
+			static function ( $clauses, $wp_query ) use ( $orderby, $taxonomy, $alias ) {
+				global $wpdb;
+
+				if ( $wp_query->get( 'orderby' ) !== $orderby ) {
+					return $clauses;
+				}
+
+				$order = 'ASC' === strtoupper( $wp_query->get( 'order' ) ) ? 'ASC' : 'DESC';
+
+				$clauses['join'] .= " LEFT JOIN {$wpdb->term_relationships} AS {$alias}r"
+					. " ON ({$wpdb->posts}.ID = {$alias}r.object_id)";
+				// $alias is an internal table alias taken from the hardcoded map
+				// in apply_admin_filters(), never from a request; the taxonomy is
+				// the only value that varies and it goes through a placeholder.
+				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$clauses['join'] .= $wpdb->prepare(
+					" LEFT JOIN {$wpdb->term_taxonomy} AS {$alias}t"
+					. " ON ({$alias}r.term_taxonomy_id = {$alias}t.term_taxonomy_id AND {$alias}t.taxonomy = %s)",
+					$taxonomy
+				);
+				// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$clauses['join'] .= " LEFT JOIN {$wpdb->terms} AS {$alias}n"
+					. " ON ({$alias}t.term_id = {$alias}n.term_id)";
+				$clauses['orderby'] = "{$alias}n.name {$order}, " . $clauses['orderby'];
+
+				return $clauses;
+			},
+			10,
+			2,
+		);
 	}
 
 	/**

--- a/tests/unit/includes/DocumentateActionsMetaboxStateTest.php
+++ b/tests/unit/includes/DocumentateActionsMetaboxStateTest.php
@@ -37,6 +37,28 @@ class DocumentateActionsMetaboxStateTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Skip when the browser converter assets are not on disk.
+	 *
+	 * They are generated from node_modules by the postinstall hook rather than
+	 * committed, so a checkout that has not run `npm install` cannot exercise
+	 * the popup path: assets_available() is false and the metabox renders the
+	 * disabled buttons instead. CI installs the npm dependencies before
+	 * PHPUnit, so this case is still covered there.
+	 *
+	 * @return void
+	 */
+	private function requireWasmAssets() {
+		require_once plugin_dir_path( DOCUMENTATE_PLUGIN_FILE )
+			. 'includes/class-documentate-libreoffice-wasm-converter.php';
+
+		if ( ! Documentate_Libreoffice_Wasm_Converter::assets_available() ) {
+			$this->markTestSkipped(
+				'LibreOffice WASM glue not generated. Run "npm install" to exercise the popup path.'
+			);
+		}
+	}
+
+	/**
 	 * Configure the conversion engine used by the metabox.
 	 *
 	 * @param string $engine   Either collabora or wasm.
@@ -280,6 +302,7 @@ class DocumentateActionsMetaboxStateTest extends WP_UnitTestCase {
 	 * so the front-end opens the isolated converter popup.
 	 */
 	public function test_browser_wasm_engine_enables_popup_conversion() {
+		$this->requireWasmAssets();
 		$this->set_conversion( 'wasm' );
 
 		$markup = $this->render_for_template( 'odt' );

--- a/tests/unit/includes/custom-post-types/DocumentateArrayFieldRenderTest.php
+++ b/tests/unit/includes/custom-post-types/DocumentateArrayFieldRenderTest.php
@@ -55,11 +55,12 @@ class DocumentateArrayFieldRenderTest extends WP_UnitTestCase {
 	 * an unrecognised raw type, which is the only route that reaches the
 	 * data_type hint in map_single_input_type().
 	 *
-	 * @param string $key Field key.
+	 * @param string $key   Field key.
+	 * @param array  $extra Further raw keys to merge in.
 	 * @return array
 	 */
-	private function unmapped_raw_field( $key ) {
-		return array( $key => array( 'type' => 'moneda' ) );
+	private function unmapped_raw_field( $key, array $extra = array() ) {
+		return array( $key => array_merge( array( 'type' => 'moneda' ), $extra ) );
 	}
 
 	/**
@@ -215,5 +216,134 @@ class DocumentateArrayFieldRenderTest extends WP_UnitTestCase {
 		);
 
 		$this->assertStringContainsString( 'tpl_fields[anexos][0][titulo]', $markup );
+	}
+
+	/**
+	 * A textarea field renders a textarea carrying the row value.
+	 *
+	 * This is the third branch of the control split, and until now no test
+	 * reached it at all.
+	 */
+	public function test_textarea_field_renders_its_value() {
+		$markup = $this->render_row(
+			array(
+				'notas' => array(
+					'label' => 'Notas',
+					'type' => 'textarea',
+				),
+			),
+			array( 'notas' => 'Observaciones' )
+		);
+
+		$this->assertStringContainsString( '<textarea', $markup );
+		$this->assertStringContainsString( 'Observaciones', $markup );
+	}
+
+	/**
+	 * A textarea gets a default row count when the schema does not set one.
+	 */
+	public function test_textarea_field_gets_default_rows() {
+		$markup = $this->render_row(
+			array(
+				'notas' => array(
+					'label' => 'Notas',
+					'type' => 'textarea',
+				),
+			)
+		);
+
+		$this->assertStringContainsString( 'rows="6"', $markup );
+	}
+
+	/**
+	 * Every control type wires its help text to the control via aria-describedby.
+	 *
+	 * The description markup and the id that points at it are produced in two
+	 * different places, so a control that renders one without the other is
+	 * silently inaccessible rather than visibly broken.
+	 *
+	 * @dataProvider control_type_provider
+	 * @param string $type Control type under test.
+	 */
+	public function test_description_is_wired_to_the_control( $type ) {
+		$markup = $this->render_row(
+			array(
+				'campo' => array(
+					'label' => 'Campo',
+					'type' => $type,
+				),
+			),
+			array(),
+			false,
+			$this->unmapped_raw_field( 'campo', array( 'description' => 'Texto de ayuda' ) )
+		);
+
+		$this->assertStringContainsString( 'Texto de ayuda', $markup );
+		$this->assertStringContainsString( 'aria-describedby="documentate-anexos-campo-0-description"', $markup );
+	}
+
+	/**
+	 * Every control type exposes its validation message to both the browser and
+	 * the JS validator.
+	 *
+	 * @dataProvider control_type_provider
+	 * @param string $type Control type under test.
+	 */
+	public function test_validation_message_is_exposed( $type ) {
+		$markup = $this->render_row(
+			array(
+				'campo' => array(
+					'label' => 'Campo',
+					'type' => $type,
+				),
+			),
+			array(),
+			false,
+			$this->unmapped_raw_field( 'campo', array( 'patternmsg' => 'Formato no válido' ) )
+		);
+
+		$this->assertStringContainsString( 'data-validation-message="Formato no válido"', $markup );
+		$this->assertStringContainsString( 'data-documentate-validation-message="true"', $markup );
+	}
+
+	/**
+	 * Every control type renders leading help text before the control itself.
+	 *
+	 * @dataProvider control_type_provider
+	 * @param string $type Control type under test.
+	 */
+	public function test_before_description_precedes_the_control( $type ) {
+		$markup = $this->render_row(
+			array(
+				'campo' => array(
+					'label' => 'Campo',
+					'type' => $type,
+				),
+			),
+			array(),
+			false,
+			$this->unmapped_raw_field( 'campo', array( 'before_description' => 'Lee esto antes' ) )
+		);
+
+		$this->assertStringContainsString( 'Lee esto antes', $markup );
+		$this->assertStringContainsString( 'documentate-field-before-description-campo', $markup );
+		$this->assertLessThan(
+			strpos( $markup, 'id="documentate-anexos-campo-0"' ),
+			strpos( $markup, 'Lee esto antes' ),
+			'The leading help text must be emitted before the control it introduces.'
+		);
+	}
+
+	/**
+	 * The three control types the row renderer dispatches to.
+	 *
+	 * @return array<string,array{0:string}>
+	 */
+	public static function control_type_provider() {
+		return array(
+			'single' => array( 'single' ),
+			'rich' => array( 'rich' ),
+			'textarea' => array( 'textarea' ),
+		);
 	}
 }

--- a/tests/unit/includes/custom-post-types/DocumentateArrayFieldRenderTest.php
+++ b/tests/unit/includes/custom-post-types/DocumentateArrayFieldRenderTest.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * Rendering tests for repeater (array) field rows.
+ *
+ * These exist because splitting render_array_field_item() by control type
+ * dropped two variables that used to come from the enclosing scope, and
+ * nothing caught it: $definition, which carries the data_type hint, and
+ * $is_template, which marks the hidden row the front-end clones. Both failed
+ * silently - one was wrapped in isset(), the other only degraded a CSS class.
+ *
+ * @covers Documentate_Documents
+ */
+
+class DocumentateArrayFieldRenderTest extends WP_UnitTestCase {
+
+	/**
+	 * Instance under test.
+	 *
+	 * @var Documentate_Documents
+	 */
+	private $documents;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->documents = new Documentate_Documents();
+	}
+
+	/**
+	 * Render one repeater row and capture its markup.
+	 *
+	 * @param array $item_schema  Normalized item schema.
+	 * @param array $values       Current row values.
+	 * @param bool  $is_template  Whether this is the clone template row.
+	 * @param array $raw_fields   Raw schema definitions, keyed by field.
+	 * @return string
+	 */
+	private function render_row( array $item_schema, array $values = array(), $is_template = false, array $raw_fields = array() ) {
+		$method = ( new ReflectionClass( $this->documents ) )->getMethod( 'render_array_field_item' );
+		$method->setAccessible( true );
+
+		ob_start();
+		$method->invoke( $this->documents, 'anexos', '0', $item_schema, $values, $is_template, $raw_fields );
+
+		return ob_get_clean();
+	}
+
+	/**
+	 * Raw schema declaring a type the control map does not know.
+	 *
+	 * resolve_field_control_type() falls back to the item schema's own type for
+	 * an unrecognised raw type, which is the only route that reaches the
+	 * data_type hint in map_single_input_type().
+	 *
+	 * @param string $key Field key.
+	 * @return array
+	 */
+	private function unmapped_raw_field( $key ) {
+		return array( $key => array( 'type' => 'moneda' ) );
+	}
+
+	/**
+	 * A single field with a date data_type renders a date input.
+	 *
+	 * The data_type hint lives on the item schema entry, not on the raw field,
+	 * so it only reaches the control if that entry is passed down.
+	 */
+	public function test_single_field_honours_the_date_data_type() {
+		$markup = $this->render_row(
+			array(
+				'fecha' => array(
+					'label' => 'Fecha',
+					'type' => 'single',
+					'data_type' => 'date',
+				),
+			),
+			array(),
+			false,
+			$this->unmapped_raw_field( 'fecha' )
+		);
+
+		$this->assertStringContainsString( 'type="date"', $markup );
+	}
+
+	/**
+	 * The number data_type reaches the control too.
+	 */
+	public function test_single_field_honours_the_number_data_type() {
+		$markup = $this->render_row(
+			array(
+				'importe' => array(
+					'label' => 'Importe',
+					'type' => 'single',
+					'data_type' => 'number',
+				),
+			),
+			array(),
+			false,
+			$this->unmapped_raw_field( 'importe' )
+		);
+
+		$this->assertStringContainsString( 'type="number"', $markup );
+	}
+
+	/**
+	 * A boolean data_type renders a checkbox.
+	 */
+	public function test_single_field_honours_the_boolean_data_type() {
+		$markup = $this->render_row(
+			array(
+				'activo' => array(
+					'label' => 'Activo',
+					'type' => 'single',
+					'data_type' => 'boolean',
+				),
+			),
+			array(),
+			false,
+			$this->unmapped_raw_field( 'activo' )
+		);
+
+		$this->assertStringContainsString( 'type="checkbox"', $markup );
+	}
+
+	/**
+	 * Without a data_type hint the control stays a plain text input.
+	 */
+	public function test_single_field_defaults_to_text() {
+		$markup = $this->render_row(
+			array(
+				'titulo' => array(
+					'label' => 'Título',
+					'type' => 'single',
+				),
+			),
+			array(),
+			false,
+			$this->unmapped_raw_field( 'titulo' )
+		);
+
+		$this->assertStringContainsString( 'type="text"', $markup );
+	}
+
+	/**
+	 * The clone template row marks its rich control so the front-end can tell
+	 * it apart from a live row and skip initialising an editor on it.
+	 */
+	public function test_template_row_marks_its_rich_control() {
+		$schema = array(
+			'cuerpo' => array(
+				'label' => 'Cuerpo',
+				'type' => 'rich',
+			),
+		);
+
+		$this->assertStringContainsString(
+			'documentate-array-rich-template',
+			$this->render_row( $schema, array(), true )
+		);
+	}
+
+	/**
+	 * A live row does not carry the template marker.
+	 */
+	public function test_live_row_does_not_carry_the_template_marker() {
+		$schema = array(
+			'cuerpo' => array(
+				'label' => 'Cuerpo',
+				'type' => 'rich',
+			),
+		);
+
+		$markup = $this->render_row( $schema, array( 'cuerpo' => 'Contenido' ), false );
+
+		$this->assertStringContainsString( 'documentate-array-rich', $markup );
+		$this->assertStringNotContainsString( 'documentate-array-rich-template', $markup );
+	}
+
+	/**
+	 * Row values are rendered into their controls.
+	 */
+	public function test_row_values_are_rendered() {
+		$markup = $this->render_row(
+			array(
+				'titulo' => array(
+					'label' => 'Título',
+					'type' => 'single',
+				),
+			),
+			array( 'titulo' => 'Anexo I' ),
+			false,
+			$this->unmapped_raw_field( 'titulo' )
+		);
+
+		$this->assertStringContainsString( 'Anexo I', $markup );
+	}
+
+	/**
+	 * Field names are namespaced by repeater slug and row index.
+	 */
+	public function test_field_names_carry_slug_and_index() {
+		$markup = $this->render_row(
+			array(
+				'titulo' => array(
+					'label' => 'Título',
+					'type' => 'single',
+				),
+			),
+			array(),
+			false,
+			$this->unmapped_raw_field( 'titulo' )
+		);
+
+		$this->assertStringContainsString( 'tpl_fields[anexos][0][titulo]', $markup );
+	}
+}

--- a/tests/unit/includes/custom-post-types/DocumentateDocumentsHelpersTest.php
+++ b/tests/unit/includes/custom-post-types/DocumentateDocumentsHelpersTest.php
@@ -1,0 +1,297 @@
+<?php
+/**
+ * Tests for the helpers extracted from Documentate_Documents.
+ *
+ * These pin the behaviour the extractions had to preserve: how a schema entry
+ * gets its slug, which entries are dropped, how repeater rows are judged empty
+ * and encoded, and what the list table filters render.
+ *
+ * @covers Documentate_Documents
+ */
+
+class DocumentateDocumentsHelpersTest extends WP_UnitTestCase {
+
+	/**
+	 * Instance under test.
+	 *
+	 * @var Documentate_Documents
+	 */
+	private $documents;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->documents = new Documentate_Documents();
+	}
+
+	/**
+	 * Invoke a private method on the instance under test.
+	 *
+	 * @param string $name Method name.
+	 * @param array  $args Arguments.
+	 * @return mixed
+	 */
+	private function invoke( $name, array $args = array() ) {
+		$method = ( new ReflectionClass( $this->documents ) )->getMethod( $name );
+		$method->setAccessible( true );
+
+		return $method->invokeArgs( $this->documents, $args );
+	}
+
+	/**
+	 * A schema entry takes its slug from slug, then name.
+	 */
+	public function test_schema_entry_slug_prefers_slug_then_name() {
+		$this->assertSame(
+			'campo',
+			$this->invoke( 'schema_entry_slug', array( array( 'slug' => 'campo', 'name' => 'Otro' ) ) )
+		);
+
+		// sanitize_key() drops characters outside a-z0-9_-, so spaces collapse
+		// rather than becoming separators.
+		$this->assertSame(
+			'solonombre',
+			$this->invoke( 'schema_entry_slug', array( array( 'name' => 'Solo Nombre' ) ) )
+		);
+
+		$this->assertSame( '', $this->invoke( 'schema_entry_slug', array( array() ) ) );
+	}
+
+	/**
+	 * The slug is sanitised, not taken verbatim.
+	 */
+	public function test_schema_entry_slug_is_sanitised() {
+		$this->assertSame(
+			'mi-campo',
+			$this->invoke( 'schema_entry_slug', array( array( 'slug' => 'Mi-Campo' ) ) )
+		);
+	}
+
+	/**
+	 * Entries that cannot be identified are dropped rather than indexed.
+	 */
+	public function test_index_schema_entries_skips_unusable_entries() {
+		$index = $this->invoke(
+			'index_schema_entries',
+			array(
+				array(
+					array( 'slug' => 'uno' ),
+					'no soy un array',
+					array( 'sin_slug_ni_nombre' => 1 ),
+					array( 'name' => 'Dos' ),
+				),
+			)
+		);
+
+		$this->assertSame( array( 'uno', 'dos' ), array_keys( $index ) );
+	}
+
+	/**
+	 * A non-array payload yields an empty index instead of an error.
+	 */
+	public function test_index_schema_entries_tolerates_non_arrays() {
+		$this->assertSame( array(), $this->invoke( 'index_schema_entries', array( null ) ) );
+		$this->assertSame( array(), $this->invoke( 'index_schema_entries', array( 'texto' ) ) );
+	}
+
+	/**
+	 * Repeaters keep their definition and get their own fields indexed.
+	 */
+	public function test_index_schema_repeaters_indexes_nested_fields() {
+		$index = $this->invoke(
+			'index_schema_repeaters',
+			array(
+				array(
+					array(
+						'slug' => 'anexos',
+						'fields' => array(
+							array( 'slug' => 'numero' ),
+							array( 'name' => 'Contenido' ),
+							'basura',
+						),
+					),
+					array( 'no_identificable' => true ),
+				),
+			)
+		);
+
+		$this->assertSame( array( 'anexos' ), array_keys( $index ) );
+		$this->assertSame( array( 'numero', 'contenido' ), array_keys( $index['anexos']['fields'] ) );
+		$this->assertSame( 'anexos', $index['anexos']['definition']['slug'] );
+	}
+
+	/**
+	 * A repeater without fields still indexes, with an empty field list.
+	 */
+	public function test_index_schema_repeaters_without_fields() {
+		$index = $this->invoke( 'index_schema_repeaters', array( array( array( 'slug' => 'vacio' ) ) ) );
+
+		$this->assertSame( array(), $index['vacio']['fields'] );
+	}
+
+	/**
+	 * No rows encodes to an empty string, which callers treat as "delete".
+	 */
+	public function test_encode_array_field_items_empty() {
+		$this->assertSame( '', $this->invoke( 'encode_array_field_items', array( array() ) ) );
+	}
+
+	/**
+	 * Quotes and accents are escaped as \uXXXX so WordPress slashing is safe.
+	 */
+	public function test_encode_array_field_items_escapes_quotes_and_accents() {
+		$json = $this->invoke(
+			'encode_array_field_items',
+			array( array( array( 'texto' => 'Añadió "algo"' ) ) )
+		);
+
+		$this->assertStringNotContainsString( '"algo"', $json );
+		$this->assertStringNotContainsString( 'ñ', $json );
+		$this->assertSame( 'Añadió "algo"', json_decode( $json, true )[0]['texto'] );
+	}
+
+	/**
+	 * An empty value removes the meta key instead of storing a blank.
+	 */
+	public function test_write_or_delete_meta_removes_on_empty() {
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, 'documentate_field_x', 'algo' );
+
+		$this->invoke( 'write_or_delete_meta', array( $post_id, 'documentate_field_x', '' ) );
+
+		$this->assertSame( '', get_post_meta( $post_id, 'documentate_field_x', true ) );
+	}
+
+	/**
+	 * A non-empty value is stored.
+	 */
+	public function test_write_or_delete_meta_stores_value() {
+		$post_id = self::factory()->post->create();
+
+		$this->invoke( 'write_or_delete_meta', array( $post_id, 'documentate_field_x', 'valor' ) );
+
+		$this->assertSame( 'valor', get_post_meta( $post_id, 'documentate_field_x', true ) );
+	}
+
+	/**
+	 * A repeater row holding only empty markup counts as blank.
+	 */
+	public function test_array_item_has_content_ignores_empty_markup() {
+		$schema = array( 'cuerpo' => array( 'type' => 'rich' ) );
+
+		$this->assertFalse(
+			$this->invoke( 'array_item_has_content', array( array( 'cuerpo' => '<p></p>' ), $schema ) )
+		);
+		$this->assertTrue(
+			$this->invoke( 'array_item_has_content', array( array( 'cuerpo' => '<p>Hola</p>' ), $schema ) )
+		);
+	}
+
+	/**
+	 * Plain values are judged on their trimmed text.
+	 */
+	public function test_array_item_has_content_trims_plain_values() {
+		$schema = array( 'titulo' => array( 'type' => 'single' ) );
+
+		$this->assertFalse(
+			$this->invoke( 'array_item_has_content', array( array( 'titulo' => '   ' ), $schema ) )
+		);
+		$this->assertTrue(
+			$this->invoke( 'array_item_has_content', array( array( 'titulo' => ' x ' ), $schema ) )
+		);
+	}
+
+	/**
+	 * Keys absent from the row are filled in, and unknown keys dropped.
+	 */
+	public function test_sanitize_array_item_follows_the_schema() {
+		$filtered = $this->invoke(
+			'sanitize_array_item',
+			array(
+				array( 'titulo' => 'Uno', 'colado' => 'fuera' ),
+				array(
+					'titulo' => array( 'type' => 'single' ),
+					'ausente' => array( 'type' => 'single' ),
+				),
+			)
+		);
+
+		$this->assertSame( array( 'titulo', 'ausente' ), array_keys( $filtered ) );
+		$this->assertSame( '', $filtered['ausente'] );
+	}
+
+	/**
+	 * A filter with no options renders nothing at all.
+	 */
+	public function test_filter_select_renders_nothing_when_empty() {
+		ob_start();
+		$this->invoke(
+			'render_admin_filter_select',
+			array(
+				array(
+					'name' => 'author',
+					'id' => 'filter-by-author',
+					'all_label' => 'Todos',
+					'current' => '',
+					'options' => array(),
+				),
+			)
+		);
+
+		$this->assertSame( '', ob_get_clean() );
+	}
+
+	/**
+	 * The option matching the current value is the selected one.
+	 */
+	public function test_filter_select_marks_the_current_option() {
+		ob_start();
+		$this->invoke(
+			'render_admin_filter_select',
+			array(
+				array(
+					'name' => 'documentate_doc_type',
+					'id' => 'filter-by-doc-type',
+					'all_label' => 'Todos los tipos',
+					'current' => 'resolucion',
+					'options' => array(
+						'resolucion' => 'Resolución',
+						'informe' => 'Informe',
+					),
+				),
+			)
+		);
+		$markup = ob_get_clean();
+
+		$this->assertStringContainsString( '<select name="documentate_doc_type" id="filter-by-doc-type">', $markup );
+		$this->assertStringContainsString( '<option value="">Todos los tipos</option>', $markup );
+		$this->assertMatchesRegularExpression( '/<option value="resolucion" selected/', $markup );
+		$this->assertMatchesRegularExpression( '/<option value="informe">/', $markup );
+	}
+
+	/**
+	 * Option labels and values are escaped.
+	 */
+	public function test_filter_select_escapes_output() {
+		ob_start();
+		$this->invoke(
+			'render_admin_filter_select',
+			array(
+				array(
+					'name' => 'category_name',
+					'id' => 'filter-by-category',
+					'all_label' => 'Todas',
+					'current' => '',
+					'options' => array( 'x"><script>' => '<b>malo</b>' ),
+				),
+			)
+		);
+		$markup = ob_get_clean();
+
+		$this->assertStringNotContainsString( '<script>', $markup );
+		$this->assertStringNotContainsString( '<b>malo</b>', $markup );
+	}
+}

--- a/tests/unit/includes/custom-post-types/DocumentateDocumentsQueryTest.php
+++ b/tests/unit/includes/custom-post-types/DocumentateDocumentsQueryTest.php
@@ -1,0 +1,330 @@
+<?php
+/**
+ * Tests for the list table query helpers and the content-composition inputs.
+ *
+ * The taxonomy sort registers a posts_clauses filter, so it is exercised by
+ * applying that filter rather than by running a real admin request.
+ *
+ * @covers Documentate_Documents
+ */
+
+class DocumentateDocumentsQueryTest extends WP_UnitTestCase {
+
+	/**
+	 * Instance under test.
+	 *
+	 * @var Documentate_Documents
+	 */
+	private $documents;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->documents = new Documentate_Documents();
+		$_GET = array();
+		$_POST = array();
+	}
+
+	/**
+	 * Clean up superglobals between cases.
+	 */
+	public function tear_down() {
+		$_GET = array();
+		$_POST = array();
+		parent::tear_down();
+	}
+
+	/**
+	 * Invoke a private method on the instance under test.
+	 *
+	 * @param string $name Method name.
+	 * @param array  $args Arguments.
+	 * @return mixed
+	 */
+	private function invoke( $name, array $args = array() ) {
+		$method = ( new ReflectionClass( $this->documents ) )->getMethod( $name );
+		$method->setAccessible( true );
+
+		return $method->invokeArgs( $this->documents, $args );
+	}
+
+	/**
+	 * Build a query carrying the given vars.
+	 *
+	 * @param array $vars Query vars.
+	 * @return WP_Query
+	 */
+	private function query( array $vars = array() ) {
+		$query = new WP_Query();
+		foreach ( $vars as $key => $value ) {
+			$query->set( $key, $value );
+		}
+
+		return $query;
+	}
+
+	/**
+	 * Sorting by a term name joins the taxonomy tables and orders by the name.
+	 */
+	public function test_term_sort_joins_the_taxonomy_and_orders_by_name() {
+		$this->invoke( 'sort_by_term_name', array( 'doc_type', 'documentate_doc_type', 'dt' ) );
+
+		$clauses = apply_filters(
+			'posts_clauses',
+			array(
+				'join' => '',
+				'orderby' => 'post_date DESC',
+			),
+			$this->query(
+				array(
+					'orderby' => 'doc_type',
+					'order' => 'asc',
+				)
+			)
+		);
+
+		$this->assertStringContainsString( 'term_relationships', $clauses['join'] );
+		$this->assertStringContainsString( "dtt.taxonomy = 'documentate_doc_type'", $clauses['join'] );
+		$this->assertStringContainsString( 'dtn.name ASC', $clauses['orderby'] );
+
+		// The original ordering is kept as the tiebreaker.
+		$this->assertStringContainsString( 'post_date DESC', $clauses['orderby'] );
+	}
+
+	/**
+	 * Anything other than ASC falls back to descending.
+	 */
+	public function test_term_sort_defaults_to_descending() {
+		$this->invoke( 'sort_by_term_name', array( 'category_name', 'category', 'ct' ) );
+
+		$clauses = apply_filters(
+			'posts_clauses',
+			array(
+				'join' => '',
+				'orderby' => 'post_date DESC',
+			),
+			$this->query(
+				array(
+					'orderby' => 'category_name',
+					'order' => 'basura',
+				)
+			)
+		);
+
+		$this->assertStringContainsString( 'ctn.name DESC', $clauses['orderby'] );
+	}
+
+	/**
+	 * A query ordered by something else is left untouched.
+	 */
+	public function test_term_sort_ignores_other_queries() {
+		$this->invoke( 'sort_by_term_name', array( 'doc_type', 'documentate_doc_type', 'dt' ) );
+
+		$original = array(
+			'join' => '',
+			'orderby' => 'post_date DESC',
+		);
+
+		$clauses = apply_filters( 'posts_clauses', $original, $this->query( array( 'orderby' => 'title' ) ) );
+
+		$this->assertSame( $original, $clauses );
+	}
+
+	/**
+	 * The default view hides archived documents.
+	 */
+	public function test_archived_hidden_by_default() {
+		$query = $this->query();
+
+		$this->invoke( 'hide_archived_by_default', array( $query ) );
+
+		$statuses = $query->get( 'post_status' );
+		$this->assertContains( 'publish', $statuses );
+		$this->assertNotContains( 'archived', $statuses );
+	}
+
+	/**
+	 * An explicit status is respected.
+	 */
+	public function test_explicit_status_is_left_alone() {
+		$query = $this->query( array( 'post_status' => 'draft' ) );
+
+		$this->invoke( 'hide_archived_by_default', array( $query ) );
+
+		$this->assertSame( 'draft', $query->get( 'post_status' ) );
+	}
+
+	/**
+	 * Asking for the archived view does not get the default applied.
+	 */
+	public function test_archived_view_is_not_overridden() {
+		$_GET['post_status'] = 'archived';
+		$query = $this->query();
+
+		$this->invoke( 'hide_archived_by_default', array( $query ) );
+
+		$this->assertSame( '', $query->get( 'post_status' ) );
+	}
+
+	/**
+	 * A repeater stored as JSON is returned as-is.
+	 */
+	public function test_array_field_read_from_json_meta() {
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, 'documentate_field_anexos', '[{"n":"I"}]' );
+
+		$this->assertSame(
+			'[{"n":"I"}]',
+			$this->invoke( 'read_array_field_from_meta', array( $post_id, 'anexos' ) )
+		);
+	}
+
+	/**
+	 * An older array-valued meta key is encoded on the way out.
+	 */
+	public function test_array_field_read_from_legacy_meta() {
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, 'documentate_temas', array( array( 'n' => 'I' ) ) );
+
+		$json = $this->invoke( 'read_array_field_from_meta', array( $post_id, 'temas' ) );
+
+		$this->assertSame( array( array( 'n' => 'I' ) ), json_decode( $json, true ) );
+	}
+
+	/**
+	 * The historical annexes key is still honoured.
+	 */
+	public function test_array_field_read_from_historical_annexes_key() {
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, 'documentate_annexes', array( array( 'n' => 'II' ) ) );
+
+		$json = $this->invoke( 'read_array_field_from_meta', array( $post_id, 'annexes' ) );
+
+		$this->assertSame( array( array( 'n' => 'II' ) ), json_decode( $json, true ) );
+	}
+
+	/**
+	 * Nothing stored yields an empty string, which callers treat as absent.
+	 */
+	public function test_array_field_read_returns_empty_when_absent() {
+		$post_id = self::factory()->post->create();
+
+		$this->assertSame( '', $this->invoke( 'read_array_field_from_meta', array( $post_id, 'nada' ) ) );
+	}
+
+	/**
+	 * A stored value the schema no longer declares is carried over.
+	 */
+	public function test_carried_over_field_keeps_stored_value() {
+		$fields = $this->invoke(
+			'compose_carried_over_fields',
+			array(
+				array(
+					'huerfano' => array(
+						'value' => 'Valor previo',
+						'type' => 'textarea',
+					),
+				),
+				array(),
+			)
+		);
+
+		$this->assertSame( 'Valor previo', $fields['huerfano']['value'] );
+		$this->assertSame( 'textarea', $fields['huerfano']['type'] );
+	}
+
+	/**
+	 * A posted value wins over the stored one.
+	 */
+	public function test_carried_over_field_prefers_the_posted_value() {
+		$_POST['documentate_field_huerfano'] = 'Editado';
+
+		$fields = $this->invoke(
+			'compose_carried_over_fields',
+			array(
+				array(
+					'huerfano' => array(
+						'value' => 'Valor previo',
+						'type' => 'textarea',
+					),
+				),
+				array(),
+			)
+		);
+
+		$this->assertStringContainsString( 'Editado', $fields['huerfano']['value'] );
+	}
+
+	/**
+	 * Slugs the schema already handled are not carried over again.
+	 */
+	public function test_carried_over_field_skips_known_slugs() {
+		$fields = $this->invoke(
+			'compose_carried_over_fields',
+			array(
+				array(
+					'conocido' => array(
+						'value' => 'x',
+						'type' => 'rich',
+					),
+				),
+				array( 'conocido' => true ),
+			)
+		);
+
+		$this->assertSame( array(), $fields );
+	}
+
+	/**
+	 * An unrecognised stored type falls back to rich.
+	 */
+	public function test_carried_over_field_normalises_unknown_type() {
+		$fields = $this->invoke(
+			'compose_carried_over_fields',
+			array(
+				array(
+					'raro' => array(
+						'value' => 'x',
+						'type' => 'inventado',
+					),
+				),
+				array(),
+			)
+		);
+
+		$this->assertSame( 'rich', $fields['raro']['type'] );
+	}
+
+	/**
+	 * Posted field keys the schema and stored content did not know are added.
+	 */
+	public function test_posted_fields_add_unknown_slugs() {
+		$_POST['documentate_field_nuevo'] = 'Contenido';
+		$_POST['otra_cosa'] = 'ignorar';
+
+		$fields = $this->invoke( 'compose_posted_fields', array( array(), array() ) );
+
+		$this->assertArrayHasKey( 'nuevo', $fields );
+		$this->assertArrayNotHasKey( 'otra_cosa', $fields );
+	}
+
+	/**
+	 * Slugs already composed are not overwritten by the posted pass.
+	 */
+	public function test_posted_fields_skip_already_composed_slugs() {
+		$_POST['documentate_field_ya'] = 'Nuevo';
+
+		$fields = $this->invoke(
+			'compose_posted_fields',
+			array(
+				array( 'ya' => array( 'type' => 'rich', 'value' => 'Original' ) ),
+				array(),
+			)
+		);
+
+		$this->assertSame( array(), $fields );
+	}
+}


### PR DESCRIPTION
Third round on the PHPMD Code Size alerts, this time in `class-documentate-documents.php` — the largest remaining source after #234.

## Result

| Rule | `main` | This branch |
|---|---:|---:|
| `NPathComplexity` | 29 | **20** |
| `CyclomaticComplexity` | 26 | **18** |
| `ExcessiveMethodLength` | 7 | **6** |
| Class-level rules | 14 | 14 |
| **All alerts** | **76** | **58** |

In `class-documentate-documents.php` specifically: **28 alerts down to 10**.

| Method | `main` | Now |
|---|---|---|
| `filter_post_data_compose_content()` | NPath 172,540,368 · CC 41 | resolved |
| `save_dynamic_fields_meta()` | NPath 113,337 · CC 22 | resolved |
| `get_raw_schema_for_post()` | NPath 43,920 · CC 27 | resolved |
| `render_array_field_item()` | NPath 3,407,880 · CC 44 · 259 lines | NPath 6,152 · CC 15 |
| `get_structured_field_values()` | NPath 2,952 · CC 18 | resolved |
| `apply_admin_filters()` | NPath 2,700 · CC 16 | resolved |

## What the refactors found

The recurring shape in this file is **the same block copied per type, format or taxonomy**. Parameterising those removes the complexity and the risk that the copies drift apart:

- `add_admin_filters()` built three near-identical `<select>` dropdowns by hand — now one `render_admin_filter_select()`.
- `apply_admin_filters()` registered two `posts_clauses` closures differing only in taxonomy and SQL alias — now one parameterised `sort_by_term_name()`. The taxonomy reaches the join through `$wpdb->prepare()` instead of being interpolated.
- `get_raw_schema_for_post()` derived "slug, or name as a fallback" three times — now `schema_entry_slug()`.
- `save_dynamic_fields_meta()` spelled out "empty value deletes, otherwise update" three times — now `write_or_delete_meta()`.
- `compose_array_field()` and the meta save path both encoded repeater rows with a specific set of JSON flags, with a comment asking the two to stay in sync. They now share `encode_array_field_items()`, so that is enforced by construction.
- The three repeater controls each carried the same help-text block: leading text, description, validation message, the ids tying them to the control, and the two trailing paragraphs. Six binary decisions multiplied into whatever else the method did — a factor of 64, three times over. Now `build_field_help_context()`, `apply_help_attributes()` and `render_help_descriptions()`.

That last one is worth stating beyond the metric: the id in `aria-describedby` and the paragraph it points at were produced in two separate places, in triplicate. A control that renders one without the other is inaccessible without looking broken.

Two dead assignments were removed along the way: `$dynamic_schema` in the compose filter, assigned twice and never read.

## Two bugs this PR introduced, and how they were caught

Splitting `render_array_field_item()` by control type dropped two variables that came from the enclosing scope, and **both failed silently**:

- `render_array_item_single()` read `$definition['data_type']`, where `$definition` was the `foreach` loop variable. The read is wrapped in `isset()`, so PHP raised nothing — repeater columns declared `date`, `number` or `boolean` quietly rendered as plain text inputs.
- `render_array_item_rich()` read `$is_template`, a parameter of the caller. The `documentate-array-rich-template` class was never applied, so the front-end could no longer tell the clone template from a live row.

Neither PHPCS, nor the 1840 tests, nor the E2E suite detected them. `DocumentateArrayFieldRenderTest` now asserts what these variables control, and was verified against the broken code — 4 of its 8 tests fail there.

Patch coverage then showed `render_array_item_textarea()` was uncovered in full: the third branch of the split that no test reached. Eleven more tests cover it and the help-text branches across all three control types, including that the description is actually wired to its control via `aria-describedby`.

## A pre-existing failure fixed first

`make test` failed on `main` before any of this. #236 stopped committing `admin/vendor/libreoffice-converter`, generating it from `node_modules` instead, which silently broke a test added in #234: it needs `assets_available()` to be true, so on a checkout that has not run `npm install` the metabox renders disabled buttons and the assertion fails. CI never showed it, because `lint_and_test` runs `npm ci` before PHPUnit.

The test now states that precondition and skips with an actionable message, so `make test` is self-contained again.

## The class-level trade-off, stated plainly

Extracting methods within a class resolves method alerts and **worsens the class ones**:

| Class metric | `main` | Now |
|---|---:|---:|
| Lines | 3183 | 3603 |
| Methods | 63 | 96 |
| Class complexity | 535 | 537 |

That is the cost of this approach. Class complexity is roughly flat — the deduplication above removed real complexity rather than relocating it — but the class is larger and has more methods, so its four class-level alerts stay open.

Closing those means moving repeater rendering out of `Documentate_Documents` into its own class, the pattern used for `Documents_Input_Attributes` in #234. That is an architectural change with a different risk profile, so it belongs in its own PR rather than being bolted onto this one.

## Remaining alerts in this file

| Method | Alert |
|---|---|
| `render_sections_metabox()` | CC 37 · NPath 906,854,404 · 184 lines |
| `render_array_field_item()` | CC 15 · NPath 6,152 |
| `render_array_field()` | NPath 576 |
| the class itself | 4 class-level alerts |

## Verification

```
make lint            ✓ PHPCS/WPCS clean
make check-plugin    ✓ No errors found
make test            ✓ 1859 tests, 13171 assertions
make test-generation ✓ 400 tests, 9687 assertions
make test-e2e        ✓ green
```

Coverage: project 84.05% → **85.54%**, patch **88.11%**.

The generation suite matters here: `filter_post_data_compose_content()` writes the `post_content` that document rendering reads back, so it exercises the change end to end rather than just at the unit level.
