### PR TITLE
Vendor the WordPress agent skills and document the AutoFirma invariants

### DIFF
--- a/.agents/skills/blueprint/SKILL.md
+++ b/.agents/skills/blueprint/SKILL.md
@@ -1,0 +1,419 @@
+---
+name: blueprint
+description: Use when the deliverable is WordPress Playground Blueprint JSON or a Blueprint bundle, including creating, editing, reviewing, validating schema keys, choosing steps/resources, and debugging Blueprint files. For only running or sharing a Playground environment, use wp-playground.
+compatibility: "WordPress 7.0+, PHP 7.4.0+. Optionally Playground CLI or a browser"
+---
+
+# WordPress Playground Blueprints
+
+## Overview
+
+A Blueprint is a JSON file that declaratively configures a WordPress Playground instance — installing plugins/themes, setting options, running PHP/SQL, manipulating files, and more.
+
+**Core principle:** Blueprints are trusted JSON-only declarations. No arbitrary JavaScript. They work on web, Node.js, and CLI.
+
+## Quick Start Template
+
+```json
+{
+  "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+  "landingPage": "/wp-admin/",
+  "preferredVersions": { "php": "8.3", "wp": "latest" },
+  "steps": [{ "step": "login" }]
+}
+```
+
+## Top-Level Properties
+
+All optional. Only documented keys are allowed — the schema rejects unknown properties.
+
+| Property | Type | Notes |
+|----------|------|-------|
+| `$schema` | string | Always `"https://playground.wordpress.net/blueprint-schema.json"` |
+| `landingPage` | string | Relative path, e.g. `/wp-admin/` |
+| `description` | string | Deprecated optional top-level description. Prefer `meta.description` for new Blueprints |
+| `meta` | object | `{ title, author, description?, categories? }` — title and author required |
+| `preferredVersions` | object | `{ php, wp }` — both required when present |
+| `features` | object | `{ networking?: boolean, intl?: boolean }` — **only** these two keys, nothing else. Networking defaults to `true` |
+| `phpExtensionBundles` | any | Deprecated/no longer used; the schema leaves the value unconstrained and says to remove it from Blueprints |
+| `extraLibraries` | array | `["wp-cli"]` — auto-included when any `wp-cli` step is present |
+| `constants` | object | Shorthand for `defineWpConfigConsts`. Values: string/boolean/number |
+| `plugins` | array | Shorthand for `installPlugin` steps. Strings = wp.org slugs |
+| `siteOptions` | object | Shorthand for `setSiteOptions` |
+| `login` | boolean or object | `true` = login as admin. Object = `{ username?, password? }` (both default to `"admin"`/`"password"`) |
+| `steps` | array | Main execution pipeline. Runs after shorthands |
+
+### preferredVersions Values
+
+- **php:** Major.minor only: `"7.4"`, `"8.0"`, `"8.1"`, `"8.2"`, `"8.3"`, `"8.4"`, `"8.5"`, or `"latest"`. Patch versions like `"7.4.1"` are invalid. Check the schema for currently supported versions.
+- **wp:** Recent major versions, `"latest"`, `"beta"`, `"nightly"`/`"trunk"`, or a URL to a custom zip. The schema also accepts `false` for PHP-only Playground; do not combine `wp: false` with WordPress-only fields such as `plugins`, `siteOptions`, `login`, or WordPress-only steps.
+
+### Shorthands vs Steps
+
+Shorthands (`login`, `plugins`, `siteOptions`, `constants`) are expanded and prepended to `steps` in an **unspecified order**. Use explicit steps when execution order matters.
+
+## Resource References
+
+Resources tell Playground where to find files. Used by `installPlugin`, `installTheme`, `writeFile`, `writeFiles`, `importWxr`, etc.
+
+| Resource Type | Required Fields | Example |
+|--------------|----------------|---------|
+| `wordpress.org/plugins` | `slug` | `{ "resource": "wordpress.org/plugins", "slug": "woocommerce" }` |
+| `wordpress.org/themes` | `slug` | `{ "resource": "wordpress.org/themes", "slug": "astra" }` |
+| `url` | `url` | `{ "resource": "url", "url": "https://example.com/plugin.zip" }` |
+| `git:directory` | `url`, `ref` | See below |
+| `literal` | `name`, `contents` | `{ "resource": "literal", "name": "file.txt", "contents": "hello" }` |
+| `literal:directory` | `name`, `files` | See below |
+| `bundled` | `path` | References a file within a blueprint bundle (e.g. `{ "resource": "bundled", "path": "/plugin.zip" }`) |
+| `zip` | `inner` | Wraps another resource in a ZIP — use when a step expects a zip but your source isn't one (e.g. wrapping a `url` resource pointing to a raw directory) |
+
+### git:directory — Installing from GitHub
+
+```json
+{
+  "resource": "git:directory",
+  "url": "https://github.com/WordPress/gutenberg",
+  "ref": "trunk",
+  "refType": "branch",
+  "path": "/"
+}
+```
+
+- When using a branch or tag name for `ref`, you **must** set `refType` (`"branch"` | `"tag"` | `"commit"` | `"refname"`). Without it, only `"HEAD"` resolves reliably.
+- `path` selects a subdirectory (defaults to repo root).
+
+### literal:directory — Inline File Trees
+
+```json
+{
+  "resource": "literal:directory",
+  "name": "my-plugin",
+  "files": {
+    "plugin.php": "<?php /* Plugin Name: My Plugin */ ?>",
+    "includes": {
+      "helper.php": "<?php // helper code ?>"
+    }
+  }
+}
+```
+
+- `files` uses nested objects for subdirectories — keys are filenames or directory names, values are **plain strings** (file content) or **objects** (subdirectories). Never use resource references as values.
+- **Do NOT use path separators in keys** (e.g. `"includes/helper.php"` is wrong — use a nested `"includes": { "helper.php": "..." }` object).
+
+## Steps Reference
+
+Every step requires `"step": "<name>"`. Any step can optionally include `"progress": { "weight": 1, "caption": "Installing..." }` for UI feedback.
+
+### Plugin & Theme Installation
+
+```json
+{
+  "step": "installPlugin",
+  "pluginData": { "resource": "wordpress.org/plugins", "slug": "gutenberg" },
+  "options": { "activate": true, "targetFolderName": "gutenberg" },
+  "ifAlreadyInstalled": "overwrite"
+}
+```
+
+```json
+{
+  "step": "installTheme",
+  "themeData": { "resource": "wordpress.org/themes", "slug": "twentytwentyfour" },
+  "options": { "activate": true, "importStarterContent": true },
+  "ifAlreadyInstalled": "overwrite"
+}
+```
+
+- Use `pluginData` / `themeData` — **NOT** the deprecated `pluginZipFile` / `themeZipFile`.
+- `pluginData` / `themeData` accept any FileReference or DirectoryReference — a zip URL, a `wordpress.org/plugins` slug, a `git:directory`, or a `literal:directory` (no `zip` wrapper needed).
+- `options.activate` controls activation. No need for a separate `activatePlugin`/`activateTheme` step when using `installPlugin`/`installTheme`.
+- `ifAlreadyInstalled`: `"overwrite"` | `"skip"` | `"error"`
+
+### Activation (standalone)
+
+Only needed for plugins/themes already on disk (e.g. after `writeFile`/`writeFiles`):
+
+```json
+{ "step": "activatePlugin", "pluginPath": "my-plugin/my-plugin.php" }
+```
+```json
+{ "step": "activateTheme", "themeFolderName": "twentytwentyfour" }
+```
+
+### File Operations
+
+```json
+{ "step": "writeFile", "path": "/wordpress/wp-content/mu-plugins/custom.php", "data": "<?php // code" }
+```
+
+`data` accepts a plain string (as shown above) or a resource reference (e.g. `{ "resource": "url", "url": "https://..." }`).
+
+```json
+{
+  "step": "writeFiles",
+  "writeToPath": "/wordpress/wp-content/plugins/",
+  "filesTree": {
+    "resource": "literal:directory",
+    "name": "my-plugin",
+    "files": {
+      "plugin.php": "<?php\n/*\nPlugin Name: My Plugin\n*/",
+      "includes": {
+        "helpers.php": "<?php // helpers"
+      }
+    }
+  }
+}
+```
+
+**`writeFiles` requires a DirectoryReference** (`literal:directory` or `git:directory`) as `filesTree` — not a plain object.
+
+Other file operations: `mkdir`, `cp`, `mv`, `rm`, `rmdir`, `unzip`.
+
+### Running Code
+
+**runPHP:**
+```json
+{ "step": "runPHP", "code": "<?php require '/wordpress/wp-load.php'; update_option('key', 'value');" }
+```
+**GOTCHA:** You must `require '/wordpress/wp-load.php';` to use any WordPress functions.
+
+**wp-cli:**
+```json
+{ "step": "wp-cli", "command": "wp post create --post_type=page --post_title='Hello' --post_status=publish" }
+```
+The step name is `wp-cli` (with hyphen), NOT `cli` or `wpcli`.
+
+**runSql:**
+```json
+{ "step": "runSql", "sql": { "resource": "literal", "name": "q.sql", "contents": "UPDATE wp_options SET option_value='val' WHERE option_name='key';" } }
+```
+
+### Site Configuration
+
+```json
+{ "step": "setSiteOptions", "options": { "blogname": "My Site", "blogdescription": "A tagline" } }
+```
+```json
+{ "step": "defineWpConfigConsts", "consts": { "WP_DEBUG": true } }
+```
+```json
+{ "step": "setSiteLanguage", "language": "en_US" }
+```
+```json
+{ "step": "defineSiteUrl", "siteUrl": "https://example.com" }
+```
+
+### Other Steps
+
+| Step | Key Properties |
+|------|---------------|
+| `login` | `username?`, `password?` (default `"admin"` / `"password"`) |
+| `enableMultisite` | (no required props) |
+| `importWxr` | `file` (FileReference) |
+| `importThemeStarterContent` | `themeSlug?` |
+| `importWordPressFiles` | `wordPressFilesZip`, `pathInZip?` — imports a full WordPress directory from a zip |
+| `request` | `request: { url, method?, headers?, body? }` |
+| `updateUserMeta` | `userId`, `meta` |
+| `runWpInstallationWizard` | `options?` — runs the WP install wizard with given options |
+| `resetData` | (no props) |
+
+## Common Patterns
+
+### Inline mu-plugin (quick custom code)
+
+```json
+{
+  "step": "writeFile",
+  "path": "/wordpress/wp-content/mu-plugins/custom.php",
+  "data": "<?php\n// mu-plugins load automatically — no activation needed, no require wp-load.php\nadd_filter('show_admin_bar', '__return_false');"
+}
+```
+
+### Inline plugin with multiple files
+
+```json
+{
+  "step": "writeFiles",
+  "writeToPath": "/wordpress/wp-content/plugins/",
+  "filesTree": {
+    "resource": "literal:directory",
+    "name": "my-plugin",
+    "files": {
+      "my-plugin.php": "<?php\n/*\nPlugin Name: My Plugin\n*/\nrequire __DIR__ . '/includes/main.php';",
+      "includes": {
+        "main.php": "<?php // main logic"
+      }
+    }
+  }
+}
+```
+
+Then activate it with a separate step:
+
+```json
+{ "step": "activatePlugin", "pluginPath": "my-plugin/my-plugin.php" }
+```
+
+### Plugin from a GitHub branch
+
+```json
+{
+  "step": "installPlugin",
+  "pluginData": {
+    "resource": "git:directory",
+    "url": "https://github.com/user/repo",
+    "ref": "feature-branch",
+    "refType": "branch",
+    "path": "/"
+  }
+}
+```
+
+## Common Mistakes
+
+| Mistake | Correct |
+|---------|---------|
+| `pluginZipFile` / `themeZipFile` | `pluginData` / `themeData` |
+| `"step": "cli"` | `"step": "wp-cli"` |
+| Flat object as `writeFiles.filesTree` | Must be a `literal:directory` or `git:directory` resource |
+| Path separators in `files` keys | Use nested objects for subdirectories |
+| `runPHP` without `wp-load.php` | Always `require '/wordpress/wp-load.php';` for WP functions |
+| Invented top-level keys | Only documented keys work — schema rejects unknown properties |
+| Inventing proxy URLs for GitHub | Use `git:directory` resource type |
+| Omitting `refType` with branch/tag `ref` | Required — only `"HEAD"` works without it |
+| Resource references in `literal:directory` `files` values | Values must be plain strings (content) or objects (subdirectories) — never resource refs |
+| `features.debug` or other invented feature keys | `features` only supports `networking` and `intl` — use `constants: { "WP_DEBUG": true }` for debug mode |
+| `require wp-load.php` in mu-plugin code | Only needed in `runPHP` steps — mu-plugins already run within WordPress |
+| Schema URL with `.org` domain | Must be `playground.wordpress.net`, not `playground.wordpress.org` |
+
+## Full Reference
+
+This skill covers the most common steps and patterns. For the complete API, see:
+
+- **Blueprint docs:** https://wordpress.github.io/wordpress-playground/blueprints
+- **JSON schema:** https://playground.wordpress.net/blueprint-schema.json
+
+Additional steps not covered above: `runPHPWithOptions` (run PHP with custom `ini` settings), `runWpInstallationWizard`, and resource types `vfs` and `bundled` (for advanced embedding scenarios).
+
+## Blueprint Bundles
+
+Bundles are self-contained packages that include a `blueprint.json` along with all the resources it references (plugins, themes, WXR files, etc.). Instead of hosting assets externally, bundle them alongside the blueprint.
+
+### Bundle Structure
+
+```
+my-bundle/
+├── blueprint.json          ← must be at the root
+├── my-plugin.zip           ← zipped plugin directory
+├── theme.zip
+└── content/
+    └── sample-content.wxr
+```
+
+Plugins and themes must be zipped before bundling — `installPlugin` expects a zip, not a raw directory. To create the zip from a plugin directory:
+
+```bash
+cd my-bundle
+zip -r my-plugin.zip my-plugin/
+```
+
+### Referencing Bundled Resources
+
+Use the `bundled` resource type to reference files within the bundle:
+
+```json
+{
+  "step": "installPlugin",
+  "pluginData": {
+    "resource": "bundled",
+    "path": "/my-plugin.zip"
+  },
+  "options": { "activate": true }
+}
+```
+
+```json
+{
+  "step": "importWxr",
+  "file": {
+    "resource": "bundled",
+    "path": "/content/sample-content.wxr"
+  }
+}
+```
+
+### Creating a Bundle Step by Step
+
+1. Create the bundle directory and add `blueprint.json` at its root.
+2. Write your plugin/theme source files in a subdirectory (e.g. `my-plugin/my-plugin.php`).
+3. Zip the plugin directory: `zip -r my-plugin.zip my-plugin/`
+4. Reference it in `blueprint.json` using `{ "resource": "bundled", "path": "/my-plugin.zip" }`.
+
+Full example — a bundle that installs a custom plugin:
+
+```
+dashboard-widget-bundle/
+├── blueprint.json
+├── dashboard-widget.zip        ← zip of dashboard-widget/
+└── dashboard-widget/           ← plugin source (kept for editing)
+    └── dashboard-widget.php
+```
+
+```json
+{
+  "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+  "landingPage": "/wp-admin/",
+  "preferredVersions": { "php": "8.3", "wp": "latest" },
+  "steps": [
+    { "step": "login" },
+    {
+      "step": "installPlugin",
+      "pluginData": { "resource": "bundled", "path": "/dashboard-widget.zip" },
+      "options": { "activate": true }
+    }
+  ]
+}
+```
+
+### Distribution Formats
+
+| Format | How to use |
+|--------|-----------|
+| ZIP file (remote) | Website: `https://playground.wordpress.net/?blueprint-url=https://example.com/bundle.zip` |
+| ZIP file (local) | CLI: `npx @wp-playground/cli server --blueprint=./bundle.zip` |
+| Local directory | CLI: `npx @wp-playground/cli server --blueprint=./my-bundle/ --blueprint-may-read-adjacent-files` |
+| Git repository directory | Point `blueprint-url` at a repo directory containing `blueprint.json` |
+
+**GOTCHA:** Local directory bundles always need `--blueprint-may-read-adjacent-files` for the CLI to read bundled resources. Without it, any `"resource": "bundled"` reference will fail with a "File not found" error. ZIP bundles don't need this flag — all files are self-contained inside the archive.
+
+## Testing Blueprints
+
+### Inline Blueprints (quick test, no bundles)
+
+Minify the blueprint JSON (no extra whitespace), encode it once with `encodeURIComponent()`, prepend `https://playground.wordpress.net/#`, and open the URL in a browser:
+
+```
+https://playground.wordpress.net/#%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.3%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%7D%5D%7D
+```
+
+Very large blueprints may exceed browser URL length limits; use the CLI or a hosted Blueprint URL instead. For share-link details, use `wp-playground/references/website.md`.
+
+### Local CLI Testing
+
+**Interactive server** (keeps running, opens in browser):
+```bash
+# Directory bundle — requires --blueprint-may-read-adjacent-files
+npx @wp-playground/cli server --blueprint=./my-bundle/ --blueprint-may-read-adjacent-files
+
+# ZIP bundle — self-contained, no extra flags needed
+npx @wp-playground/cli server --blueprint=./bundle.zip
+```
+
+**Headless validation** (runs blueprint and exits):
+```bash
+npx @wp-playground/cli run-blueprint --blueprint=./my-bundle/ --blueprint-may-read-adjacent-files
+```
+
+### Testing with WordPress Playground
+
+Use the `wp-playground` skill for local or browser testing. For CLI testing, follow `wp-playground/references/cli.md` with `--blueprint=<path-or-url>`; for directory bundles, pass `--blueprint-may-read-adjacent-files`.

--- a/.agents/skills/wp-plugin-development/SKILL.md
+++ b/.agents/skills/wp-plugin-development/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: wp-plugin-development
+description: "Use when developing WordPress plugins: architecture and hooks, activation/deactivation/uninstall, admin UI and Settings API, data storage, cron/tasks, security (nonces/capabilities/sanitization/escaping), and release packaging."
+compatibility: "Targets WordPress 7.0+ (PHP 7.4.0+). Filesystem-based agent with bash + node. Some workflows require WP-CLI."
+---
+
+# WP Plugin Development
+
+## When to use
+
+Use this skill for plugin work such as:
+
+- creating or refactoring plugin structure (bootstrap, includes, namespaces/classes)
+- adding hooks/actions/filters
+- activation/deactivation/uninstall behavior and migrations
+- adding settings pages / options / admin UI (Settings API)
+- security fixes (nonces, capabilities, sanitization/escaping, SQL safety)
+- packaging a release (build artifacts, readme, assets)
+
+## Inputs required
+
+- Repo root + target plugin(s) (path to plugin main file if known).
+- Where this plugin runs: single site vs multisite; WP.com conventions if applicable.
+- Target WordPress + PHP versions (affects available APIs and placeholder support in `$wpdb->prepare()`).
+
+## Procedure
+
+### 0) Triage and locate plugin entrypoints
+
+1. Run triage:
+   - `node skills/wp-project-triage/scripts/detect_wp_project.mjs`
+2. Detect plugin headers (deterministic scan):
+   - `node skills/wp-plugin-development/scripts/detect_plugins.mjs`
+
+If this is a full site repo, pick the specific plugin under `wp-content/plugins/` or `mu-plugins/` before changing code.
+
+### 1) Follow a predictable architecture
+
+Guidelines:
+
+- Keep a single bootstrap (main plugin file with header).
+- Avoid heavy side effects at file load time; load on hooks.
+- Prefer a dedicated loader/class to register hooks.
+- Keep admin-only code behind `is_admin()` (or admin hooks) to reduce frontend overhead.
+
+See:
+- `references/structure.md`
+
+### 2) Hooks and lifecycle (activation/deactivation/uninstall)
+
+Activation hooks are fragile; follow guardrails:
+
+- register activation/deactivation hooks at top-level, not inside other hooks
+- flush rewrite rules only when needed and only after registering CPTs/rules
+- uninstall should be explicit and safe (`uninstall.php` or `register_uninstall_hook`)
+
+See:
+- `references/lifecycle.md`
+
+### 3) Settings and admin UI (Settings API)
+
+Prefer Settings API for options:
+
+- `register_setting()`, `add_settings_section()`, `add_settings_field()`
+- sanitize via `sanitize_callback`
+
+See:
+- `references/settings-api.md`
+
+### 4) Security baseline (always)
+
+Before shipping:
+
+- Validate/sanitize input early; escape output late.
+- Use nonces to prevent CSRF *and* capability checks for authorization.
+- Avoid directly trusting `$_POST` / `$_GET`; use `wp_unslash()` and specific keys.
+- Use `$wpdb->prepare()` for SQL; avoid building SQL with string concatenation.
+
+See:
+- `references/security.md`
+
+### 5) Data storage, cron, migrations (if needed)
+
+- Prefer options for small config; custom tables only if necessary.
+- For cron tasks, ensure idempotency and provide manual run paths (WP-CLI or admin).
+- For schema changes, write upgrade routines and store schema version.
+
+See:
+- `references/data-and-cron.md`
+
+## Verification
+
+- Plugin activates with no fatals/notices.
+- Settings save and read correctly (capability + nonce enforced).
+- Uninstall removes intended data (and nothing else).
+- Run repo lint/tests (PHPUnit/PHPCS if present) and any JS build steps if the plugin ships assets.
+
+## Failure modes / debugging
+
+- Activation hook not firing:
+  - hook registered incorrectly (not in main file scope), wrong main file path, or plugin is network-activated
+- Settings not saving:
+  - settings not registered, wrong option group, missing capability, nonce failure
+- Security regressions:
+  - nonce present but missing capability checks; or sanitized input not escaped on output
+
+See:
+- `references/debugging.md`
+
+## Escalation
+
+For canonical detail, consult the Plugin Handbook and security guidelines before inventing patterns.

--- a/.agents/skills/wp-plugin-development/references/data-and-cron.md
+++ b/.agents/skills/wp-plugin-development/references/data-and-cron.md
@@ -1,0 +1,19 @@
+# Data storage, cron, and upgrades
+
+Use this file when adding persistent storage, background jobs, or upgrade routines.
+
+## Data storage
+
+- Prefer Options API for small config/state.
+- Use custom tables only when needed; store schema version and provide upgrade paths.
+
+## Cron
+
+- Ensure tasks are idempotent (may run late or multiple times).
+- Provide a manual trigger path for debugging (WP-CLI or admin-only action).
+
+## Database safety note
+
+If using `$wpdb->prepare()`, avoid building queries with concatenated user input.
+Recent WordPress versions support identifier placeholders (`%i`) but you must not assume it exists without checking capabilities or target versions.
+

--- a/.agents/skills/wp-plugin-development/references/debugging.md
+++ b/.agents/skills/wp-plugin-development/references/debugging.md
@@ -1,0 +1,19 @@
+# Debugging quick routes
+
+## Plugin doesn’t load / fatal errors
+
+- Confirm correct plugin main file and header.
+- Check PHP error logs and `WP_DEBUG_LOG`.
+- If the repo is a site repo, confirm you edited the correct plugin under `wp-content/plugins/`.
+
+## Activation hook surprises
+
+- Hooks must be registered at top-level.
+- Activation runs in a special context; avoid assuming other hooks already ran.
+
+## Settings not saving
+
+- Confirm `register_setting()` is called.
+- Confirm the option group matches the form.
+- Confirm capability checks and nonces.
+

--- a/.agents/skills/wp-plugin-development/references/lifecycle.md
+++ b/.agents/skills/wp-plugin-development/references/lifecycle.md
@@ -1,0 +1,33 @@
+# Activation, deactivation, uninstall
+
+Use this file for lifecycle changes and data cleanup.
+
+## Activation / deactivation hooks
+
+- `register_activation_hook( __FILE__, 'callback' )`
+- `register_deactivation_hook( __FILE__, 'callback' )`
+
+Guardrails:
+
+- These hooks must be registered at top-level (not inside other hooks).
+- If you flush rewrite rules, ensure rules are registered first (often via a shared function called both on `init` and activation).
+
+Upstream reference:
+
+- https://developer.wordpress.org/plugins/plugin-basics/activation-deactivation-hooks/
+
+## Uninstall
+
+Preferred approaches:
+
+- `uninstall.php` (runs only on uninstall)
+- `register_uninstall_hook()`
+
+Guardrails:
+
+- Check `WP_UNINSTALL_PLUGIN` before running destructive cleanup.
+
+Upstream reference:
+
+- https://developer.wordpress.org/plugins/plugin-basics/uninstall-methods/
+

--- a/.agents/skills/wp-plugin-development/references/security.md
+++ b/.agents/skills/wp-plugin-development/references/security.md
@@ -1,0 +1,29 @@
+# Security guardrails (plugin work)
+
+Use this file when making security fixes or when handling any input/output.
+
+## Nonces + permissions
+
+- Nonces help prevent CSRF, not authorization.
+- Always pair nonces with capability checks (`current_user_can()` or a more specific capability).
+
+Upstream reference:
+
+- https://developer.wordpress.org/apis/security/nonces/
+
+## Sanitization and escaping
+
+Golden rule:
+
+- sanitize/validate on input, escape on output.
+
+Practical rules:
+
+- never process the entire `$_POST` / `$_GET` array; read explicit keys
+- use `wp_unslash()` before sanitizing when needed
+- use prepared statements for SQL; avoid interpolating user input into queries
+
+Common review guidance:
+
+- https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/
+

--- a/.agents/skills/wp-plugin-development/references/settings-api.md
+++ b/.agents/skills/wp-plugin-development/references/settings-api.md
@@ -1,0 +1,22 @@
+# Settings API (admin options)
+
+Use this file when adding settings pages or storing user-configurable options.
+
+Core APIs:
+
+- `register_setting()`
+- `add_settings_section()`
+- `add_settings_field()`
+
+Upstream references:
+
+- Settings API overview: https://developer.wordpress.org/plugins/settings/settings-api/
+- Register settings: https://developer.wordpress.org/plugins/settings/registration/
+- Add settings fields: https://developer.wordpress.org/plugins/settings/settings-fields/
+
+Practical guardrails:
+
+- Use `sanitize_callback` to validate/sanitize data.
+- Use capability checks (commonly `manage_options`) for settings screens and saves.
+- Escape values on output (`esc_attr`, `esc_html`, etc.).
+

--- a/.agents/skills/wp-plugin-development/references/structure.md
+++ b/.agents/skills/wp-plugin-development/references/structure.md
@@ -1,0 +1,16 @@
+# Plugin structure and loading
+
+Use this file when introducing or refactoring a plugin architecture.
+
+## Core concepts
+
+- Main plugin file contains the plugin header and bootstraps the plugin.
+- Prefer predictable init:
+  - minimal boot file
+  - a loader/class that registers hooks
+  - admin-only code behind admin hooks
+
+Upstream reference:
+
+- https://developer.wordpress.org/plugins/plugin-basics/
+

--- a/.agents/skills/wp-plugin-development/scripts/detect_plugins.mjs
+++ b/.agents/skills/wp-plugin-development/scripts/detect_plugins.mjs
@@ -1,0 +1,122 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const DEFAULT_IGNORES = new Set([
+  ".git",
+  "node_modules",
+  "vendor",
+  "dist",
+  "build",
+  "coverage",
+  ".next",
+  ".turbo",
+]);
+
+function statSafe(p) {
+  try {
+    return fs.statSync(p);
+  } catch {
+    return null;
+  }
+}
+
+function readFileSafe(p, maxBytes = 128 * 1024) {
+  try {
+    const buf = fs.readFileSync(p);
+    if (buf.byteLength > maxBytes) return buf.subarray(0, maxBytes).toString("utf8");
+    return buf.toString("utf8");
+  } catch {
+    return null;
+  }
+}
+
+function findFilesRecursive(repoRoot, predicate, { maxFiles = 6000, maxDepth = 10 } = {}) {
+  const results = [];
+  const queue = [{ dir: repoRoot, depth: 0 }];
+  let visited = 0;
+
+  while (queue.length > 0) {
+    const { dir, depth } = queue.shift();
+    if (depth > maxDepth) continue;
+
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const ent of entries) {
+      const fullPath = path.join(dir, ent.name);
+      if (ent.isDirectory()) {
+        if (DEFAULT_IGNORES.has(ent.name)) continue;
+        queue.push({ dir: fullPath, depth: depth + 1 });
+        continue;
+      }
+      if (!ent.isFile()) continue;
+
+      visited += 1;
+      if (visited > maxFiles) return { results, truncated: true };
+      if (predicate(fullPath)) results.push(fullPath);
+    }
+  }
+
+  return { results, truncated: false };
+}
+
+function parsePluginHeader(contents) {
+  // WordPress reads plugin headers from the top of the file. We only need key fields.
+  const header = {};
+  const pairs = [
+    ["Plugin Name", "name"],
+    ["Plugin URI", "uri"],
+    ["Description", "description"],
+    ["Version", "version"],
+    ["Author", "author"],
+    ["Author URI", "authorUri"],
+    ["Text Domain", "textDomain"],
+    ["Domain Path", "domainPath"],
+  ];
+  for (const [label, key] of pairs) {
+    const m = contents.match(new RegExp(`^\\s*${label}:\\s*(.+)\\s*$`, "im"));
+    if (m) header[key] = m[1].trim();
+  }
+  if (!header.name) return null;
+  return header;
+}
+
+function main() {
+  const repoRoot = process.cwd();
+
+  const { results: phpFiles, truncated } = findFilesRecursive(repoRoot, (p) => p.toLowerCase().endsWith(".php"), {
+    maxFiles: 5000,
+    maxDepth: 10,
+  });
+
+  const plugins = [];
+
+  for (const phpPath of phpFiles) {
+    const txt = readFileSafe(phpPath);
+    if (!txt) continue;
+    if (!/Plugin Name:/i.test(txt)) continue;
+    const header = parsePluginHeader(txt);
+    if (!header) continue;
+    plugins.push({
+      pluginFile: path.relative(repoRoot, phpPath),
+      ...header,
+    });
+  }
+
+  const report = {
+    tool: { name: "detect_plugins", version: "0.1.0" },
+    repoRoot,
+    truncated,
+    count: plugins.length,
+    plugins,
+  };
+
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+}
+
+main();
+

--- a/.agents/skills/wp-plugin-directory-guidelines/SKILL.md
+++ b/.agents/skills/wp-plugin-directory-guidelines/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: wp-plugin-directory-guidelines
+description: "Use when reviewing WordPress plugins for GPL compliance, checking license headers or compatibility, evaluating upsell/freemium/trialware patterns, validating plugin naming or trademark rules, checking plugin slugs, understanding why a plugin was rejected from WordPress.org, or answering any question about the 18 WordPress.org Plugin Directory guidelines — even if the user doesn't mention 'guidelines' explicitly."
+compatibility: "Targets WordPress 7.0+ (PHP 7.4.0+)."
+---
+
+## Overview
+
+Authoritative reference for the 18 WordPress.org Plugin Directory guidelines. Covers GPL licensing, plugin naming/trademark rules, trialware restrictions, and all other submission requirements.
+
+## When to use
+
+Use this skill when you need to:
+- Review a WordPress plugin for compliance with the WordPress.org Plugin Directory guidelines
+- Check GPL license compatibility for a plugin or its bundled libraries
+- Verify license headers in plugin files
+- Identify common guideline violations before submission
+- Answer questions about what is or is not allowed on WordPress.org
+- Evaluate premium/upsell flows, license checks, or freemium positioning
+- Review "teaser" or "preview" UI for trialware violations
+
+## Inputs required
+
+- Plugin source code (or specific files to review)
+- Optional: plugin readme and plugin header metadata for naming and license checks
+
+## Procedure
+
+1. Check the plugin's license header against the **Valid License Headers** section below.
+2. Walk through the **18 Guidelines** checklist, paying special attention to Guidelines 1, 4, 5, 7, 8, and 17.
+3. Confirm trialware/freemium compliance using the checklist in [guideline-review-checklist.md](references/guideline-review-checklist.md) (Guideline 5 section).
+4. For bundled third-party code, verify license compatibility against **GPL-Compatible Licenses (Quick)** below.
+5. Flag matches from **Common GPL Violations (Quick)** below.
+6. For edge cases, consult the detailed references and the [GNU GPL FAQ](https://www.gnu.org/licenses/gpl-faq.html).
+
+## 18-Guideline Review Checklist
+
+Use the detailed, per-guideline checklist in [guideline-review-checklist.md](references/guideline-review-checklist.md). Load this reference file only when a full guideline audit is requested.
+
+## GPL Compliance (Guideline 1 in Detail)
+
+Use [gpl-compliance.md](references/gpl-compliance.md) for full license tables, compatibility nuances, and examples. Keep this inline section as a quick decision aid.
+
+### Verification (Licensing)
+
+- Every licensing-related issue must cite **Guideline 1** and include the file path and exact license string.
+- Confirm compatibility claims against **GPL-Compatible Licenses (Quick)** and escalate ambiguous licenses.
+
+### Failure modes (Licensing)
+
+- If a license is not clearly GPL-compatible, do not guess. Check the [GNU license list](https://www.gnu.org/licenses/license-list.html).
+- For dual-license packages, verify both licenses and redistribution terms.
+
+### Quick Reference: WordPress GPL Requirements
+
+- WordPress is **GPLv2 or later**.
+- Plugins distributed on WordPress.org must be 100% GPL-compatible (code and assets).
+- Include a valid `License:` header and `License URI:` in the main plugin file.
+- Do not add restrictions that conflict with GPL freedoms.
+
+### Valid License Headers
+
+## GPL Versions Summary
+
+| Version | Year | Key Addition |
+|---------|------|--------------|
+| GPLv1 | 1989 | Base copyleft: share-alike for modifications |
+| GPLv2 | 1991 | "Liberty or death" clause (Section 7), clearer distribution terms |
+| GPLv3 | 2007 | Anti-tivoization, explicit patent grants, compatibility provisions |
+
+WordPress uses **GPLv2 or later**, meaning plugins can use GPLv2, GPLv3, or "GPLv2 or later".
+
+For full license texts, see:
+- [GNU General Public License v1](https://www.gnu.org/licenses/gpl-1.0.html)
+- [GNU General Public License v2](https://www.gnu.org/licenses/gpl-2.0.html)
+- [GNU General Public License v3](https://www.gnu.org/licenses/gpl-3.0.html)
+
+## License Compliance Checklist
+
+When reviewing a plugin, verify:
+
+- [ ] Main plugin file has a valid `License:` header (e.g., `GPL-2.0-or-later`, `GPL-2.0+`, `GPLv2 or later`)
+- [ ] Main plugin file has a `License URI:` header pointing to the GPL text
+- [ ] If bundled libraries exist, each has a GPL-compatible license
+- [ ] No "split licensing" (e.g., code GPL but premium features proprietary)
+- [ ] No additional restrictions beyond what GPL allows
+- [ ] No clauses restricting commercial use, modification, or redistribution
+- [ ] No obfuscated code (violates the spirit of source code availability)
+
+## Valid License Headers for WordPress Plugins
+
+```
+License: GPL-2.0-or-later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+```
+
+```text
+License: GPL-3.0-or-later
+License URI: https://www.gnu.org/licenses/gpl-3.0.html
+```
+
+```text
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+```
+
+### GPL-Compatible Licenses (Quick)
+
+- Safe defaults: GPL-2.0-or-later, GPL-3.0-or-later.
+- Commonly accepted permissive families: MIT/Expat, BSD, ISC, zlib, Boost.
+- Conditional compatibility requires care: Apache-2.0 and MPL-2.0 (verify usage context).
+- For full accepted and rejected identifiers, use [gpl-compliance.md](references/gpl-compliance.md).
+
+### Common GPL Violations (Quick)
+
+- Split licensing that restricts distributed code.
+- Obfuscated or non-corresponding source distribution.
+- Restrictive clauses (non-commercial, no-resale, forced backlink).
+- Bundling GPL-incompatible libraries or assets.
+
+## Plugin Naming Rules (Guideline 17)
+
+Use [naming-rules.md](references/naming-rules.md) for full trademark lists, slug blocks, and naming examples. Keep this inline checklist for quick screening.
+
+### Naming Checklist (Quick)
+
+- Name is not a placeholder and has at least 5 alphanumeric characters.
+- Header name and readme name match.
+- Name is specific and function-related; avoid keyword stuffing.
+- Trademark/project names appear only after connectors like `for`, `with`, `using`, `and`.
+- No banned/discouraged terms or trademark portmanteaus.
+- Slug is lowercase, hyphenated, <= 50 chars, and avoids blocked terms.

--- a/.agents/skills/wp-plugin-directory-guidelines/references/gpl-compliance.md
+++ b/.agents/skills/wp-plugin-directory-guidelines/references/gpl-compliance.md
@@ -1,0 +1,217 @@
+## GPL Compliance (Guideline 1 in Detail)
+
+### Verification (Licensing)
+
+- Every licensing-related issue must cite **Guideline 1** and include the specific file/license value found.
+- License compatibility claims must match the GPL-Compatible Licenses table or the [GNU GPL-Compatible License List](https://www.gnu.org/licenses/license-list.html#GPLCompatibleLicenses).
+- Use local `references/` files when present; otherwise use authoritative external URLs.
+
+### Failure modes (Licensing)
+
+- If a license is not listed in the compatibility tables, do not guess; check the [GNU license list](https://www.gnu.org/licenses/license-list.html) or escalate.
+- If a plugin uses a dual-license model, verify both licenses independently.
+
+
+### Quick Reference: WordPress GPL Requirements
+
+WordPress is licensed under **GPLv2 or later**. All plugins distributed via WordPress.org must be:
+
+1. **100% GPL-compatible** (code, images, CSS, and all assets)
+2. Include a **license declaration** in the main plugin file header
+3. Include the **full license text** or a URI reference to it
+4. **Not restrict freedoms** granted by the GPL
+
+## GPL Versions Summary
+
+| Version | Year | Key Addition |
+|---------|------|--------------|
+| GPLv1 | 1989 | Base copyleft: share-alike for modifications |
+| GPLv2 | 1991 | Patent clause (Section 7), clearer distribution terms |
+| GPLv3 | 2007 | Anti-tivoization, explicit patent grants, compatibility provisions |
+
+WordPress uses **GPLv2 or later**, meaning plugins can use GPLv2, GPLv3, or "GPLv2 or later".
+
+For full license texts, see:
+- [GNU General Public License v1](https://www.gnu.org/licenses/gpl-1.0.html)
+- [GNU General Public License v2](https://www.gnu.org/licenses/gpl-2.0.html)
+- [GNU General Public License v3](https://www.gnu.org/licenses/gpl-3.0.html)
+
+## License Compliance Checklist
+
+When reviewing a plugin, verify:
+
+- [ ] Main plugin file has a valid `License:` header (e.g., `GPL-2.0-or-later`, `GPL-2.0+`, `GPLv2 or later`)
+- [ ] Main plugin file has a `License URI:` header pointing to the GPL text
+- [ ] If bundled libraries exist, each has a GPL-compatible license
+- [ ] No "split licensing" (e.g., code GPL but premium features proprietary)
+- [ ] No additional restrictions beyond what GPL allows
+- [ ] No clauses restricting commercial use, modification, or redistribution
+- [ ] No obfuscated code (violates the spirit of source code availability)
+
+## Valid License Headers for WordPress Plugins
+
+```
+License: GPL-2.0-or-later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+```
+
+```
+License: GPL-3.0-or-later
+License URI: https://www.gnu.org/licenses/gpl-3.0.html
+```
+
+```
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+```
+
+## Accepted Licenses by the WordPress.org Plugin Directory
+
+Source: [Plugin Check - License_Utils trait](https://github.com/WordPress/plugin-check/blob/trunk/includes/Traits/License_Utils.php)
+
+The Plugin Directory accepts licenses matching these identifiers (after normalization). The validation uses `is_license_gpl_compatible()` with the pattern:
+
+```
+GPL|GNU|LGPL|MIT|FreeBSD|New BSD|BSD-3-Clause|BSD 3 Clause|OpenLDAP|Expat|Apache2|MPL20|ISC|CC0|Unlicense|WTFPL|Artistic|Boost|NCSA|ZLib|X11
+```
+
+### GPL Family (recommended)
+
+| Accepted Values | SPDX Identifier | License URI |
+|-----------------|-----------------|-------------|
+| `GPL-2.0-or-later`, `GPLv2 or later`, `GPL-2.0+` | GPL-2.0-or-later | https://www.gnu.org/licenses/gpl-2.0.html |
+| `GPL-2.0-only`, `GPLv2` | GPL-2.0-only | https://www.gnu.org/licenses/gpl-2.0.html |
+| `GPL-3.0-or-later`, `GPLv3 or later`, `GPL-3.0+` | GPL-3.0-or-later | https://www.gnu.org/licenses/gpl-3.0.html |
+| `GPL-3.0-only`, `GPLv3` | GPL-3.0-only | https://www.gnu.org/licenses/gpl-3.0.html |
+| `GNU General Public License` (any version text) | — | — |
+| `LGPL-2.1`, `LGPLv2.1` | LGPL-2.1-or-later | https://www.gnu.org/licenses/lgpl-2.1.html |
+| `LGPL-3.0`, `LGPLv3` | LGPL-3.0-or-later | https://www.gnu.org/licenses/lgpl-3.0.html |
+
+### Other GPL-Compatible Licenses Accepted
+
+| Identifier | License Name | Notes |
+|------------|-------------|-------|
+| `MIT` | MIT License | Permissive, compatible with GPLv2 and GPLv3 |
+| `Expat` | Expat License | Functionally equivalent to MIT |
+| `X11` | X11 License | Permissive; similar to Expat but with extra X Consortium clause |
+| `FreeBSD` | BSD 2-Clause (FreeBSD) | Permissive, compatible with GPLv2 and GPLv3 |
+| `New BSD`, `BSD-3-Clause`, `BSD 3 Clause` | BSD 3-Clause | Permissive, compatible with GPLv2 and GPLv3 |
+| `Apache2`, `Apache-2.0` | Apache License 2.0 | Compatible with GPLv3 only (NOT GPLv2) |
+| `MPL20`, `MPL-2.0` | Mozilla Public License 2.0 | Compatible via Section 3.3 |
+| `ISC` | ISC License | Permissive, compatible with GPLv2 and GPLv3 |
+| `OpenLDAP` | OpenLDAP Public License v2.7 | Permissive; older v2.3 is NOT compatible |
+| `CC0` | Creative Commons Zero | Public domain dedication |
+| `Unlicense` | The Unlicense | Public domain dedication |
+| `WTFPL` | Do What The F*** You Want To Public License | Permissive, accepted in full text form too |
+| `Artistic` | Artistic License 2.0 | Compatible via relicensing option in §4(c)(ii); Artistic 1.0 is NOT compatible |
+| `Boost` | Boost Software License 1.0 | Lax permissive, compatible with GPLv2 and GPLv3 |
+| `NCSA` | NCSA/University of Illinois Open Source License | Based on Expat + modified BSD; compatible with GPLv2 and GPLv3 |
+| `ZLib` | zlib License | Permissive, compatible with GPLv2 and GPLv3 |
+
+### Licenses NOT Accepted
+
+Any license not matching the identifiers above will be rejected. Common rejections include:
+
+- **Proprietary / All Rights Reserved**
+- **Creative Commons BY-NC** (NonCommercial restriction)
+- **Creative Commons BY-ND** (NoDerivatives restriction)
+- **Creative Commons BY-SA** (v3.0 and earlier; v4.0 is one-way compatible with GPLv3 but not in the Plugin Check regex)
+- **JSON License** ("shall be used for Good, not Evil")
+- **SSPL** (Server Side Public License)
+- **BSL** (Business Source License)
+- **Commons Clause**
+- **Elastic License**
+- **Original BSD (4-clause)** — advertising clause incompatible with GPL
+- **MPL-1.0** — only MPL 2.0 is GPL-compatible
+- **EPL** (Eclipse Public License) — weak copyleft, incompatible with GPL
+- **EUPL** (European Union Public License) — copyleft incompatible with GPL without multi-step relicensing
+- **Artistic License 1.0** — vague wording makes it incompatible; use 2.0 instead
+- **OpenLDAP v2.3** (old) — incompatible; v2.7 is accepted
+
+## Common GPL Violations in Plugin Review
+
+### 1. Split Licensing
+Plugin claims GPL but restricts premium features:
+- "Free version is GPL, premium is proprietary" - **VIOLATION**
+- All code distributed must be GPL-compatible
+
+### 2. Obfuscated Code
+- Minified JavaScript is acceptable IF source is provided
+- PHP obfuscation (ionCube, Zend Guard, etc.) - **VIOLATION** (prevents exercise of GPL freedoms)
+- Encoded/encrypted PHP - **VIOLATION**
+
+### 3. Missing License Information
+- No license header in main file
+- No license file in the package
+- Bundled libraries without license documentation
+
+### 4. Restrictive Clauses
+- "You may not sell this plugin" - **VIOLATION** (GPL allows commercial redistribution)
+- "You may not remove author credits" - Acceptable under GPLv3 Section 7(b), but not as blanket restriction
+- "For personal use only" - **VIOLATION**
+- "You must link back to our site" - **VIOLATION** (additional restriction)
+
+### 5. Incompatible Library Inclusion
+- Including code under GPL-incompatible licenses
+- Using assets (images, fonts, CSS) under restrictive licenses
+
+## Key GPL Concepts for Reviewers
+
+### Distribution vs. Private Use
+- GPL obligations activate upon **distribution** (conveying to others)
+- Private modifications do NOT trigger GPL requirements
+- Publishing on WordPress.org IS distribution
+
+### Derivative Works
+- A WordPress plugin that uses WordPress APIs is generally considered a derivative work
+- Plugins that merely aggregate with WordPress may have different considerations
+- When in doubt, the safe approach is GPL-compatible licensing
+
+### Source Code Requirement
+- GPL requires access to "complete corresponding source code"
+- For WordPress plugins: all PHP, JS source files, build scripts
+- Minified files must have corresponding source available
+
+### The "Or Later" Clause
+- "GPLv2 or later" allows users to choose GPLv2 OR any later version
+- "GPLv2 only" means strictly GPLv2 (less flexible but valid)
+- WordPress itself uses "GPLv2 or later"
+
+## Violation Reporting Workflow
+
+When a GPL violation is identified:
+
+1. **Document the violation** precisely:
+   - Product name and version
+   - Distributor information
+   - Specific license terms violated
+   - Evidence (screenshots, code snippets)
+
+2. **Contact the copyright holder** first
+3. **Report to FSF** if the code is FSF-copyrighted: license-violation@gnu.org
+4. **For WordPress.org plugins**: flag through the plugin review process
+
+## Frequently Asked Questions
+
+For comprehensive GPL FAQ answers, see the [GNU GPL FAQ](https://www.gnu.org/licenses/gpl-faq.html).
+
+Common questions during plugin review:
+
+**Can a plugin charge money and still be GPL?**
+Yes. GPL allows charging for distribution. The requirement is that recipients get GPL freedoms (use, modify, redistribute).
+
+**Does a plugin need to include the full GPL text?**
+GPLv2 Section 1 and GPLv3 Section 4 require giving recipients a copy of the license. A URI reference in the header plus including a LICENSE file is standard practice.
+
+**Can a plugin restrict who uses it?**
+No. GPL explicitly prohibits additional restrictions on recipients. "For personal use only" or "non-commercial" clauses are incompatible.
+
+**Is minified JS without source a violation?**
+If the plugin only distributes minified JS without any way to obtain the source, this conflicts with GPL's source code requirements. The source should be available (in the package or via a repository).
+
+**Can a plugin use CC-BY-SA images?**
+CC-BY-SA 4.0 is one-way compatible with GPLv3 (CC-BY-SA material can be included in GPLv3 works). CC-BY-SA 3.0 is NOT compatible.
+
+**What about fonts bundled in plugins?**
+Fonts must be under GPL-compatible licenses. Common acceptable font licenses: OFL (SIL Open Font License), Apache 2.0 (with GPLv3), MIT, GPL with font exception.
+

--- a/.agents/skills/wp-plugin-directory-guidelines/references/guideline-review-checklist.md
+++ b/.agents/skills/wp-plugin-directory-guidelines/references/guideline-review-checklist.md
@@ -1,0 +1,592 @@
+# WordPress.org Plugin Directory Guidelines — Review Checklist
+
+Source: [Detailed Plugin Guidelines](https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/?output_format=md)
+
+Use this section as a structured checklist when reviewing a plugin. Each guideline includes the violation signal to look for, the verdict to issue, and the fix to recommend. Cite the guideline number in every finding.
+
+## Contents
+
+- [WordPress.org Plugin Directory Guidelines — Review Checklist](#wordpressorg-plugin-directory-guidelines--review-checklist)
+	- [Contents](#contents)
+		- [Guideline 1: GPL-Compatible License](#guideline-1-gpl-compatible-license)
+		- [Guideline 2: Developer Responsibility](#guideline-2-developer-responsibility)
+		- [Guideline 3: Stable Version in SVN](#guideline-3-stable-version-in-svn)
+		- [Guideline 4: Human-Readable Code](#guideline-4-human-readable-code)
+		- [Guideline 5: No Trialware](#guideline-5-no-trialware)
+		- [Guideline 6: SaaS Integrations Are Allowed — With Conditions](#guideline-6-saas-integrations-are-allowed--with-conditions)
+		- [Guideline 7: No External Data Collection Without Consent](#guideline-7-no-external-data-collection-without-consent)
+		- [Guideline 8: No Remotely Loaded Executable Code](#guideline-8-no-remotely-loaded-executable-code)
+		- [Guideline 9: No Illegal, Dishonest, or Offensive Behavior](#guideline-9-no-illegal-dishonest-or-offensive-behavior)
+		- [Guideline 10: No Forced External Links](#guideline-10-no-forced-external-links)
+		- [Guideline 11: No Admin Dashboard Hijacking](#guideline-11-no-admin-dashboard-hijacking)
+		- [Guideline 12: No Readme Spam](#guideline-12-no-readme-spam)
+		- [Guideline 13: Use WordPress-Bundled Libraries](#guideline-13-use-wordpress-bundled-libraries)
+		- [Guideline 14: SVN Is a Release Repository](#guideline-14-svn-is-a-release-repository)
+		- [Guideline 15: Increment Version Numbers](#guideline-15-increment-version-numbers)
+		- [Guideline 16: Plugin Must Be Complete at Submission](#guideline-16-plugin-must-be-complete-at-submission)
+		- [Guideline 17: Respect Trademarks and Copyrights](#guideline-17-respect-trademarks-and-copyrights)
+		- [Guideline 18: WordPress.org Reserves Directory Rights](#guideline-18-wordpressorg-reserves-directory-rights)
+
+---
+
+### Guideline 1: GPL-Compatible License
+
+**Check:** Does the main plugin file have a `License:` header with a GPL-compatible value? Are all bundled third-party libraries under compatible licenses?
+
+**Violation signals:**
+- Missing `License:` or `License URI:` header in the main plugin file
+- License is `Proprietary`, `All Rights Reserved`, `CC-BY-NC`, `CC-BY-ND`, `SSPL`, `BSL`, `Commons Clause`, `EPL`, `EUPL`, or `MPL-1.0`
+- Bundled library under a license not in the GPL-Compatible Licenses table (see below)
+- PHP files encoded with ionCube, Zend Guard, or similar — source cannot be exercised → violation
+
+**Verdict:** Flag as **FAIL** with the specific file and license value found.
+
+**Fix:** Use `GPL-2.0-or-later` (recommended). Add full license text or a `License URI:` to `https://www.gnu.org/licenses/gpl-2.0.html`. Replace incompatible libraries.
+
+---
+
+### Guideline 2: Developer Responsibility
+
+**Check:** Has the developer deliberately re-introduced previously removed code, circumvented a prior guideline decision, or included files they cannot legally distribute?
+
+**Violation signals:**
+- Commit history shows restoring a file after it was removed by the review team
+- Bundled assets with no documented license (treat as unlicensed until proven otherwise)
+- Third-party API terms prohibit redistribution of the bundled SDK
+
+**Verdict:** Flag as **FAIL**. Document the specific file or commit.
+
+**Fix:** Remove the offending file or obtain and document proper licensing.
+
+---
+
+### Guideline 3: Stable Version in SVN
+
+**Check:** Is the WordPress.org SVN version the canonical release? Is the plugin also distributed via an external channel with a newer version?
+
+**Violation signals:**
+- `readme.txt` advertises a version not present in SVN trunk/tags
+- External download page (developer's own site) offers a newer build than WP.org
+- Plugin auto-updates itself from a non-WP.org server (also a Guideline 8 issue)
+
+**Verdict:** Flag as **FAIL** if an actively maintained external version is ahead of the directory.
+
+**Fix:** Keep SVN up to date. External channels may mirror but must not supersede the directory version.
+
+---
+
+### Guideline 4: Human-Readable Code
+
+**Check:** Is all PHP, JS, and CSS in a form that a developer can read and understand? Are build sources available?
+
+**Violation signals:**
+- PHP obfuscated with packer, eval+base64 chains, or variable names like `$a1b2c3` throughout
+- Minified JS present **without** any source map or reference to the source repo/file in the readme
+- Build artifacts (`.min.js`) committed with no corresponding unminified source in the package or a public repo linked from `readme.txt`
+
+**Verdict:** Flag as **FAIL** for obfuscated PHP (always). Flag minified-only JS as **FAIL** if no source access is documented.
+
+**Fix:** Remove obfuscation. Add a `Development` or `Build` section to `readme.txt` linking to the source repo (GitHub, GitLab, etc.).
+
+---
+
+### Guideline 5: No Trialware
+
+**Core rule:** Every feature shipped in the directory must function end-to-end without a license key, payment, or account.
+
+**Check for each feature gate in the code:**
+
+1. Does a `has_paid_access()` / `is_licensed()` / `check_license()` check gate **local** processing (not an external service call)?
+2. Is there a time-based expiry (`time() > $installed_at + 30 * DAY_IN_SECONDS`) for local behavior?
+3. Is there a usage quota (`if ( $count >= 100 )`) that is artificially low and only exists to pressure upgrades?
+4. Does the free user see a blocked/locked UI that prevents completing a core workflow?
+
+**Violation signals (flag as FAIL):**
+- `return` / `wp_die()` / blocking screen shown when `has_paid_access()` is false for a local feature
+- Ternary limits: `$limit = $licensed ? 10000 : 100` with no filter to extend the free cap
+- Features expire after X days even when no external service is involved
+- Admin screen is entirely replaced with an upgrade prompt
+
+**Allowed patterns (do not flag):**
+- Upsell notice shown alongside a working free feature (non-blocking)
+- Premium feature delegated to a **separate** add-on plugin not hosted on WP.org
+- External SaaS feature gated because the **service** itself requires payment (e.g., AI API quota)
+- Dismissible comparison table or upgrade button in plugin settings
+
+**Code patterns:**
+
+```php
+// VIOLATION — local feature blocked by paid check
+if ( ! $this->has_paid_access() ) {
+    echo 'Upgrade required';
+    return; // ← blocks execution
+}
+
+// VIOLATION — artificial cap with no extension point
+$limit = $this->has_paid_access() ? 10000 : 100;
+```
+
+```php
+// COMPLIANT — free path works; premium adds to it
+$this->render_basic_export();
+if ( $this->has_premium_addon() ) {
+    do_action( 'myplugin_premium_export_options' );
+}
+
+// COMPLIANT — cap is consistent; extensible via filter
+$limit = apply_filters( 'myplugin_event_limit', 10000 );
+```
+
+**Pre-submission checklist:**
+- [ ] All free features work without a license key
+- [ ] No time-based expirations or usage quotas for local behavior
+- [ ] No blocking/locked UI preventing free-tier workflows
+- [ ] Upsell prompts are informational, non-blocking, and dismissible
+- [ ] Premium-only code lives in a separate add-on or an external service
+
+---
+
+### Guideline 6: SaaS Integrations Are Allowed — With Conditions
+
+**Check:** Does the external service provide real functionality? Is it documented in the readme?
+
+**Violation signals:**
+- The external service's sole purpose is validating a license key; all actual processing is local
+- Code was moved server-side specifically to disguise what is really a local feature gate
+- Plugin is a storefront or checkout page for an external product with no real plugin functionality
+
+**Verdict:** Flag as **FAIL** for license-validation-only services. Do not flag genuine SaaS integrations.
+
+**Fix:** Document what the external service does in `readme.txt`. Move license validation out of the plugin's critical path if the functionality is local.
+
+---
+
+### Guideline 7: No External Data Collection Without Consent
+
+**Check:** Does the plugin send any data to an external server without the user explicitly opting in?
+
+**Violation signals:**
+- HTTP request to a remote URL on plugin activation, admin page load, or cron job with no user opt-in
+- User email, site URL, or usage data sent without a visible opt-in checkbox or registration step
+- Third-party analytics or ad-tracking scripts loaded in admin or frontend without consent
+- Assets (images, fonts, scripts) loaded from an external CDN that are not the plugin's primary service
+
+**Exception:** Plugins that are interfaces to a named third-party service (e.g., Akismet, Mailchimp, a CDN) — consent is implied when the user configures the service connection.
+
+**Code patterns (violation vs compliant):**
+
+```php
+// VIOLATION — sends data on activation without consent
+register_activation_hook( __FILE__, function() {
+    wp_remote_post(
+        'https://api.example.com/collect',
+        array(
+            'body' => array(
+                'site' => home_url(),
+                'admin_email' => get_option( 'admin_email' ),
+            ),
+        )
+    );
+} );
+
+// COMPLIANT — explicit opt-in gate
+if ( isset( $_POST['myplugin_opt_in'] ) && '1' === $_POST['myplugin_opt_in'] ) {
+    update_option( 'myplugin_tracking_opt_in', 1 );
+}
+
+if ( get_option( 'myplugin_tracking_opt_in' ) ) {
+    wp_remote_post( 'https://api.example.com/collect', $payload );
+}
+```
+
+**Review questions:**
+1. Is any outbound request made on activation, first-run, or cron before consent is stored?
+2. Is the opt-in UI explicit, unambiguous, and default-off?
+3. Is consent persisted and checked before every telemetry request path?
+4. Are collected fields documented in `readme.txt` privacy disclosures?
+
+**Verdict:** Flag as **FAIL** for any unconsented outbound call. Include the specific URL or domain found.
+
+**Fix:** Wrap all outbound calls in an opt-in gate. Add a `Privacy Policy` section to `readme.txt` describing what data is collected and why.
+
+**Pre-submission checklist:**
+- [ ] No telemetry/analytics calls occur before explicit opt-in
+- [ ] Opt-in control is visible and off by default
+- [ ] Consent is stored and checked in every outbound path
+- [ ] Privacy policy in readme explains data, destination, and purpose
+
+---
+
+### Guideline 8: No Remotely Loaded Executable Code
+
+**Check:** Is all JS/CSS that runs on the user's site included in the plugin package?
+
+**Violation signals:**
+- `wp_enqueue_script()` loading JS from a third-party CDN (not a self-hosted asset)
+- Plugin fetches and executes code from an external URL at runtime (`file_get_contents` + `eval`, dynamic `<script src>`)
+- Plugin installs or updates itself from a non-WP.org server
+- Admin page rendered entirely inside an `<iframe>` pointing to an external URL
+
+**Exceptions allowed:**
+- Web fonts loaded from Google Fonts or similar font CDNs
+- The plugin's own SaaS service loading its own widget/embed scripts (with user consent per Guideline 7)
+
+**Code patterns (violation vs compliant):**
+
+```php
+// VIOLATION — executable JS loaded from third-party CDN
+wp_enqueue_script(
+    'myplugin-admin',
+    'https://cdn.example.com/myplugin/admin.js',
+    array(),
+    '1.0.0',
+    true
+);
+
+// COMPLIANT — executable JS bundled in plugin package
+wp_enqueue_script(
+    'myplugin-admin',
+    plugins_url( 'assets/js/admin.js', __FILE__ ),
+    array(),
+    MYPLUGIN_VERSION,
+    true
+);
+```
+
+**Review questions:**
+1. Are any script/style enqueues pointing to third-party domains for executable assets?
+2. Is any runtime code download/execution path present (`eval`, dynamic `<script>`, remote includes)?
+3. Does update/install logic bypass WP.org distribution channels?
+4. Are external assets limited to permitted exceptions (fonts, genuine service embed)?
+
+**Verdict:** Flag as **FAIL** for each externally loaded executable. Note the URL and the file/line where it is enqueued.
+
+**Fix:** Bundle JS/CSS locally. Use the WP.org SVN for updates. Replace `<iframe>` admin pages with proper WP Admin UI backed by a REST or admin-ajax API.
+
+**Pre-submission checklist:**
+- [ ] All executable JS/CSS is packaged locally in the plugin
+- [ ] No runtime remote code download or execution
+- [ ] No external self-update/install mechanism
+- [ ] Any external assets are documented and fall under allowed exceptions
+
+---
+
+### Guideline 9: No Illegal, Dishonest, or Offensive Behavior
+
+**Check:** Does the plugin engage in any deceptive, manipulative, or harmful behavior?
+
+**Violation signals:**
+- Hidden keyword stuffing in page output to manipulate search rankings
+- Code that posts reviews, ratings, or support replies on the user's behalf
+- Plugin presented as original work but is a fork or copy of another plugin without attribution
+- Plugin claims to make a site “GDPR compliant” or “ADA compliant” without legal basis
+- Code that uses site visitor resources for crypto-mining, botnets, or similar
+
+**Verdict:** Flag as **FAIL**. This is a high-severity category; document evidence thoroughly.
+
+---
+
+### Guideline 10: No Forced External Links
+
+**Check:** Does the plugin output any “Powered by” links, footer credits, or backlinks visible to site visitors?
+
+**Violation signals:**
+- Credit link output by default with no setting to disable it
+- Plugin requires the credit link to remain active for full functionality
+- Link is embedded in non-optional template output
+- “Powered by” text/link in templates (scanner pattern: `(?<!x-)powered[ -_]by`)
+- Backlink required to unlock an upgrade/feature (crosses Guideline 5 + 10)
+
+**Exception:** A service may brand its own rendered output (e.g., a payment form branded with the payment processor's logo).
+
+**Code patterns (violation vs compliant):**
+
+```php
+// VIOLATION — forced credit link on public output
+add_action( 'wp_footer', function() {
+    echo '<p class="myplugin-credit"><a href="https://vendor.example">Powered by Vendor</a></p>';
+} );
+
+// VIOLATION — backlink required for feature activation
+if ( ! get_option( 'myplugin_keep_backlink' ) ) {
+    wp_die( 'Please keep our credit link active to use this feature.' );
+}
+
+// COMPLIANT — optional, explicit opt-in, default off
+if ( get_option( 'myplugin_show_credit_link', false ) ) {
+    echo '<p class="myplugin-credit"><a href="https://vendor.example">Powered by Vendor</a></p>';
+}
+```
+
+**Review questions:**
+1. Is any “Powered by” or credit link injected into frontend output by default?
+2. Can users disable the link without breaking functionality?
+3. Is there any logic that ties feature access to keeping a backlink active?
+4. Is consent for showing credits explicit (not implied) and persisted?
+
+**Verdict:** Flag as **FAIL** if the link is on by default with no opt-out. Flag as **FAIL** if removing it breaks functionality.
+
+**Fix:** Default the setting to `false` (hidden). Provide a clear checkbox in settings to enable it.
+
+**Pre-submission checklist:**
+- [ ] No credit/backlink is shown by default on public pages
+- [ ] Credit link is strictly opt-in and user-controlled
+- [ ] Disabling credit links does not disable any plugin functionality
+- [ ] No upgrade path requires a backlink to remain active
+
+---
+
+### Guideline 11: No Admin Dashboard Hijacking
+
+**Check:** Are admin notices, upgrade prompts, and nags limited and non-intrusive?
+
+**Violation signals:**
+- Site-wide admin notice that cannot be dismissed (no dismiss button, reappears on every page load)
+- Upgrade/upsell prompt shown on every admin page, not just the plugin's own settings screen
+- Plugin overrides the WordPress dashboard home page or injects full-page overlays
+- Ad banners or tracking pixels placed in the WordPress admin area
+- Admin settings page rendered as an external `<iframe>` instead of native WP admin UI
+
+**Code patterns (violation vs compliant):**
+
+```php
+// VIOLATION — external iframe in admin page
+add_action( 'admin_menu', function() {
+    add_menu_page( 'My Plugin', 'My Plugin', 'manage_options', 'myplugin', function() {
+        echo '<iframe src="https://app.vendor.example/dashboard" style="width:100%;height:80vh;border:0"></iframe>';
+    } );
+} );
+
+// COMPLIANT — native admin page shell with server/API data fetch
+add_action( 'admin_menu', function() {
+    add_menu_page( 'My Plugin', 'My Plugin', 'manage_options', 'myplugin', function() {
+        echo '<div class="wrap"><h1>My Plugin</h1><div id="myplugin-admin-app"></div></div>';
+    } );
+} );
+
+add_action( 'admin_enqueue_scripts', function( $hook ) {
+    if ( 'toplevel_page_myplugin' !== $hook ) {
+        return;
+    }
+    wp_enqueue_script(
+        'myplugin-admin',
+        plugins_url( 'assets/js/admin.js', __FILE__ ),
+        array( 'wp-api-fetch' ),
+        MYPLUGIN_VERSION,
+        true
+    );
+} );
+```
+
+**Review questions:**
+1. Does any admin screen render plugin UI inside an external iframe?
+2. Is the plugin using native WP admin pages and capabilities checks instead?
+3. Are upsells/notices scoped to plugin pages and dismissible?
+4. Does removing upsell UI leave settings and core flows fully usable?
+
+**Verdict:** Flag as **FAIL** for persistent undismissable notices or for notices appearing outside the plugin's own pages.
+
+**Fix:** Use `is_plugin_page()` or an equivalent check to scope notices. Add a dismiss handler using `update_user_meta` or the WP dismissible notice pattern. Never show upgrade prompts on unrelated admin pages.
+
+**Pre-submission checklist:**
+- [ ] No external iframes used for admin/settings pages
+- [ ] Admin UI is rendered as native WP admin pages
+- [ ] Notices are dismissible and scoped to plugin screens only
+- [ ] Removing notices/upsells does not break plugin functionality
+
+---
+
+### Guideline 12: No Readme Spam
+
+**Check:** Is the `readme.txt` free of keyword stuffing, excessive affiliate links, and competitor tags?
+
+**Violation signals:**
+- More than 5 tags in the `Tags:` field
+- Affiliate links present but not disclosed, or using redirect/cloaking URLs
+- Tags that name competitor plugins or irrelevant popular terms purely for SEO
+- `readme.txt` reads as a keyword list rather than useful documentation
+
+**Verdict:** Flag as **WARNING** for minor stuffing; **FAIL** for undisclosed affiliate links or more than 5 tags.
+
+**Fix:** Reduce tags to 5 or fewer relevant terms. Disclose all affiliate links with “(affiliate link)” notation. Link affiliate URLs directly without cloaking.
+
+---
+
+### Guideline 13: Use WordPress-Bundled Libraries
+
+**Check:** Does the plugin bundle its own copies of libraries that WordPress already ships?
+
+**Violation signals:**
+- Plugin includes its own `jquery.js`, `jquery.min.js`, or loads jQuery from a CDN
+- Plugin bundles `PHPMailer`, `SimplePie`, `PHPass`, `Backbone`, `Underscore`, `React`, `wp-polyfill`, or other WP-bundled libraries
+- `wp_enqueue_script()` registers a library already available as a WordPress handle (check [Default Scripts](https://developer.wordpress.org/reference/functions/wp_enqueue_script/))
+- Scanner indicators: `files_library_core` and known core library filename matches (see scanner `known-libraries.php`)
+
+**Code patterns (violation vs compliant):**
+
+```php
+// VIOLATION — loading custom/bundled jQuery copy
+wp_enqueue_script(
+    'myplugin-jquery',
+    plugins_url( 'assets/vendor/jquery-3.7.1.min.js', __FILE__ ),
+    array(),
+    '3.7.1',
+    true
+);
+
+// COMPLIANT — use WordPress-bundled jQuery handle
+wp_enqueue_script( 'jquery' );
+```
+
+```php
+// VIOLATION — bundling WP core PHP libs directly
+require_once __DIR__ . '/vendor/PHPMailer.php';
+require_once __DIR__ . '/vendor/SimplePie.php';
+
+// COMPLIANT — use WordPress APIs that rely on core libs
+wp_mail( $to, $subject, $message, $headers );
+$feed = fetch_feed( $feed_url );
+```
+
+```php
+// VIOLATION — registering local copy for a core-shipped package
+wp_register_script(
+    'myplugin-underscore',
+    plugins_url( 'assets/vendor/underscore.min.js', __FILE__ ),
+    array(),
+    '1.13.6',
+    true
+);
+
+// COMPLIANT — rely on core handle
+wp_enqueue_script( 'underscore' );
+```
+
+**Review questions:**
+1. Does the plugin ship filenames that match core-library patterns (`jquery`, `underscore`, `backbone`, `codemirror`, `moment`, `PHPMailer`, `SimplePie`)?
+2. Are any core-library equivalents registered/enqueued from plugin paths instead of WP handles?
+3. Are SMTP/feed features implemented through WordPress APIs (`wp_mail`, `fetch_feed`) rather than bundled core libs?
+4. Can bundled duplicates be removed without breaking functionality?
+
+**Verdict:** Flag as **FAIL** for each duplicate bundled library.
+
+**Fix:** Replace bundled copies with `wp_enqueue_script( 'jquery' )` (or the appropriate WP handle). Remove the local copy from the plugin package.
+
+**Pre-submission checklist:**
+- [ ] No bundled copies of libraries already shipped by WordPress core
+- [ ] Core script dependencies are loaded via WP handles
+- [ ] Mail/feed functionality uses WordPress APIs instead of bundled core libs
+- [ ] Any remaining third-party libs are not core duplicates and are documented/license-compliant
+
+---
+
+### Guideline 14: SVN Is a Release Repository
+
+**Check:** Are SVN commits release-quality and infrequent?
+
+**Violation signals:**
+- Multiple commits per day with messages like “fix typo”, “testing”, “debug”
+- Development/debug code committed to trunk (e.g., `var_dump()`, `error_log()`, `console.log( 'test' )`)
+- Version number not incremented between commits that change functional code
+
+**Note:** This guideline is primarily advisory; violations do not block submission but reflect poorly on the developer.
+
+**Fix:** Use a development branch (GitHub/GitLab) and commit to SVN only for releases. Each SVN commit should correspond to a version bump.
+
+---
+
+### Guideline 15: Increment Version Numbers
+
+**Check:** Is the version number in `readme.txt` and the plugin header incremented for every release?
+
+**Violation signals:**
+- `Stable tag:` in `readme.txt` does not match the `Version:` field in the main plugin file
+- `Stable tag: trunk` used (discouraged; use an explicit version number)
+- Version number is the same across two different functional releases in SVN tags
+
+**Code patterns (violation vs compliant):**
+
+```text
+// VIOLATION — readme/plugin header mismatch
+readme.txt:
+Stable tag: 1.4.0
+
+my-plugin.php header:
+Version: 1.3.9
+```
+
+```text
+// COMPLIANT — values are aligned and bumped together
+readme.txt:
+Stable tag: 1.4.1
+
+my-plugin.php header:
+Version: 1.4.1
+```
+
+```text
+// VIOLATION — releasing functional changes without version increment
+SVN tag: tags/1.4.1
+Current release code: changed features, still Version: 1.4.1
+
+// COMPLIANT — each functional release gets a new version tag
+SVN tags: tags/1.4.1 -> tags/1.4.2
+```
+
+**Review questions:**
+1. Does `readme.txt` `Stable tag` exactly match main plugin `Version`?
+2. Is the new SVN tag version unique for this release?
+3. Did functional/code changes occur without a version increment?
+4. Are all user-facing changelog/release markers consistent with the bumped version?
+
+**Verdict:** Flag as **FAIL** if `Stable tag` and plugin header `Version` do not match.
+
+**Fix:** Bump both values together on every release. Tag the release in SVN under `tags/X.Y.Z`.
+
+**Pre-submission checklist:**
+- [ ] `Stable tag` matches plugin header `Version`
+- [ ] Version is incremented for this release
+- [ ] SVN tag uses the new version (`tags/X.Y.Z`)
+- [ ] Changelog/release notes reflect the same version
+
+---
+
+### Guideline 16: Plugin Must Be Complete at Submission
+
+**Check:** Is the plugin functional and complete at the time of submission?
+
+**Violation signals:**
+- Plugin is a skeleton with placeholder functions or “coming soon” admin pages
+- Slug was requested to reserve a name for a future or in-progress product
+- Primary plugin functionality requires a separate plugin not yet published
+
+**Verdict:** Flag as **FAIL**. An incomplete plugin cannot be approved.
+
+**Fix:** Submit only when the plugin is feature-complete and functional for end users.
+
+---
+
+### Guideline 17: Respect Trademarks and Copyrights
+
+**Check:** Does the plugin name or slug start with a trademark or project name the developer does not own?
+
+**Violation signals:**
+- Slug starts with `woocommerce-`, `elementor-`, `jetpack-`, `yoast-`, or any term in the Trademark Slug List (see Naming Rules section below)
+- Plugin name starts with a trademarked term (e.g., “WooCommerce Pricing Rates” → starts with WooCommerce)
+- Name uses a portmanteau of a trademark (e.g., “PricingPress” uses `-Press` from WordPress)
+
+**Correct pattern:** Trademark may only appear **after** a connector word: `for`, `with`, `using`, `and`.
+- ✅ `Pricing Rates for WooCommerce`
+- ❌ `WooCommerce Pricing Rates`
+
+**Verdict:** Flag as **FAIL** with the specific trademark and the correct name structure.
+
+**Fix:** Move the trademark to after a connector. Rename the slug accordingly (max 50 chars, lowercase, hyphens only).
+
+---
+
+### Guideline 18: WordPress.org Reserves Directory Rights
+
+**Note:** This guideline is informational — no code or readme check is required. It establishes that WordPress.org may update guidelines, remove plugins, revoke access, or modify plugins for public safety at any time. Inform developers of this when advising on submission strategy.
+
+---

--- a/.agents/skills/wp-plugin-directory-guidelines/references/naming-rules.md
+++ b/.agents/skills/wp-plugin-directory-guidelines/references/naming-rules.md
@@ -1,0 +1,121 @@
+## Plugin Naming Rules (Guideline 17 + Plugin Check Namer)
+
+Sources: [Plugin Header Requirements](https://developer.wordpress.org/plugins/plugin-basics/header-requirements/#header-fields) · [Detailed Plugin Guidelines §17](https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/) · Plugin Check `Plugin_Header_Fields_Check`, `Trademarks_Check`, and AI Namer prompts.
+
+### Technical Name Requirements
+
+| Rule | Details | Error Code |
+|------|---------|------------|
+| Must not use placeholder names | `"Plugin Name"` or `"My Basics Plugin"` are rejected | `plugin_header_invalid_plugin_name` |
+| Minimum 5 alphanumeric characters | Name must contain at least 5 latin letters (a–Z) or digits | `plugin_header_unsupported_plugin_name` (new plugins only) |
+| Name must exist in readme | `=== Plugin Name ===` header required and must be valid | `invalid_plugin_name` / `empty_plugin_name` |
+| Name must match across files | Readme and plugin header name must match (case/entity-decoded) | `mismatched_plugin_name` (warning) |
+
+**Slug rules:** lowercase, hyphens only, max 50 characters, derived from display name.
+
+### Naming Quality Rules (AI Namer)
+
+**1. No generic names**
+Names must be specific enough to distinguish the plugin from ~60,000 others.
+- Rejected: "Shipping", "Ecommerce Tracker", "SEO Plugin"
+- Accepted: "ShipGlex Shipping", "Shipping Tracker for UPS"
+- Exception: invented/original terms are allowed if placed at the **beginning** of the name
+
+**2. Name must relate to plugin function**
+The display name must correlate with what the plugin actually does. Exception: original invented terms.
+
+**3. No keyword stuffing**
+Unnaturally repeating keywords in the name for SEO purposes is not allowed.
+
+**4. No names too similar to existing plugins**
+Checked against the WordPress.org Plugin Directory. If similar, suggest a distinctive term (author name, brand, or crafted term) at the beginning.
+
+**5. Trademark/project name usage rules**
+Trademarks and project names are allowed **only** after connectors like `for`, `with`, `using`, or `and`:
+- ✅ `"My Plugin for WooCommerce"` — trademark after "for", no affiliation implied
+- ✅ `"Pricing Rates for WooCommerce"` — OK
+- ❌ `"WooCommerce Pricing Rates"` — starts with trademark, implies affiliation
+- ❌ `"Nicedev Paypal for WooCommerce"` — PayPal is not after a no-affiliation structure; correct form: `"Nicedev Payment Gateway with PayPal for WooCommerce"`
+- ❌ `"PricingPress"` — portmanteau using `-Press` (WordPress trademark)
+- Check for portmanteaus: names blending a trademark (e.g., `-Press`, `Woo-`) are not allowed
+
+**6. Banned and discouraged terms**
+
+Banned/discouraged terms cannot appear **anywhere** in the name — not even after `for`/`with`.
+
+#### Banned Terms (hard block)
+
+| Term | Reason |
+|------|--------|
+| Facebook, FB, fbook, Whatsapp, WA, Instagram, Insta, Gram, INS, Threads, Oculus | Meta legal request: no use in name, slug, or banners |
+| WordPress, wordpess, wpress | WordPress trademark; redundant in the WP.org directory |
+| WP (as standalone/redundant, e.g., "for WP") | Same as WordPress — redundant in context |
+| Trustpilot | Direct request from trademark holder |
+| Binance Pay | Direct request from trademark holder |
+
+#### Discouraged Terms (must be removed)
+
+| Term | Reason |
+|------|--------|
+| plugin (when redundant, e.g., "SEO Plugin") | Redundant; forbidden as first word |
+| best, #1, First, Perfect, The most | Superlatives / unverifiable comparative claims |
+| free (when redundant, e.g., "(free)") | All directory plugins are free — redundant |
+| WP, W P (at beginning or end, referring to WordPress) | WordPress abbreviation — redundant |
+| Gutenberg, gberg, guten, berg | Creates confusion; block editor is the current name |
+
+### Trademark Slug List (static check — `Trademarks_Check`)
+
+The following slugs are statically blocked. Terms ending in `-` cannot **begin** a slug; terms without `-` cannot appear **anywhere** in the slug. `woocommerce` (no dash) is allowed only as `for-woocommerce`, `with-woocommerce`, `using-woocommerce`, or `and-woocommerce`.
+
+```
+adobe-, adsense-, advanced-custom-fields-, adwords-, akismet-,
+all-in-one-wp-migration, amazon-, android-, apple-, applenews-, applepay-,
+aws-, azon-, bbpress-, bing-, booking-com, bootstrap-, buddypress-,
+chatgpt-, chat-gpt-, cloudflare-, contact-form-7-, cpanel-, disqus-, divi-,
+dropbox-, easy-digital-downloads-, elementor-, envato-,
+fbook, facebook, fb-, fb-messenger, fedex-, feedburner, firefox-,
+fontawesome-, font-awesome-, ganalytics-, gberg, github-, givewp-, google-,
+googlebot-, googles-, gravity-form-, gravity-forms-, gravityforms-, gtmetrix-,
+gutenberg, guten-, hubspot-, ig-, insta-, instagram, internet-explorer-,
+ios-, jetpack-, macintosh-, macos-, mailchimp-, microsoft-,
+ninja-forms-, oculus, onlyfans-, only-fans-, opera-, paddle-, paypal-,
+pinterest-, plugin, skype-, stripe-, tiktok-, tik-tok-, trustpilot,
+twitch-, twitter-, tweet, ups-, usps-, vvhatsapp, vvcommerce, vva-, vvoo,
+wa-, webpush-vn, wh4tsapps, whatsapp, whats-app, watson, windows-,
+wocommerce, woocom-, woocommerce, woocomerce, woo-commerce, woo-, wo-,
+wordpress, wordpess, wpress, wp, wc, wp-mail-smtp-, yandex-, yahoo-,
+yoast, youtube-, you-tube-
+```
+
+**Portmanteaus also blocked:** any slug starting with `woo` (case-insensitive) — e.g., `woopress`, `wooland`.
+
+### Naming Examples
+
+| Plugin Name | Verdict | Reason |
+|-------------|---------|--------|
+| `Shipping` | ❌ | Too generic |
+| `Ecommerce Tracker` | ❌ | Too generic, no context |
+| `Shipping Tracker for UPS` | ✅ | Descriptive + context |
+| `ShipGlex Shipping` | ✅ | Invented term at beginning |
+| `WooCommerce Pricing Rates` | ❌ | Starts with trademark |
+| `Pricing Rates for WooCommerce` | ✅ | Trademark after "for" |
+| `PricingPress` | ❌ | `-Press` portmanteau |
+| `PRT Text editor for WP` | ❌ | WP is banned/redundant; correct: `PRT Text editor` |
+| `Nicedev Paypal for WooCommerce` | ❌ | PayPal not after no-affiliation structure |
+| `Nicedev Payment Gateway with PayPal for WooCommerce` | ✅ | Correct structure |
+| `Best SEO Plugin for WordPress` | ❌ | Superlative + banned terms |
+| `My Free Slider` | ❌ | "free" is redundant/discouraged |
+
+### Naming Review Checklist (pre-submission)
+
+- [ ] Name is not a placeholder (`Plugin Name`, `My Basics Plugin`)
+- [ ] Name has at least 5 alphanumeric characters
+- [ ] Name matches between plugin header and readme
+- [ ] Name is specific — not too generic for 60,000+ plugins
+- [ ] Name relates to what the plugin actually does
+- [ ] No keyword stuffing
+- [ ] No banned terms anywhere (Meta brands, WordPress/WP redundant, Trustpilot, Binance Pay)
+- [ ] No discouraged terms (Plugin, Best/#1, Free, Gutenberg, standalone WP)
+- [ ] Trademarks/project names only appear after `for`/`with`/`using`/`and`
+- [ ] No portmanteaus using WordPress or WooCommerce trademarks
+- [ ] Slug is lowercase, hyphens only, max 50 chars, no blocked terms

--- a/.agents/skills/wp-rest-api/SKILL.md
+++ b/.agents/skills/wp-rest-api/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: wp-rest-api
+description: "Use when building, extending, or debugging WordPress REST API endpoints/routes: register_rest_route, WP_REST_Controller/controller classes, schema/argument validation, permission_callback/authentication, response shaping, register_rest_field/register_meta, or exposing CPTs/taxonomies via show_in_rest."
+compatibility: "Targets WordPress 7.0+ (PHP 7.4.0+). Filesystem-based agent with bash + node. Some workflows require WP-CLI."
+---
+
+# WP REST API
+
+## When to use
+
+Use this skill when you need to:
+
+- create or update REST routes/endpoints
+- debug 401/403/404 errors or permission/nonce issues
+- add custom fields/meta to REST responses
+- expose custom post types or taxonomies via REST
+- implement schema + argument validation
+- adjust response links/embedding/pagination
+
+## Inputs required
+
+- Repo root + target plugin/theme/mu-plugin (path to entrypoint).
+- Desired namespace + version (e.g. `my-plugin/v1`) and routes.
+- Authentication mode (cookie + nonce vs application passwords vs auth plugin).
+- Target WordPress version constraints (if below 7.0, call out).
+
+## Procedure
+
+### 0) Triage and locate REST usage
+
+1. Run triage:
+   - `node skills/wp-project-triage/scripts/detect_wp_project.mjs`
+2. Search for existing REST usage:
+   - `register_rest_route`
+   - `WP_REST_Controller`
+   - `rest_api_init`
+   - `show_in_rest`, `rest_base`, `rest_controller_class`
+
+If this is a full site repo, pick the specific plugin/theme before changing code.
+
+### 1) Choose the right approach
+
+- **Expose CPT/taxonomy in `wp/v2`:**
+  - Use `show_in_rest => true` + `rest_base` if needed.
+  - Optionally provide `rest_controller_class`.
+  - Read `references/custom-content-types.md`.
+- **Custom endpoints:**
+  - Use `register_rest_route()` on `rest_api_init`.
+  - Prefer a controller class (`WP_REST_Controller` subclass) for anything non-trivial.
+  - Read `references/routes-and-endpoints.md` and `references/schema.md`.
+
+### 2) Register routes safely (namespaces, methods, permissions)
+
+- Use a unique namespace `vendor/v1`; avoid `wp/*` unless core.
+- Always provide `permission_callback` (use `__return_true` for public endpoints).
+- Use `WP_REST_Server::READABLE/CREATABLE/EDITABLE/DELETABLE` constants.
+- Return data via `rest_ensure_response()` or `WP_REST_Response`.
+- Return errors via `WP_Error` with an explicit `status`.
+
+Read `references/routes-and-endpoints.md`.
+
+### 3) Validate/sanitize request args
+
+- Define `args` with `type`, `default`, `required`, `validate_callback`, `sanitize_callback`.
+- Prefer JSON Schema validation with `rest_validate_value_from_schema` then `rest_sanitize_value_from_schema`.
+- Never read `$_GET`/`$_POST` directly inside endpoints; use `WP_REST_Request`.
+
+Read `references/schema.md`.
+
+### 4) Responses, fields, and links
+
+- Do **not** remove core fields from default endpoints; add fields instead.
+- Use `register_rest_field` for computed fields; `register_meta` with `show_in_rest` for meta.
+- For `object`/`array` meta, define schema in `show_in_rest.schema`.
+- If you need unfiltered post content (e.g., ToC plugins injecting HTML), request `?context=edit` to access `content.raw` (auth required). Pair with `_fields=content.raw` to keep responses small.
+- Add related resource links via `WP_REST_Response::add_link()`.
+
+Read `references/responses-and-fields.md`.
+
+### 5) Authentication and authorization
+
+- For wp-admin/JS: cookie auth + `X-WP-Nonce` (action `wp_rest`).
+- For external clients: application passwords (basic auth) or an auth plugin.
+- Use capability checks in `permission_callback` (authorization), not just “logged in”.
+
+Read `references/authentication.md`.
+
+### 6) Client-facing behavior (discovery, pagination, embeds)
+
+- Ensure discovery works (`Link` header or `<link rel="https://api.w.org/">`).
+- Support `_fields`, `_embed`, `_method`, `_envelope`, pagination headers.
+- Remember `per_page` is capped at 100.
+
+Read `references/discovery-and-params.md`.
+
+## Verification
+
+- `/wp-json/` index includes your namespace.
+- `OPTIONS` on your route returns schema (when provided).
+- Endpoint returns expected data; permission failures return 401/403 as appropriate.
+- CPT/taxonomy routes appear under `wp/v2` when `show_in_rest` is true.
+- Run repo lint/tests and any PHP/JS build steps.
+
+## Failure modes / debugging
+
+- 404: `rest_api_init` not firing, route typo, or permalinks off (use `?rest_route=`).
+- 401/403: missing nonce/auth, or `permission_callback` too strict.
+- `_doing_it_wrong` for missing `permission_callback`: add it (use `__return_true` if public).
+- Invalid params: missing/incorrect `args` schema or validation callbacks.
+- Fields missing: `show_in_rest` false, meta not registered, or CPT lacks `custom-fields` support.
+
+## Escalation
+
+If version support or behavior is unclear, consult the REST API Handbook and core docs before inventing patterns.

--- a/.agents/skills/wp-rest-api/references/authentication.md
+++ b/.agents/skills/wp-rest-api/references/authentication.md
@@ -1,0 +1,18 @@
+# Authentication (summary)
+
+## Cookie authentication (in-dashboard / same-site)
+
+- Standard for wp-admin and theme/plugin JS.
+- Requires a REST nonce (`wp_rest`) sent as `X-WP-Nonce` header or `_wpnonce` param.
+- If the nonce is missing, the request is treated as unauthenticated even if cookies exist.
+
+## Application Passwords (external clients)
+
+- Available in WordPress 5.6+.
+- Use HTTPS + Basic Auth with the application password.
+- Recommended over the legacy Basic Auth plugin.
+
+## Auth plugins
+
+- OAuth 1.0a or JWT plugins are common for external apps.
+- Use only if required; follow plugin docs and security guidance.

--- a/.agents/skills/wp-rest-api/references/custom-content-types.md
+++ b/.agents/skills/wp-rest-api/references/custom-content-types.md
@@ -1,0 +1,20 @@
+# Custom Content Types (summary)
+
+## Custom post types
+
+- Set `show_in_rest => true` in `register_post_type()` to expose in `wp/v2`.
+- Use `rest_base` to change the route slug.
+- Optionally set `rest_controller_class` (must extend `WP_REST_Controller`).
+
+## Custom taxonomies
+
+- Set `show_in_rest => true` in `register_taxonomy()`.
+- Use `rest_base` and optional `rest_controller_class` (default `WP_REST_Terms_Controller`).
+
+## Adding REST support to existing types
+
+- Use `register_post_type_args` or `register_taxonomy_args` filters to enable `show_in_rest` for types you do not control.
+
+## Discovery links for custom controllers
+
+- If you use a custom controller class, use `rest_route_for_post` or `rest_route_for_term` filters to map objects to routes.

--- a/.agents/skills/wp-rest-api/references/discovery-and-params.md
+++ b/.agents/skills/wp-rest-api/references/discovery-and-params.md
@@ -1,0 +1,20 @@
+# Discovery and Global Parameters (summary)
+
+## API discovery
+
+- REST API root is discovered via the `Link` header: `rel="https://api.w.org/"`.
+- HTML pages also include a `<link rel="https://api.w.org/" href="...">` element.
+- For non-pretty permalinks, use `?rest_route=/`.
+
+## Global parameters
+
+- `_fields` limits response fields (supports nested meta keys).
+- `_embed` includes linked resources in `_embedded`.
+- `_method` or `X-HTTP-Method-Override` allows POST to simulate PUT/DELETE.
+- `_envelope` puts headers/status in the response body.
+- `_jsonp` enables JSONP for legacy clients.
+
+## Pagination
+
+- Collections accept `page`, `per_page` (1-100), and `offset`.
+- Pagination headers: `X-WP-Total` and `X-WP-TotalPages`.

--- a/.agents/skills/wp-rest-api/references/responses-and-fields.md
+++ b/.agents/skills/wp-rest-api/references/responses-and-fields.md
@@ -1,0 +1,30 @@
+# Responses and Fields (summary)
+
+## Do not remove core fields
+
+- Removing or changing core fields breaks clients (including wp-admin).
+- Prefer adding new fields or using `_fields` to limit response size.
+
+## register_rest_field
+
+- Use for computed or custom fields.
+- Provide `get_callback`, optional `update_callback`, and `schema`.
+- Register on `rest_api_init`.
+
+## Raw vs rendered content
+
+- For posts, `content.rendered` reflects filters (plugins like ToC inject HTML).
+- Use `?context=edit` (authenticated) to access `content.raw`.
+- Combine with `_fields=content.raw` when you only need the editable body.
+
+## register_meta / register_post_meta / register_term_meta
+
+- Use when the data is stored as meta.
+- Set `show_in_rest => true` to expose under `.meta`.
+- For `object` or `array` types, provide a JSON schema in `show_in_rest.schema`.
+
+## Links and embedding
+
+- Add links with `WP_REST_Response::add_link( $rel, $href, $attrs )`.
+- Use `embeddable => true` to allow `_embed`.
+- Use IANA rels or a custom URI relation; CURIEs can be registered via `rest_response_link_curies`.

--- a/.agents/skills/wp-rest-api/references/routes-and-endpoints.md
+++ b/.agents/skills/wp-rest-api/references/routes-and-endpoints.md
@@ -1,0 +1,36 @@
+# Routes and Endpoints (summary)
+
+## Registering routes
+
+- Register routes on the `rest_api_init` hook with `register_rest_route( $namespace, $route, $args )`.
+- A **route** is the URL pattern; an **endpoint** is the method + callback bound to that route.
+- For non-pretty permalinks, the route is accessed via `?rest_route=/namespace/route`.
+
+## Namespacing
+
+- Always namespace routes (`vendor/v1`).
+- **Do not** use the `wp/*` namespace unless you are targeting core.
+
+## Methods
+
+- Use `WP_REST_Server::READABLE` (GET), `CREATABLE` (POST), `EDITABLE` (PUT/PATCH), `DELETABLE` (DELETE).
+- Multiple endpoints can share a route, one per method.
+
+## permission_callback (required)
+
+- Always provide `permission_callback`.
+- Public endpoints should use `__return_true`.
+- For restricted endpoints, use capability checks (`current_user_can`) or object-level authorization.
+- Missing `permission_callback` emits a `_doing_it_wrong` notice in modern WP.
+
+## Arguments
+
+- Register `args` to validate and sanitize inputs.
+- Use `type`, `required`, `default`, `validate_callback`, `sanitize_callback`.
+- Access params via the `WP_REST_Request` object, not `$_GET`/`$_POST`.
+
+## Return values
+
+- Return data via `rest_ensure_response()` or a `WP_REST_Response`.
+- Return `WP_Error` with a `status` in `data` for error responses.
+- Do not call `wp_send_json()` in REST callbacks.

--- a/.agents/skills/wp-rest-api/references/schema.md
+++ b/.agents/skills/wp-rest-api/references/schema.md
@@ -1,0 +1,22 @@
+# Schema and Argument Validation (summary)
+
+## JSON Schema in WordPress
+
+- REST API uses JSON Schema (draft 4 subset) for resource and argument definitions.
+- Provide schema via `get_item_schema()` on controllers or `schema` callbacks on routes.
+- Schema enables discovery (`OPTIONS`) and validation.
+
+## Validation + sanitization
+
+- Use `rest_validate_value_from_schema( $value, $schema )` then `rest_sanitize_value_from_schema( $value, $schema )`.
+- If you override `sanitize_callback`, built-in schema validation will not run; use `rest_validate_request_arg` to keep it.
+- `WP_REST_Controller::get_endpoint_args_for_item_schema()` wires validation automatically.
+
+## Schema caching
+
+- Cache the generated schema on the controller instance (`$this->schema`) to avoid recomputation.
+
+## Formats and types
+
+- Common formats: `date-time`, `uri`, `email`, `ip`, `uuid`, `hex-color`.
+- For `array` and `object` types, you must define `items` or `properties` schemas.

--- a/.claude/skills/blueprint
+++ b/.claude/skills/blueprint
@@ -1,0 +1,1 @@
+../../.agents/skills/blueprint

--- a/.claude/skills/wp-plugin-development
+++ b/.claude/skills/wp-plugin-development
@@ -1,0 +1,1 @@
+../../.agents/skills/wp-plugin-development

--- a/.claude/skills/wp-plugin-directory-guidelines
+++ b/.claude/skills/wp-plugin-directory-guidelines
@@ -1,0 +1,1 @@
+../../.agents/skills/wp-plugin-directory-guidelines

--- a/.claude/skills/wp-rest-api
+++ b/.claude/skills/wp-rest-api
@@ -1,0 +1,1 @@
+../../.agents/skills/wp-rest-api

--- a/.distignore
+++ b/.distignore
@@ -1,4 +1,6 @@
 # Directories
+.agents
+.claude
 .git
 .github
 .idea
@@ -23,6 +25,11 @@ languages/*.po
 # Files
 .aider.chat.history.md
 .aider.input.history
+AGENTS.md
+ARCHITECTURE.md
+CLAUDE.md
+GEMINI.md
+skills-lock.json
 *.DS_Store
 .DS_Store
 .distignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -43,3 +43,5 @@ linter-baseline.toml                                       export-ignore
 mago.toml                                                  export-ignore
 ARCHITECTURE.md                                            export-ignore
 GEMINI.md                                                  export-ignore
+# `.agents/` and `.claude/` already match the `.*` rule above; this one does not.
+skills-lock.json                                           export-ignore

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,6 +36,21 @@ make mago-format           # optional secondary Mago format
 
 ---
 
+## Agent skills
+
+This repository ships skills in `.agents/skills/`, which Copilot loads on demand.
+Consult the relevant one before working in its area:
+
+- `wp-plugin-development` — hooks, activation/uninstall, Settings API, options, cron, packaging
+- `wp-rest-api` — `register_rest_route`, `permission_callback`, schema/args, `register_meta`, `show_in_rest`
+- `wp-plugin-directory-guidelines` — `readme.txt`, license headers, naming; what `make check-plugin` enforces
+- `blueprint` — `blueprint.json` and the Playground preview
+- `security-audit` — vulnerability hunting and finding validation
+
+They are vendored verbatim from upstream: never reformat or edit them in place.
+
+---
+
 ## Key Coding Rules
 
 - **PHP indentation**: tab characters (tab-width = 4), per WordPress Coding Standards and `.editorconfig`.
@@ -48,6 +63,10 @@ make mago-format           # optional secondary Mago format
 - **SQL**: always use `$wpdb->prepare()`.
 - **UI text**: Spanish; all code, comments, and docblocks in English.
 - **Text domain**: `documentate`.
+- **AutoFirma exception**: the intermediate routes in `includes/autofirma/` use
+  `permission_callback => '__return_true'` deliberately — AutoFirma is a desktop
+  app with no WordPress session, and a 32-char session token authorises them.
+  Adding a nonce or capability check there breaks signing. See `AGENTS.md`.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,6 +238,60 @@ A change is ready when **all** of the following are true:
 
 ---
 
+## Skills
+
+Recurring procedures live as skills in `.agents/skills/`, the path GitHub
+Copilot, Codex and other agents read directly. Claude Code reads
+`.claude/skills/`, which contains **symlinks** to those same directories, not
+copies. When adding a skill, create it in `.agents/skills/` and link it from
+`.claude/skills/`; never duplicate a `SKILL.md`.
+
+| Skill | Read it before | Origin |
+| --- | --- | --- |
+| `wp-plugin-development` | Touching hooks, activation/uninstall, the Settings API, options, cron or release packaging | [`WordPress/agent-skills`](https://github.com/WordPress/agent-skills), GPL-2.0-or-later |
+| `wp-rest-api` | Adding or debugging routes: `register_rest_route`, `permission_callback`, schema/args, `register_meta`, `show_in_rest` | idem |
+| `wp-plugin-directory-guidelines` | Editing `readme.txt`, license headers or plugin naming — this is what `make check-plugin` enforces | idem |
+| `blueprint` | Editing `blueprint.json` or the Playground preview | idem |
+| `security-audit` | Hunting vulnerabilities and validating findings | [`cloudflare/security-audit-skill`](https://github.com/cloudflare/security-audit-skill) |
+
+All of them are **third party and vendored verbatim**. Do not reformat or edit
+them: diverging from upstream makes future updates harder. Fix the problem
+upstream and re-vendor instead.
+
+`skills-lock.json` records provenance for skills fetched with a skills
+installer; `security-audit` is the only one so far. The `WordPress/agent-skills`
+set was vendored by hand and is therefore not listed there.
+
+Skills and the agent instruction files are excluded from the release ZIP via
+`.gitattributes`.
+
+---
+
+## AutoFirma Integration
+
+`includes/autofirma/` adapts the AutoFirma intermediate-server protocol. Two
+invariants there look like bugs and are not:
+
+- **`/documentate/v1/autofirma/intermediate/<token>/{storage,retrieve}` uses
+  `permission_callback => '__return_true'` on purpose.** AutoFirma is a desktop
+  application; it does not carry the WordPress session cookie, so those routes
+  cannot require a nonce or a capability. What authorises them is the 32-char
+  opaque token, issued only by
+  `/autofirma/intermediate-sessions`, which *does* check `edit_posts`, and which
+  expires with its transient. Do not "harden" the token routes with
+  `current_user_can()` or a nonce check — that breaks signing outright.
+- **The protocol itself lives in `erseco/autofirma-intermediate-server`** and is
+  copied into `includes/vendor/autofirma-intermediate-server/` by a Composer
+  script. The browser side is `@erseco/autofirma-client`, bundled by
+  `npm run build:autofirma`. Do not reimplement either one in this plugin; fix
+  it upstream and bump the dependency.
+
+Never introduce a fallback that returns the unsigned document when AutoFirma is
+missing or fails. A file that looks signed but is not is worse than an error.
+Certificate metadata arriving from JavaScript is untrusted input.
+
+---
+
 ## Architecture Reference
 
 Read `ARCHITECTURE.md` for details on:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,17 @@ Read `ARCHITECTURE.md` before making significant changes.
 
 ---
 
+## Skills
+
+`.agents/skills/` holds vendored third-party skills; `.claude/skills/` symlinks
+to them. Read the relevant one before working in its area — `wp-plugin-development`
+(hooks, Settings API, packaging), `wp-rest-api` (routes, permission callbacks,
+schema), `wp-plugin-directory-guidelines` (`readme.txt`, licensing, what
+`make check-plugin` enforces), `blueprint` (`blueprint.json`, Playground),
+`security-audit`. Never reformat or edit a skill in place.
+
+---
+
 ## Critical rules
 
 - Make **small, focused diffs**. No unrelated refactors.
@@ -49,6 +60,9 @@ A task is **not done** until all relevant checks pass.
 - UI text in **Spanish**; code, comments, docblocks in **English**.
 - Text domain: `documentate`.
 - Requires Docker / wp-env for `make check-plugin` and `make test`.
+- AutoFirma's intermediate routes use `permission_callback => '__return_true'`
+  deliberately — a 32-char session token authorises them, not the WP session.
+  See the AutoFirma section of `AGENTS.md` before touching `includes/autofirma/`.
 
 ---
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -15,6 +15,15 @@ Read `ARCHITECTURE.md` before making significant changes.
 
 ---
 
+## Skills
+
+`.agents/skills/` holds vendored third-party skills covering plugin development,
+the REST API, the WordPress.org directory guidelines, Playground blueprints and
+security auditing. Read the relevant one before working in its area, and never
+reformat or edit a skill in place. Details in `AGENTS.md`.
+
+---
+
 ## Critical rules
 
 - Make **small, focused diffs**. No unrelated refactors.
@@ -49,6 +58,9 @@ A task is **not done** until all relevant checks pass.
 - UI text in **Spanish**; code, comments, docblocks in **English**.
 - Text domain: `documentate`.
 - Requires Docker / wp-env for `make check-plugin` and `make test`.
+- AutoFirma's intermediate routes use `permission_callback => '__return_true'`
+  deliberately — a 32-char session token authorises them, not the WP session.
+  See the AutoFirma section of `AGENTS.md` before touching `includes/autofirma/`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,28 @@ make check          # lint + plugin-check + tests + translations (no auto-fix)
 
 See `AGENTS.md` for the full agent/developer instructions and `ARCHITECTURE.md` for system design.
 
+### Working with AI coding agents
+
+`AGENTS.md` is canonical; `CLAUDE.md`, `GEMINI.md` and `.github/copilot-instructions.md` point at it.
+
+Reusable procedures ship as agent skills in `.agents/skills/` (symlinked from `.claude/skills/`):
+
+| Skill | Read it before |
+|-------|----------------|
+| `wp-plugin-development` | Hooks, activation/uninstall, Settings API, options, cron, packaging |
+| `wp-rest-api` | Routes, `permission_callback`, schema/args, `register_meta`, `show_in_rest` |
+| `wp-plugin-directory-guidelines` | `readme.txt`, license headers, naming — what `make check-plugin` enforces |
+| `blueprint` | `blueprint.json` and the Playground preview |
+| `security-audit` | Vulnerability hunting and finding validation |
+
+The first four come from [`WordPress/agent-skills`](https://github.com/WordPress/agent-skills)
+(GPL-2.0-or-later), `security-audit` from
+[`cloudflare/security-audit-skill`](https://github.com/cloudflare/security-audit-skill).
+All are vendored verbatim — do not reformat or patch them locally. To add one, drop it in
+`.agents/skills/<name>/` and `ln -s ../../.agents/skills/<name> .claude/skills/<name>`.
+
+None of it reaches the release ZIP; `.gitattributes` marks it `export-ignore`.
+
 ### Key make targets
 
 | Target                 | Description                                            |


### PR DESCRIPTION
Same treatment as [ateeducacion/wp-decker#311](https://github.com/ateeducacion/wp-decker/pull/311): port the agent tooling `wp-autofirma` already runs with, keeping only what earns its place here. This repo already had `AGENTS.md`, `CLAUDE.md`, `GEMINI.md` and `copilot-instructions.md` wired together, so the gap was skills — plus one undocumented subsystem.

## Skills

Four skills from [`WordPress/agent-skills`](https://github.com/WordPress/agent-skills) (GPL-2.0-or-later), vendored verbatim next to the existing `security-audit`:

| Skill | Why it fits Documentate |
| --- | --- |
| `wp-plugin-development` | Hooks, activation/uninstall, Settings API, options, cron, packaging |
| `wp-rest-api` | `register_rest_route` appears in 7 files, including the AutoFirma intermediate controller |
| `wp-plugin-directory-guidelines` | `readme.txt`, license headers, naming — the same ground `make check-plugin` covers, and that gate is mandatory here |
| `blueprint` | We ship `blueprint.json` and a Playground preview |

Layout follows what `security-audit` established: one copy in `.agents/skills/`, a symlink from `.claude/skills/` (mode `120000`, verified). `.agents/skills/` is a path [Copilot reads directly](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills), so no third copy is needed.

## AutoFirma invariants

Neither `AGENTS.md` nor `ARCHITECTURE.md` mentioned `includes/autofirma/` at all, and two things in there read as bugs on first contact:

- `/documentate/v1/autofirma/intermediate/<token>/{storage,retrieve}` uses `permission_callback => '__return_true'`. That is deliberate: AutoFirma is a desktop application and carries no WordPress session cookie. Authorisation comes from the 32-char token, issued only by `/autofirma/intermediate-sessions` (which does check `edit_posts`) and backed by a transient — `serve()` returns `403 ERR-06` once it expires. An agent "hardening" this with `current_user_can()` or a nonce breaks signing outright, and both `copilot-instructions.md` and `CLAUDE.md` currently tell it to add capability checks everywhere.
- The protocol lives in `erseco/autofirma-intermediate-server` (copied into `includes/vendor/` by a Composer script) and `@erseco/autofirma-client` (bundled by `npm run build:autofirma`). Not something to reimplement in-plugin.

Plus the rule from `wp-autofirma`: never add a fallback that returns the unsigned document when AutoFirma is missing. A file that looks signed but is not is worse than an error.

Every claim above was read out of the code, not carried over on faith.

## Packaging fix

`skills-lock.json` was shipping inside the release ZIP — the `.*` rule in `.gitattributes` covers `.agents/` and `.claude/`, and `AGENTS.md`/`CLAUDE.md`/`GEMINI.md` were already listed, but that one file was not. Marked `export-ignore` and mirrored in `.distignore` together with the agent files.

## Verification

- `git archive HEAD` contains no `.agents`/`.claude`/`AGENTS.md`/`CLAUDE.md`/`GEMINI.md`/`skills-lock.json` entry.
- Symlinks resolve; the four skills load.
- Added files are `.md` and `.mjs` only — zero PHP under `.agents/`, no user-facing strings. PHPCS, plugin-check, PHPUnit, Playwright and `check-untranslated` are untouched by this diff.
- Local `.wp-env.json` / `.wp-env.docker.json` edits that were already in the working tree were deliberately left out of the commit.

## Notes

- `skills-lock.json` is otherwise left alone. Its `computedHash` comes from whatever installer fetched `security-audit` and is not reproducible from the file contents, so the hand-vendored set is documented in `AGENTS.md` instead of getting invented entries.
- Unrelated observation: `.distignore` excludes `docs/` but `.gitattributes` does not, and `composer archive` reads the latter — so `docs/` currently ships in the ZIP. Left as-is; happy to fix separately.
- Upstream also has `wp-abilities-api`, `wp-abilities-audit` and `wp-abilities-verify`, worth a look if this plugin ever exposes abilities.
