### PR TITLE
refactor: finish the repeater rendering complexity

### DIFF
--- a/includes/custom-post-types/class-documentate-documents.php
+++ b/includes/custom-post-types/class-documentate-documents.php
@@ -688,15 +688,38 @@ class Documentate_Documents {
 		}
 
 		$raw_field = isset( $raw_fields[ $slug ] ) ? $raw_fields[ $slug ] : array();
-		$type = isset( $row['type'] ) ? sanitize_key( $row['type'] ) : 'textarea';
+
+		return array_merge(
+			$this->prepare_field_control( $row, $raw_field, $label ),
+			array(
+				'slug' => $slug,
+				'field_type' => \Documentate\Documents\Documents_Field_Validator::extract_raw_type( $raw_field ),
+				'data_type' => isset( $row['data_type'] ) ? sanitize_key( $row['data_type'] ) : '',
+			)
+		);
+	}
+
+	/**
+	 * Resolve the label, control type and hover text shared by every field.
+	 *
+	 * Schema rows and repeater columns declare the same things in the same way,
+	 * so both arrive here rather than spelling the rules out twice.
+	 *
+	 * @param array  $definition    Field definition, from a schema row or an item schema.
+	 * @param array  $raw_field     Raw schema definition for the field.
+	 * @param string $default_label Label to use when the definition declares none.
+	 * @return array{label:string,type:string,raw_field:array,title_attribute:string}
+	 */
+	private function prepare_field_control( $definition, $raw_field, $default_label ) {
+		$label = isset( $definition['label'] )
+			? sanitize_text_field( $definition['label'] )
+			: $default_label;
+		$type = isset( $definition['type'] ) ? sanitize_key( $definition['type'] ) : 'textarea';
 		$field_title = $this->get_field_title( $raw_field );
 
 		return array(
-			'slug' => $slug,
 			'label' => '' !== $field_title ? $field_title : $label,
 			'type' => $this->resolve_field_control_type( $type, $raw_field ),
-			'field_type' => \Documentate\Documents\Documents_Field_Validator::extract_raw_type( $raw_field ),
-			'data_type' => isset( $row['data_type'] ) ? sanitize_key( $row['data_type'] ) : '',
 			'raw_field' => $raw_field,
 			'title_attribute' => $this->resolve_title_attribute( $raw_field, $field_title ),
 		);
@@ -785,7 +808,14 @@ class Documentate_Documents {
 		echo '>' . esc_html( $label ) . '</label></th>';
 		echo '<td>';
 		$this->render_before_description( $help['before'] );
-		$this->render_array_field( $slug, $label, $this->normalize_array_item_schema( $row ), $items, $raw_repeater );
+		$this->render_array_field(
+			$slug,
+			$label,
+			$title_attribute,
+			$this->normalize_array_item_schema( $row ),
+			$items,
+			$raw_repeater
+		);
 		$this->render_help_descriptions( $help );
 		echo '</td></tr>';
 	}
@@ -1765,38 +1795,32 @@ class Documentate_Documents {
 	/**
 	 * Render an array field with repeatable items.
 	 *
-	 * @param string $slug         Field slug.
-	 * @param string $label        Field label.
-	 * @param array  $item_schema  Item schema definition.
-	 * @param array  $items        Current values.
-	 * @param array  $raw_repeater Raw schema definition for this repeater.
+	 * The label and hover text are resolved by the caller, which already has to
+	 * know them to draw the surrounding table row.
+	 *
+	 * @param string $slug            Field slug.
+	 * @param string $label           Field label.
+	 * @param string $title_attribute Hover text for the repeater heading.
+	 * @param array  $item_schema     Item schema definition.
+	 * @param array  $items           Current values.
+	 * @param array  $raw_repeater    Raw schema definition for this repeater.
 	 * @return void
 	 */
-	private function render_array_field( $slug, $label, $item_schema, $items, $raw_repeater = array() ) {
+	private function render_array_field( $slug, $label, $title_attribute, $item_schema, $items, $raw_repeater = array() ) {
 		$slug = sanitize_key( $slug );
 		$label = sanitize_text_field( $label );
-		$repeater_source = isset( $raw_repeater['definition'] ) ? $raw_repeater['definition'] : array();
-		$repeater_title = $this->get_field_title( $repeater_source );
-		if ( '' !== $repeater_title ) {
-			$label = $repeater_title;
-		}
-		$repeater_title_attribute = $this->get_field_pattern_message( $repeater_source );
-		if ( '' === $repeater_title_attribute ) {
-			$repeater_title_attribute = $repeater_title;
-		}
 		$field_id = 'documentate-array-' . $slug;
 		$items = is_array( $items ) ? $items : array();
 		$item_schema = is_array( $item_schema ) ? $item_schema : array();
-		$raw_fields = array();
-		if ( isset( $raw_repeater['fields'] ) && is_array( $raw_repeater['fields'] ) ) {
-			$raw_fields = $raw_repeater['fields'];
-		}
+		$raw_fields = isset( $raw_repeater['fields'] ) && is_array( $raw_repeater['fields'] )
+			? $raw_repeater['fields']
+			: array();
 
 		echo '<div class="documentate-array-field" data-array-field="' . esc_attr( $slug ) . '" style="margin-bottom:24px;">';
 		echo '<div class="documentate-array-heading" style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px;gap:12px;">';
 		echo '<span class="documentate-array-title" style="font-weight:600;font-size:15px;"';
-		if ( '' !== $repeater_title_attribute ) {
-			echo ' title="' . esc_attr( $repeater_title_attribute ) . '"';
+		if ( '' !== $title_attribute ) {
+			echo ' title="' . esc_attr( $title_attribute ) . '"';
 		}
 		echo '>' . esc_html( $label ) . '</span>';
 		echo '<button type="button" class="button button-secondary documentate-array-add" data-array-target="'
@@ -1857,48 +1881,99 @@ class Documentate_Documents {
 		echo '</div>';
 
 		foreach ( $item_schema as $key => $definition ) {
-			$item_key = sanitize_key( $key );
-			if ( '' === $item_key ) {
+			$field = $this->prepare_array_item_field( $key, $definition, $raw_fields, $values, $slug, $index_attr );
+			if ( null === $field ) {
 				continue;
 			}
 
-			$field_name = 'tpl_fields[' . $slug . '][' . $index_attr . '][' . $item_key . ']';
-			$field_id = 'documentate-' . $slug . '-' . $item_key . '-' . $index_attr;
-			$label = isset( $definition['label'] )
-				? sanitize_text_field( $definition['label'] )
-				: $this->humanize_unknown_field_label( $item_key );
-			$type = isset( $definition['type'] ) ? sanitize_key( $definition['type'] ) : 'textarea';
-			$raw_field = isset( $raw_fields[ $item_key ] ) ? $raw_fields[ $item_key ] : array();
-			$type = $this->resolve_field_control_type( $type, $raw_field );
-			$value = isset( $values[ $item_key ] ) ? (string) $values[ $item_key ] : '';
-			$field_title = $this->get_field_title( $raw_field );
-			if ( '' !== $field_title ) {
-				$label = $field_title;
-			}
-			$field_title_attribute = $this->get_field_pattern_message( $raw_field );
-			if ( '' === $field_title_attribute ) {
-				$field_title_attribute = $field_title;
-			}
-
 			echo '<div class="documentate-array-field-control" style="margin-bottom:12px;">';
-			echo '<label for="' . esc_attr( $field_id ) . '" style="font-weight:600;display:block;margin-bottom:4px;"';
-			if ( '' !== $field_title_attribute ) {
-				echo ' title="' . esc_attr( $field_title_attribute ) . '"';
+			echo '<label for="' . esc_attr( $field['field_id'] ) . '" style="font-weight:600;display:block;margin-bottom:4px;"';
+			if ( '' !== $field['title_attribute'] ) {
+				echo ' title="' . esc_attr( $field['title_attribute'] ) . '"';
 			}
-			echo '>' . esc_html( $label ) . '</label>';
+			echo '>' . esc_html( $field['label'] ) . '</label>';
 
-			if ( 'single' === $type ) {
-				$this->render_array_item_single( $item_key, $field_name, $field_id, $label, $raw_field, $value, $definition );
-			} elseif ( 'rich' === $type ) {
-				$this->render_array_item_rich( $item_key, $field_name, $field_id, $raw_field, $value, $is_template );
-			} else {
-				$this->render_array_item_textarea( $item_key, $field_name, $field_id, $raw_field, $value );
-			}
+			$this->render_array_item_control( $field, $is_template );
 
 			echo '</div>';
 		}
 
 		echo '</div>';
+	}
+
+	/**
+	 * Resolve everything one column of a repeater row needs to draw itself.
+	 *
+	 * @param string $slug_key   Raw key of the column inside the item schema.
+	 * @param array  $definition Item schema entry for the column.
+	 * @param array  $raw_fields Raw schema definitions, keyed by column.
+	 * @param array  $values     Values stored for this row.
+	 * @param string $slug       Repeater slug.
+	 * @param string $index_attr Row index, already a string.
+	 * @return array|null Null when the column has no usable key.
+	 */
+	private function prepare_array_item_field( $slug_key, $definition, $raw_fields, $values, $slug, $index_attr ) {
+		$item_key = sanitize_key( $slug_key );
+		if ( '' === $item_key ) {
+			return null;
+		}
+
+		$raw_field = isset( $raw_fields[ $item_key ] ) ? $raw_fields[ $item_key ] : array();
+
+		return array_merge(
+			$this->prepare_field_control( $definition, $raw_field, $this->humanize_unknown_field_label( $item_key ) ),
+			array(
+				'item_key' => $item_key,
+				'field_name' => 'tpl_fields[' . $slug . '][' . $index_attr . '][' . $item_key . ']',
+				'field_id' => 'documentate-' . $slug . '-' . $item_key . '-' . $index_attr,
+				'value' => isset( $values[ $item_key ] ) ? (string) $values[ $item_key ] : '',
+				'definition' => $definition,
+			)
+		);
+	}
+
+	/**
+	 * Dispatch to the control matching a repeater column's type.
+	 *
+	 * @param array $field       Prepared column from prepare_array_item_field().
+	 * @param bool  $is_template Whether this row is the hidden clone template.
+	 * @return void
+	 */
+	private function render_array_item_control( $field, $is_template ) {
+		if ( 'single' === $field['type'] ) {
+			$this->render_array_item_single(
+				$field['item_key'],
+				$field['field_name'],
+				$field['field_id'],
+				$field['label'],
+				$field['raw_field'],
+				$field['value'],
+				$field['definition']
+			);
+
+			return;
+		}
+
+		if ( 'rich' === $field['type'] ) {
+			$this->render_array_item_rich(
+				$field['item_key'],
+				$field['field_name'],
+				$field['field_id'],
+				$field['raw_field'],
+				$field['value'],
+				$is_template
+			);
+
+			return;
+		}
+
+		$this->render_array_item_textarea(
+			$field['item_key'],
+			$field['field_name'],
+			$field['field_id'],
+			$field['raw_field'],
+			$field['value']
+		);
 	}
 
 	/**

--- a/tests/unit/includes/custom-post-types/DocumentateSchemaRowTest.php
+++ b/tests/unit/includes/custom-post-types/DocumentateSchemaRowTest.php
@@ -210,6 +210,94 @@ class DocumentateSchemaRowTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Prepare one repeater column.
+	 *
+	 * @param string $key        Column key.
+	 * @param array  $definition Item schema entry.
+	 * @param array  $raw_fields Raw definitions keyed by column.
+	 * @param array  $values     Row values.
+	 * @return array|null
+	 */
+	private function prepare_item( $key, array $definition, array $raw_fields = array(), array $values = array() ) {
+		return $this->invoke(
+			'prepare_array_item_field',
+			array( $key, $definition, $raw_fields, $values, 'anexos', '0' )
+		);
+	}
+
+	/**
+	 * A column key that sanitizes away is skipped.
+	 */
+	public function test_repeater_column_without_usable_key_is_skipped() {
+		$this->assertNull( $this->prepare_item( '///', array( 'label' => 'Roto' ) ) );
+	}
+
+	/**
+	 * The submitted name and DOM id carry the repeater slug and row index.
+	 */
+	public function test_repeater_column_names_carry_slug_and_index() {
+		$field = $this->prepare_item( 'titulo', array( 'label' => 'Título' ) );
+
+		$this->assertSame( 'tpl_fields[anexos][0][titulo]', $field['field_name'] );
+		$this->assertSame( 'documentate-anexos-titulo-0', $field['field_id'] );
+	}
+
+	/**
+	 * A column with no declared label falls back to a readable form of its key.
+	 */
+	public function test_repeater_column_label_falls_back_to_the_key() {
+		$field = $this->prepare_item( 'fecha_firma', array() );
+
+		$this->assertNotSame( '', $field['label'] );
+		$this->assertStringContainsStringIgnoringCase( 'firma', $field['label'] );
+	}
+
+	/**
+	 * The stored value for the column is picked up.
+	 */
+	public function test_repeater_column_reads_its_value() {
+		$field = $this->prepare_item(
+			'titulo',
+			array( 'label' => 'Título' ),
+			array(),
+			array( 'titulo' => 'Anexo I' )
+		);
+
+		$this->assertSame( 'Anexo I', $field['value'] );
+	}
+
+	/**
+	 * The item schema entry travels with the column.
+	 *
+	 * The single control reads its data_type hint from here, and losing this
+	 * on the way through was one of the two bugs #239 introduced.
+	 */
+	public function test_repeater_column_carries_its_definition() {
+		$definition = array(
+			'label' => 'Fecha',
+			'type' => 'single',
+			'data_type' => 'date',
+		);
+
+		$field = $this->prepare_item( 'fecha', $definition );
+
+		$this->assertSame( $definition, $field['definition'] );
+	}
+
+	/**
+	 * A raw title on the column replaces its label, as it does for schema rows.
+	 */
+	public function test_repeater_column_title_replaces_the_label() {
+		$field = $this->prepare_item(
+			'titulo',
+			array( 'label' => 'Título' ),
+			array( 'titulo' => array( 'title' => 'Título del anexo' ) )
+		);
+
+		$this->assertSame( 'Título del anexo', $field['label'] );
+	}
+
+	/**
 	 * A value stored under a non-array type is not treated as repeater rows.
 	 */
 	public function test_non_array_stored_value_yields_a_blank_row() {


### PR DESCRIPTION
Stacked on #240, which is stacked on #239. Review those first; GitHub retargets the base as each merges.

Fifth and last round on `class-documentate-documents.php`. **The file now has no method-level PHPMD alerts.**

## What is left

| | `main` | #239 | #240 | This PR |
|---|---:|---:|---:|---:|
| Plugin-wide alerts | 76 | 58 | 55 | **52** |

In this file, only the four class-level alerts remain. More on those below.

## The last two alerts

| Method | Before |
|---|---|
| `render_array_field_item()` | NPath 6,152 · CC 15 |
| `render_array_field()` | NPath 576 |

Both came from redoing work the caller had already done.

**`render_array_field()`** re-resolved the repeater's title and hover text from the raw definition. But `render_repeater_field_row()` resolves exactly the same values before calling it — it has to, to draw the surrounding table row. The `$label` parameter was being handed in and then overwritten with an identical value. It now takes the hover text alongside the label and trusts both.

`get_field_title()` sanitizes before returning, so dropping the second `sanitize_text_field()` over the same string changes nothing.

**`render_array_field_item()`** spelled out, per column, the same eight lines `prepare_schema_row()` already spells out per schema row:

```php
$label = isset( $definition['label'] ) ? sanitize_text_field( ... ) : $fallback;
$type  = isset( $definition['type'] ) ? sanitize_key( ... ) : 'textarea';
$raw_field = isset( $raw_fields[ $key ] ) ? ... : array();
$type = $this->resolve_field_control_type( $type, $raw_field );
$field_title = $this->get_field_title( $raw_field );
if ( '' !== $field_title ) { $label = $field_title; }
// ...and the pattern-message-or-title dance for the hover text
```

Both now call `prepare_field_control()`. `prepare_array_item_field()` adds what only a repeater column needs — submitted name, DOM id, stored value, and the item schema entry the single control reads its `data_type` from. The three-way type dispatch moved to `render_array_item_control()`.

## Why the class-level alerts are not touched

#239 said the next step was moving repeater rendering into its own class. Measuring before writing anything showed why that does not work yet, and why no single extraction closes these:

| Class metric | Now | Threshold | Gap |
|---|---:|---:|---:|
| Lines | 3755 | 2500 | **−1255** |
| Methods | 105 | 50 | **−55** |
| Complexity | 537 | 100 | **−437** |

The field-help subsystem — the most coherent movable unit, 13 methods — is ~252 lines. Extracting it closes **zero** alerts. These four need `Documentate_Documents` broken into several classes (metabox rendering, the save/compose pipeline, the admin list table), which is a multi-PR architectural project with a different risk profile, not a step that belongs here.

Worth stating plainly: extracting methods within one class, which is what #234, #239, #240 and this PR all did, resolves method alerts and cannot resolve class ones. The remaining four are the honest residue of that approach.

## Verification

Same technique as #240, since this is again a pure rendering refactor. A schema with **two repeater rows plus the clone template**, four column types, titles, descriptions and validation messages, and the field-and-repeater-sharing-a-slug case was rendered against the pre-refactor code and against this one.

**Byte-for-byte identical** — no deliberate exception this time.

`DocumentateSchemaRowTest` gains six cases for the column preparation, including that the item schema entry survives the trip. That variable going missing was one of the two bugs #239 introduced, so it now has a test that does not depend on rendering a full row to catch it.

```
make lint      ✓ PHPCS/WPCS clean
make test      ✓ 1877 tests, 13194 assertions
make test-e2e  ✓ 73 passed, 21 skipped
```
