### PR TITLE
refactor: split the sections metabox into per-row renderers

### DIFF
--- a/includes/custom-post-types/class-documentate-documents.php
+++ b/includes/custom-post-types/class-documentate-documents.php
@@ -653,156 +653,10 @@ class Documentate_Documents {
 		echo '<table class="form-table"><tbody>';
 
 		foreach ( $schema as $row ) {
-			if ( empty( $row['slug'] ) || empty( $row['label'] ) ) {
-				continue;
-			}
-
-			$slug = sanitize_key( $row['slug'] );
-			$label = sanitize_text_field( $row['label'] );
-
-			if ( '' === $slug || '' === $label ) {
-				continue;
-			}
-
-			if ( 'post_title' === $slug ) {
-				$known_meta_keys[] = 'documentate_field_' . $slug;
-				// Let WordPress handle the native title field.
-				continue;
-			}
-
-			$type = isset( $row['type'] ) ? sanitize_key( $row['type'] ) : 'textarea';
-			$raw_field = isset( $raw_fields[ $slug ] ) ? $raw_fields[ $slug ] : array();
-			$field_type = \Documentate\Documents\Documents_Field_Validator::extract_raw_type( $raw_field );
-			$data_type = isset( $row['data_type'] ) ? sanitize_key( $row['data_type'] ) : '';
-			$type = $this->resolve_field_control_type( $type, $raw_field );
-			$field_title = $this->get_field_title( $raw_field );
-			if ( '' !== $field_title ) {
-				$label = $field_title;
-			}
-			$field_title_attribute = $this->get_field_pattern_message( $raw_field );
-			if ( '' === $field_title_attribute ) {
-				$field_title_attribute = $field_title;
-			}
-
-			if ( 'array' === $type ) {
-				$item_schema = $this->normalize_array_item_schema( $row );
-				$items = array();
-				$raw_repeater = isset( $raw_schema['repeaters'][ $slug ] ) && is_array( $raw_schema['repeaters'][ $slug ] )
-					? $raw_schema['repeaters'][ $slug ]
-					: array();
-				$repeater_source = isset( $raw_repeater['definition'] ) ? $raw_repeater['definition'] : array();
-				$repeater_title = $this->get_field_title( $repeater_source );
-				if ( '' !== $repeater_title ) {
-					$label = $repeater_title;
-				}
-				$repeater_title_attribute = $this->get_field_pattern_message( $repeater_source );
-				if ( '' === $repeater_title_attribute ) {
-					$repeater_title_attribute = $repeater_title;
-				}
-
-				// Mark repeater meta key as known so it does not appear under unknown fields.
-				$meta_key = 'documentate_field_' . $slug;
+			$meta_key = $this->render_schema_row( $post, $row, $raw_schema, $raw_fields, $stored_fields );
+			if ( '' !== $meta_key ) {
 				$known_meta_keys[] = $meta_key;
-
-				if (
-					isset( $stored_fields[ $slug ] )
-					&& isset( $stored_fields[ $slug ]['type'] )
-					&& 'array' === $stored_fields[ $slug ]['type']
-				) {
-					$items = $this->get_array_field_items_from_structured( $stored_fields[ $slug ] );
-				}
-
-				if ( empty( $items ) ) {
-					$items = array( array() );
-				}
-
-				$before_description = $this->get_before_description_context( $meta_key, $slug, $raw_field );
-				$description = $this->get_field_description( $raw_field );
-				$validation = $this->get_field_validation_message( $raw_field );
-
-				echo '<tr class="documentate-field documentate-field-array documentate-field-' . esc_attr( $slug ) . '">';
-				echo '<th scope="row"><label';
-				if ( '' !== $repeater_title_attribute ) {
-					echo ' title="' . esc_attr( $repeater_title_attribute ) . '"';
-				}
-				echo '>' . esc_html( $label ) . '</label></th>';
-				echo '<td>';
-				$this->render_before_description( $before_description );
-				$this->render_array_field( $slug, $label, $item_schema, $items, $raw_repeater );
-				if ( '' !== $description ) {
-					echo '<p class="description">' . esc_html( $description ) . '</p>';
-				}
-				if ( '' !== $validation ) {
-					echo '<p class="description documentate-field-validation" data-documentate-validation-message="true">'
-							. esc_html( $validation )
-							. '</p>';
-				}
-				echo '</td></tr>';
-				continue;
 			}
-
-			if ( ! in_array( $type, array( 'single', 'textarea', 'rich' ), true ) ) {
-				$type = 'textarea';
-			}
-
-			$meta_key = 'documentate_field_' . $slug;
-			$known_meta_keys[] = $meta_key;
-			$value = '';
-
-			if ( isset( $stored_fields[ $slug ] ) ) {
-				$value = (string) $stored_fields[ $slug ]['value'];
-			}
-
-			$before_description = $this->get_before_description_context( $meta_key, $slug, $raw_field );
-			$description = $this->get_field_description( $raw_field );
-			$validation = $this->get_field_validation_message( $raw_field );
-			$description_id = '' !== $description ? $meta_key . '-description' : '';
-			$validation_id = '' !== $validation ? $meta_key . '-validation' : '';
-			$describedby = $this->build_describedby_ids( $before_description['id'], $description_id, $validation_id );
-
-			echo '<tr class="documentate-field documentate-field-'
-					. esc_attr( $slug )
-					. ' documentate-field-control-'
-					. esc_attr( $type )
-					. '">';
-			echo '<th scope="row"><label for="' . esc_attr( $meta_key ) . '"';
-			if ( '' !== $field_title_attribute ) {
-				echo ' title="' . esc_attr( $field_title_attribute ) . '"';
-			}
-			echo '>' . esc_html( $label ) . '</label></th>';
-			echo '<td>';
-			$this->render_before_description( $before_description );
-
-			if ( 'single' === $type ) {
-				$this->render_single_input_control(
-					$meta_key,
-					$label,
-					$value,
-					$field_type,
-					$data_type,
-					$raw_field,
-					$describedby,
-					$validation,
-				);
-			} elseif ( 'rich' === $type ) {
-				$is_locked = in_array( $post->post_status, array( 'publish', 'archived' ), true );
-				$this->render_rich_editor_control( $meta_key, $value, $is_locked, $raw_field, $describedby, $validation );
-			} else {
-				$this->render_textarea_control( $meta_key, $value, $raw_field, $describedby, $validation );
-			}
-
-			if ( '' !== $description ) {
-				echo '<p id="' . esc_attr( $description_id ) . '" class="description">' . esc_html( $description ) . '</p>';
-			}
-			if ( '' !== $validation ) {
-				echo '<p id="'
-						. esc_attr( $validation_id )
-						. '" class="description documentate-field-validation" data-documentate-validation-message="true">'
-						. esc_html( $validation )
-						. '</p>';
-			}
-
-			echo '</td></tr>';
 		}
 
 		echo '</tbody></table>';
@@ -810,6 +664,229 @@ class Documentate_Documents {
 		$unknown = $this->collect_unknown_dynamic_fields( $post->ID, $known_meta_keys );
 		$this->render_unknown_dynamic_fields_ui( $unknown );
 		echo '</div>';
+	}
+
+	/**
+	 * Normalize one schema row into the values its control needs.
+	 *
+	 * Rows without a usable slug and label are dropped here rather than in the
+	 * render loop, so the caller deals with fields it can actually draw.
+	 *
+	 * @param array $row        Raw schema row.
+	 * @param array $raw_fields Raw field definitions, keyed by slug.
+	 * @return array|null Null when the row cannot be rendered.
+	 */
+	private function prepare_schema_row( $row, $raw_fields ) {
+		if ( empty( $row['slug'] ) || empty( $row['label'] ) ) {
+			return null;
+		}
+
+		$slug = sanitize_key( $row['slug'] );
+		$label = sanitize_text_field( $row['label'] );
+		if ( '' === $slug || '' === $label ) {
+			return null;
+		}
+
+		$raw_field = isset( $raw_fields[ $slug ] ) ? $raw_fields[ $slug ] : array();
+		$type = isset( $row['type'] ) ? sanitize_key( $row['type'] ) : 'textarea';
+		$field_title = $this->get_field_title( $raw_field );
+
+		return array(
+			'slug' => $slug,
+			'label' => '' !== $field_title ? $field_title : $label,
+			'type' => $this->resolve_field_control_type( $type, $raw_field ),
+			'field_type' => \Documentate\Documents\Documents_Field_Validator::extract_raw_type( $raw_field ),
+			'data_type' => isset( $row['data_type'] ) ? sanitize_key( $row['data_type'] ) : '',
+			'raw_field' => $raw_field,
+			'title_attribute' => $this->resolve_title_attribute( $raw_field, $field_title ),
+		);
+	}
+
+	/**
+	 * Pick the text shown when hovering a field label.
+	 *
+	 * @param array  $raw_field   Raw schema definition for the field.
+	 * @param string $field_title Title already resolved for the field.
+	 * @return string
+	 */
+	private function resolve_title_attribute( $raw_field, $field_title ) {
+		$pattern_message = $this->get_field_pattern_message( $raw_field );
+
+		return '' !== $pattern_message ? $pattern_message : $field_title;
+	}
+
+	/**
+	 * Render one schema row and report the meta key it occupies.
+	 *
+	 * The key is returned even for rows that draw nothing, because the caller
+	 * uses it to decide which stored values still count as unknown fields.
+	 *
+	 * @param WP_Post $post          Post being edited.
+	 * @param array   $row           Raw schema row.
+	 * @param array   $raw_schema    Full raw schema, for repeater definitions.
+	 * @param array   $raw_fields    Raw field definitions, keyed by slug.
+	 * @param array   $stored_fields Structured values stored on the post.
+	 * @return string Meta key claimed by the row, or '' when the row was skipped.
+	 */
+	private function render_schema_row( $post, $row, $raw_schema, $raw_fields, $stored_fields ) {
+		$field = $this->prepare_schema_row( $row, $raw_fields );
+		if ( null === $field ) {
+			return '';
+		}
+
+		$meta_key = 'documentate_field_' . $field['slug'];
+
+		// WordPress draws the native title field itself.
+		if ( 'post_title' === $field['slug'] ) {
+			return $meta_key;
+		}
+
+		if ( 'array' === $field['type'] ) {
+			$this->render_repeater_field_row( $field, $meta_key, $row, $raw_schema, $stored_fields );
+
+			return $meta_key;
+		}
+
+		$this->render_scalar_field_row( $post, $field, $meta_key, $stored_fields );
+
+		return $meta_key;
+	}
+
+	/**
+	 * Render the table row holding a repeater.
+	 *
+	 * @param array  $field         Prepared field from prepare_schema_row().
+	 * @param string $meta_key      Meta key the repeater is stored under.
+	 * @param array  $row           Raw schema row, for the item schema.
+	 * @param array  $raw_schema    Full raw schema, for the repeater definition.
+	 * @param array  $stored_fields Structured values stored on the post.
+	 * @return void
+	 */
+	private function render_repeater_field_row( $field, $meta_key, $row, $raw_schema, $stored_fields ) {
+		$slug = $field['slug'];
+		$raw_repeater = isset( $raw_schema['repeaters'][ $slug ] ) && is_array( $raw_schema['repeaters'][ $slug ] )
+			? $raw_schema['repeaters'][ $slug ]
+			: array();
+		$repeater_source = isset( $raw_repeater['definition'] ) ? $raw_repeater['definition'] : array();
+
+		// A repeater carries its own title, which wins over the field's.
+		$repeater_title = $this->get_field_title( $repeater_source );
+		$label = '' !== $repeater_title ? $repeater_title : $field['label'];
+		$title_attribute = $this->resolve_title_attribute( $repeater_source, $repeater_title );
+
+		$items = $this->get_repeater_rows( $slug, $stored_fields );
+		$help = $this->build_field_help_context( $meta_key, $slug, $field['raw_field'] );
+
+		echo '<tr class="documentate-field documentate-field-array documentate-field-' . esc_attr( $slug ) . '">';
+		echo '<th scope="row"><label';
+		if ( '' !== $title_attribute ) {
+			echo ' title="' . esc_attr( $title_attribute ) . '"';
+		}
+		echo '>' . esc_html( $label ) . '</label></th>';
+		echo '<td>';
+		$this->render_before_description( $help['before'] );
+		$this->render_array_field( $slug, $label, $this->normalize_array_item_schema( $row ), $items, $raw_repeater );
+		$this->render_help_descriptions( $help );
+		echo '</td></tr>';
+	}
+
+	/**
+	 * Read the stored rows of a repeater, falling back to one blank row.
+	 *
+	 * The editor always shows at least one row, so an empty repeater still has
+	 * something to type into.
+	 *
+	 * @param string $slug          Repeater slug.
+	 * @param array  $stored_fields Structured values stored on the post.
+	 * @return array
+	 */
+	private function get_repeater_rows( $slug, $stored_fields ) {
+		$items = array();
+		if (
+			isset( $stored_fields[ $slug ] )
+			&& isset( $stored_fields[ $slug ]['type'] )
+			&& 'array' === $stored_fields[ $slug ]['type']
+		) {
+			$items = $this->get_array_field_items_from_structured( $stored_fields[ $slug ] );
+		}
+
+		return empty( $items ) ? array( array() ) : $items;
+	}
+
+	/**
+	 * Render the table row holding a scalar control.
+	 *
+	 * @param WP_Post $post          Post being edited.
+	 * @param array   $field         Prepared field from prepare_schema_row().
+	 * @param string  $meta_key      Meta key the value is stored under.
+	 * @param array   $stored_fields Structured values stored on the post.
+	 * @return void
+	 */
+	private function render_scalar_field_row( $post, $field, $meta_key, $stored_fields ) {
+		$slug = $field['slug'];
+		$type = in_array( $field['type'], array( 'single', 'textarea', 'rich' ), true ) ? $field['type'] : 'textarea';
+		$value = isset( $stored_fields[ $slug ] ) ? (string) $stored_fields[ $slug ]['value'] : '';
+		$help = $this->build_field_help_context( $meta_key, $slug, $field['raw_field'] );
+
+		echo '<tr class="documentate-field documentate-field-'
+				. esc_attr( $slug )
+				. ' documentate-field-control-'
+				. esc_attr( $type )
+				. '">';
+		echo '<th scope="row"><label for="' . esc_attr( $meta_key ) . '"';
+		if ( '' !== $field['title_attribute'] ) {
+			echo ' title="' . esc_attr( $field['title_attribute'] ) . '"';
+		}
+		echo '>' . esc_html( $field['label'] ) . '</label></th>';
+		echo '<td>';
+		$this->render_before_description( $help['before'] );
+		$this->render_scalar_control( $post, $field, $meta_key, $type, $value, $help );
+		$this->render_help_descriptions( $help );
+		echo '</td></tr>';
+	}
+
+	/**
+	 * Dispatch to the control matching a scalar field's type.
+	 *
+	 * @param WP_Post $post     Post being edited.
+	 * @param array   $field    Prepared field from prepare_schema_row().
+	 * @param string  $meta_key Meta key the value is stored under.
+	 * @param string  $type     Resolved control type.
+	 * @param string  $value    Current value.
+	 * @param array   $help     Context from build_field_help_context().
+	 * @return void
+	 */
+	private function render_scalar_control( $post, $field, $meta_key, $type, $value, $help ) {
+		if ( 'single' === $type ) {
+			$this->render_single_input_control(
+				$meta_key,
+				$field['label'],
+				$value,
+				$field['field_type'],
+				$field['data_type'],
+				$field['raw_field'],
+				$help['describedby'],
+				$help['validation'],
+			);
+
+			return;
+		}
+
+		if ( 'rich' === $type ) {
+			$is_locked = in_array( $post->post_status, array( 'publish', 'archived' ), true );
+			$this->render_rich_editor_control(
+				$meta_key,
+				$value,
+				$is_locked,
+				$field['raw_field'],
+				$help['describedby'],
+				$help['validation']
+			);
+
+			return;
+		}
+
+		$this->render_textarea_control( $meta_key, $value, $field['raw_field'], $help['describedby'], $help['validation'] );
 	}
 
 	/**

--- a/tests/unit/includes/custom-post-types/DocumentateSchemaRowTest.php
+++ b/tests/unit/includes/custom-post-types/DocumentateSchemaRowTest.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * Tests for the per-row preparation behind the sections metabox.
+ *
+ * These rules used to be inline `continue` statements and reassignments inside
+ * one 184-line loop, where nothing could reach them on their own.
+ *
+ * @covers Documentate_Documents
+ */
+
+class DocumentateSchemaRowTest extends WP_UnitTestCase {
+
+	/**
+	 * Instance under test.
+	 *
+	 * @var Documentate_Documents
+	 */
+	private $documents;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->documents = new Documentate_Documents();
+	}
+
+	/**
+	 * Invoke a private method on the instance under test.
+	 *
+	 * @param string $name Method name.
+	 * @param array  $args Arguments.
+	 * @return mixed
+	 */
+	private function invoke( $name, array $args = array() ) {
+		$method = ( new ReflectionClass( $this->documents ) )->getMethod( $name );
+		$method->setAccessible( true );
+
+		return $method->invokeArgs( $this->documents, $args );
+	}
+
+	/**
+	 * Prepare a schema row.
+	 *
+	 * @param array $row        Raw schema row.
+	 * @param array $raw_fields Raw field definitions.
+	 * @return array|null
+	 */
+	private function prepare( array $row, array $raw_fields = array() ) {
+		return $this->invoke( 'prepare_schema_row', array( $row, $raw_fields ) );
+	}
+
+	/**
+	 * A row missing its slug cannot be rendered.
+	 */
+	public function test_row_without_slug_is_dropped() {
+		$this->assertNull( $this->prepare( array( 'label' => 'Sin slug' ) ) );
+	}
+
+	/**
+	 * A row missing its label cannot be rendered either.
+	 */
+	public function test_row_without_label_is_dropped() {
+		$this->assertNull( $this->prepare( array( 'slug' => 'sin_label' ) ) );
+	}
+
+	/**
+	 * A slug that sanitizes away is dropped rather than rendered under an empty
+	 * meta key.
+	 */
+	public function test_row_with_unsanitizable_slug_is_dropped() {
+		$this->assertNull(
+			$this->prepare(
+				array(
+					'slug' => '///',
+					'label' => 'Etiqueta',
+				)
+			)
+		);
+	}
+
+	/**
+	 * A usable row keeps its slug and label.
+	 */
+	public function test_usable_row_keeps_slug_and_label() {
+		$field = $this->prepare(
+			array(
+				'slug' => 'resumen',
+				'label' => 'Resumen',
+				'type' => 'textarea',
+			)
+		);
+
+		$this->assertSame( 'resumen', $field['slug'] );
+		$this->assertSame( 'Resumen', $field['label'] );
+		$this->assertSame( 'textarea', $field['type'] );
+	}
+
+	/**
+	 * A title declared on the raw field replaces the schema label.
+	 */
+	public function test_raw_field_title_replaces_the_label() {
+		$field = $this->prepare(
+			array(
+				'slug' => 'resumen',
+				'label' => 'Resumen',
+				'type' => 'single',
+			),
+			array( 'resumen' => array( 'title' => 'Resumen ejecutivo' ) )
+		);
+
+		$this->assertSame( 'Resumen ejecutivo', $field['label'] );
+	}
+
+	/**
+	 * The hover text prefers the pattern message over the title, because it is
+	 * the more specific thing to tell someone about the field.
+	 */
+	public function test_title_attribute_prefers_the_pattern_message() {
+		$field = $this->prepare(
+			array(
+				'slug' => 'resumen',
+				'label' => 'Resumen',
+				'type' => 'single',
+			),
+			array(
+				'resumen' => array(
+					'title' => 'Resumen ejecutivo',
+					'patternmsg' => 'Formato inválido',
+				),
+			)
+		);
+
+		$this->assertSame( 'Formato inválido', $field['title_attribute'] );
+	}
+
+	/**
+	 * Without a pattern message the title is used instead.
+	 */
+	public function test_title_attribute_falls_back_to_the_title() {
+		$field = $this->prepare(
+			array(
+				'slug' => 'resumen',
+				'label' => 'Resumen',
+				'type' => 'single',
+			),
+			array( 'resumen' => array( 'title' => 'Resumen ejecutivo' ) )
+		);
+
+		$this->assertSame( 'Resumen ejecutivo', $field['title_attribute'] );
+	}
+
+	/**
+	 * The data_type hint travels with the row.
+	 */
+	public function test_data_type_is_carried_through() {
+		$field = $this->prepare(
+			array(
+				'slug' => 'fecha',
+				'label' => 'Fecha',
+				'type' => 'single',
+				'data_type' => 'date',
+			)
+		);
+
+		$this->assertSame( 'date', $field['data_type'] );
+	}
+
+	/**
+	 * A row with no type declared renders as a textarea.
+	 */
+	public function test_missing_type_defaults_to_textarea() {
+		$field = $this->prepare(
+			array(
+				'slug' => 'notas',
+				'label' => 'Notas',
+			)
+		);
+
+		$this->assertSame( 'textarea', $field['type'] );
+	}
+
+	/**
+	 * Stored repeater rows are returned as they were saved.
+	 */
+	public function test_repeater_rows_come_from_stored_values() {
+		$rows = $this->invoke(
+			'get_repeater_rows',
+			array(
+				'anexos',
+				array(
+					'anexos' => array(
+						'type' => 'array',
+						'value' => wp_json_encode( array( array( 'titulo' => 'Anexo I' ) ) ),
+					),
+				),
+			)
+		);
+
+		$this->assertCount( 1, $rows );
+		$this->assertSame( 'Anexo I', $rows[0]['titulo'] );
+	}
+
+	/**
+	 * An empty repeater still offers one row to type into.
+	 */
+	public function test_empty_repeater_gets_one_blank_row() {
+		$this->assertSame( array( array() ), $this->invoke( 'get_repeater_rows', array( 'anexos', array() ) ) );
+	}
+
+	/**
+	 * A value stored under a non-array type is not treated as repeater rows.
+	 */
+	public function test_non_array_stored_value_yields_a_blank_row() {
+		$rows = $this->invoke(
+			'get_repeater_rows',
+			array(
+				'anexos',
+				array(
+					'anexos' => array(
+						'type' => 'textarea',
+						'value' => 'texto suelto',
+					),
+				),
+			)
+		);
+
+		$this->assertSame( array( array() ), $rows );
+	}
+}


### PR DESCRIPTION
Follows #239, now merged; this branch is rebased onto `main` and carries a single commit.

(Reopened as a new PR: #240 was auto-closed when #239's branch was deleted on merge, and GitHub would not let it reopen.)

Fourth round on the PHPMD Code Size alerts. This one takes the worst method in the plugin.

## `render_sections_metabox()`

| | Before | Now |
|---|---:|---:|
| Cyclomatic complexity | 37 | resolved |
| NPath complexity | **906,854,404** | resolved |
| Length | 184 lines | resolved |

It opened the table, then ran a loop whose body held four skip conditions, the label and title resolution, a ~45-line repeater branch and a ~55-line scalar branch — all inline. Split along the seams that were already there:

| Method | Responsibility |
|---|---|
| `prepare_schema_row()` | skip rules and label/type resolution; `null` for a row that cannot be drawn |
| `render_schema_row()` | dispatch; returns the meta key the row claims |
| `render_repeater_field_row()` | the repeater table row |
| `render_scalar_field_row()` | the scalar table row |
| `render_scalar_control()` | single / rich / textarea |
| `get_repeater_rows()` | stored rows, or one blank row to type into |

`render_sections_metabox()` is now the table and the loop.

## Five copies, not three

#239 deduplicated the help-text block across the three repeater controls. Tracing what the repeater rendering actually depends on — 30 methods in the transitive closure, 18 of them shared with `render_sections_metabox` — turned up **two more copies of the same block** inside the metabox itself, one per branch:

```php
$before_description = $this->get_before_description_context( $meta_key, $slug, $raw_field );
$description        = $this->get_field_description( $raw_field );
$validation         = $this->get_field_validation_message( $raw_field );
$description_id     = '' !== $description ? $meta_key . '-description' : '';
$validation_id      = '' !== $validation ? $meta_key . '-validation' : '';
$describedby        = $this->build_describedby_ids( ... );
```

Both branches now call `build_field_help_context()` and `render_help_descriptions()`.

That closure analysis also ruled out the plan stated in #239 — moving repeater rendering into its own class. With 18 helpers shared with the metabox, that would have duplicated exactly what #239 removed. Sharing the help subsystem first is the prerequisite; the class extraction becomes viable afterwards.

## Result

| | `main` | #239 | This PR |
|---|---:|---:|---:|
| Plugin-wide alerts | 76 | 58 | **55** |

Remaining in `class-documentate-documents.php`: `render_array_field()` (NPath 576), `render_array_field_item()` (CC 15 · NPath 6,152), and the four class-level alerts.

## Verification

This is a pure rendering refactor, so the suite passing is necessary but not sufficient. The markup was diffed directly: a schema covering every control type, both branches, help text, `title`/`patternmsg` resolution, stored values and skipped rows was rendered against the pre-refactor code and against this one.

**Byte-for-byte identical**, with one deliberate exception: the repeater row's help paragraphs now carry the same ids the scalar row's always had. Nothing references them, and it only surfaces when a schema declares a field and a repeater under one slug. The omission was an inconsistency between two copies of the same block, not a decision.

Two things that nearly produced a false result, and how they were caught:

- The first harness used invented filter names to inject a schema. They do not exist, so it rendered the empty-schema path — a comparison of nothing against nothing. It now uses the real `SchemaStorage` setup the existing tests use, and asserts on the dump's size and content before the comparison is trusted.
- The first diff came back identical but never reached the repeater's help paragraphs, because the description lived in `repeaters` while that branch reads from `fields`. Forcing that case is what surfaced the id change above.

`prepare_schema_row()` is pure, so the skip rules can finally be tested on their own rather than only through a rendered metabox. `DocumentateSchemaRowTest` covers them, plus the title/pattern precedence and the repeater row fallback.

```
make lint      ✓ PHPCS/WPCS clean
make test      ✓ 1871 tests, 13186 assertions
make test-e2e  ✓ 73 passed, 21 skipped
```

