### PR TITLE
Run the postponed action after saving, once its handler is bound

### DIFF
--- a/admin/js/documentate-actions.js
+++ b/admin/js/documentate-actions.js
@@ -811,6 +811,17 @@
 				console.warn('AutoFirma init warning:', e);
 			}
 		}
+
+		// An action the user postponed to save first is replayed as a click, so it
+		// can only run now that the handler above is listening. This module loads
+		// after documentate-unsaved-changes, which is why the guard leaves the call
+		// to us instead of making it from its own ready callback.
+		if (
+			window.documentateUnsavedChanges &&
+			typeof window.documentateUnsavedChanges.resumePendingAction === 'function'
+		) {
+			window.documentateUnsavedChanges.resumePendingAction();
+		}
 	}
 
 	$(init);

--- a/admin/js/documentate-unsaved-changes.js
+++ b/admin/js/documentate-unsaved-changes.js
@@ -524,6 +524,13 @@
 
 	/**
 	 * Replay the action stored before the last save, if there is one.
+	 *
+	 * Called by documentate-actions once it has delegated its click handler, not
+	 * from this module's own ready callback. The replay is a synthetic click, and
+	 * this module loads first precisely because the other one depends on it, so
+	 * its ready callback runs while nothing is listening for the action yet: the
+	 * click would land on nothing and the stored entry would be consumed for
+	 * nothing.
 	 */
 	function resumePendingAction() {
 		var pending = takePendingAction();
@@ -575,6 +582,7 @@
 		},
 		markDirty: markDirty,
 		markClean: markClean,
+		resumePendingAction: resumePendingAction,
 
 		/**
 		 * Observe dirty-state transitions.
@@ -604,7 +612,5 @@
 				$indicator.prop('hidden', !dirty);
 			});
 		}
-
-		resumePendingAction();
 	});
 })(jQuery);

--- a/docs/unsaved-changes-guard.md
+++ b/docs/unsaved-changes-guard.md
@@ -118,6 +118,16 @@ Before submitting, the pending action is recorded in `sessionStorage` under
 the module reads the entry, deletes it immediately, discards it if older than two
 minutes, and replays the action.
 
+The replay is a synthetic click, so it only does something once
+`documentate-actions` has delegated its handler. Both modules bind on DOM ready and
+the guard loads first — `documentate-actions` depends on it — so its ready callback
+runs while nothing is listening yet. `resumePendingAction()` is therefore exposed on
+`window.documentateUnsavedChanges` and called at the end of `documentate-actions`'
+`init()`, after the handler is bound, rather than from the guard's own ready
+callback. Calling it from there consumed the stored entry and dispatched a click
+that landed on nothing: the page saved and reloaded, and the document was never
+generated.
+
 ### Popup blocking
 
 `documentate-actions.js` opens previews with `window.open(url, '_blank')` inside an
@@ -143,7 +153,7 @@ change is announced once rather than on every keystroke.
 | --- | --- |
 | `admin/js/documentate-unsaved-changes.js` | new — detector, gate, modal, resume, indicator |
 | `admin/css/documentate-actions.css` | modal and indicator styles |
-| `admin/js/documentate-actions.js` | delete `hasUnsavedChanges()`; popup fallback for preview |
+| `admin/js/documentate-actions.js` | delete `hasUnsavedChanges()`; popup fallback for preview; resume the pending action after binding |
 | `assets/js/documentate-autofirma.js` | delete `hasUnsavedChanges()` and its `confirm()` |
 | `admin/js/documentate-autofirma.js` | regenerated via `npm run build:autofirma` |
 | `includes/class-documentate-admin-helper.php` | enqueue, dependency, localized strings, indicator markup |
@@ -154,7 +164,9 @@ No changes to the generation layer or the workflow.
 
 - **Jest** — `isDirty()` after `input` on a plain field, after TinyMCE `Dirty`,
   after `input` on `.ProseMirror`; starts clean; `sessionStorage` TTL; gate passes
-  through when clean.
+  through when clean. Plus one test that evaluates the guard and
+  `documentate-actions` in load order and asserts the resumed action reaches
+  `$.ajax`, which a test binding its own listener up front cannot catch.
 - **PHPUnit** — the handle is enqueued with the right dependencies and strings.
 - **Playwright** — edit a field, click Preview, assert the modal; assert the
   "use saved version" branch generates; assert the save branch reloads and resumes.

--- a/tests/e2e/specs/document-unsaved-changes.spec.js
+++ b/tests/e2e/specs/document-unsaved-changes.spec.js
@@ -207,6 +207,12 @@ test.describe( 'Unsaved changes guard', () => {
 			guard.save.click(),
 		] );
 
+		// The point of the branch: the action the save interrupted runs on its own
+		// once the page is back. The loading modal only opens from the generation
+		// handler, so seeing it proves the replayed click was actually handled and
+		// not fired before anything listened for it.
+		await expect( guard.loadingModal ).toBeVisible();
+
 		// The document reloaded from the database, so nothing is pending and the
 		// replay entry was consumed rather than left to fire again later.
 		await expect( guard.indicator ).toBeHidden();

--- a/tests/js/documentate-unsaved-changes.test.js
+++ b/tests/js/documentate-unsaved-changes.test.js
@@ -17,6 +17,11 @@ const SOURCE = fs.readFileSync(
 	'utf8'
 );
 
+const ACTIONS_SOURCE = fs.readFileSync(
+	path.join( __dirname, '../../admin/js/documentate-actions.js' ),
+	'utf8'
+);
+
 const POST_ID = 42;
 const STORAGE_KEY = `documentate_pending_action_${ POST_ID }`;
 
@@ -304,6 +309,7 @@ describe( 'save and resume', () => {
 		);
 
 		await loadGuard();
+		window.documentateUnsavedChanges.resumePendingAction();
 
 		expect( downstream ).toHaveBeenCalled();
 		expect( window.sessionStorage.getItem( STORAGE_KEY ) ).toBeNull();
@@ -320,6 +326,7 @@ describe( 'save and resume', () => {
 		);
 
 		await loadGuard();
+		window.documentateUnsavedChanges.resumePendingAction();
 
 		expect( downstream ).not.toHaveBeenCalled();
 		expect( window.sessionStorage.getItem( STORAGE_KEY ) ).toBeNull();
@@ -333,6 +340,7 @@ describe( 'save and resume', () => {
 		);
 
 		await loadGuard();
+		window.documentateUnsavedChanges.resumePendingAction();
 
 		expect( downstream ).not.toHaveBeenCalled();
 		expect( document.querySelector( '.documentate-unsaved-modal.is-visible' ) ).not.toBeNull();
@@ -340,5 +348,76 @@ describe( 'save and resume', () => {
 		document.querySelector( '.documentate-unsaved-modal__primary' ).click();
 
 		expect( downstream ).toHaveBeenCalled();
+	} );
+} );
+
+describe( 'resume against the real action handler', () => {
+	let ajaxSpy;
+
+	beforeEach( () => {
+		// The stand-in bound in the outer beforeEach listens from the start, which
+		// is exactly the ordering these tests must not assume.
+		document.removeEventListener( 'click', downstreamListener );
+
+		window.documentateActionsConfig = {
+			ajaxUrl: '/wp-admin/admin-ajax.php',
+			postId: POST_ID,
+			nonce: 'test-nonce',
+			strings: {},
+		};
+
+		ajaxSpy = jest.fn();
+		global.jQuery.ajax = ajaxSpy;
+	} );
+
+	afterEach( () => {
+		// Each evaluation of documentate-actions delegates another handler on the
+		// document, which outlives the fixture and would double-count later runs.
+		global.jQuery( document ).off( 'click' );
+		delete window.documentateActionsConfig;
+	} );
+
+	/**
+	 * Evaluate both modules in the order the page loads them.
+	 *
+	 * documentate-actions declares the guard as a dependency, so the guard runs
+	 * first and its jQuery ready callback is queued ahead of the one that binds
+	 * the action click handler.
+	 *
+	 * @return {Promise<void>} Resolves once the ready queue has drained.
+	 */
+	async function loadPage() {
+		// eslint-disable-next-line no-new-func
+		new Function( SOURCE )();
+		// eslint-disable-next-line no-new-func
+		new Function( ACTIONS_SOURCE )();
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+		instances.push( window.documentateUnsavedChanges );
+	}
+
+	it( 'generates the document the save interrupted', async () => {
+		// The replay is a synthetic click, so it only does something once
+		// documentate-actions has delegated its handler. Firing it earlier lands
+		// on nothing and the action is lost, with the stored entry consumed.
+		window.sessionStorage.setItem(
+			STORAGE_KEY,
+			JSON.stringify( { action: 'download', format: 'pdf', ts: Date.now() } )
+		);
+
+		await loadPage();
+
+		expect( ajaxSpy ).toHaveBeenCalledTimes( 1 );
+		expect( ajaxSpy.mock.calls[ 0 ][ 0 ].data ).toMatchObject( {
+			action: 'documentate_generate_document',
+			post_id: POST_ID,
+			format: 'pdf',
+			output: 'download',
+		} );
+	} );
+
+	it( 'generates nothing when no action was interrupted', async () => {
+		await loadPage();
+
+		expect( ajaxSpy ).not.toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
## Problem

In the unsaved-changes dialog, **"Guardar y previsualizar"** (and the PDF / DOCX / ODT variants) saved the document and reloaded the page — and then nothing happened. Only the save half of the button worked; the user had to click the action again.

## Root cause

The replay is a synthetic click, so it needs `documentate-actions` to be listening for it.

Both modules bind on DOM ready, and the guard loads **first** because `documentate-actions` declares it as a dependency. jQuery fires ready callbacks in registration order, so the guard's ran first: `resumePendingAction()` consumed the `sessionStorage` entry and dispatched a click on an `<a href="#">` that nothing handled yet. The entry was already deleted, so no later handler could pick it up either.

Signing was unaffected — AutoFirma needs a user gesture, so it resumes behind a button the user clicks well after everything is bound.

## Fix

`resumePendingAction()` is exposed on `window.documentateUnsavedChanges` and called at the end of `documentate-actions`' `init()`, right after the click handler is delegated. Ordering by contract instead of by timing, so it also survives the scripts being enqueued with a `defer` strategy later on.

## Why the tests missed it

- **Jest** bound its stand-in for the action handler *before* loading the guard — the one ordering production never has. Added a test that evaluates both real modules in load order and asserts the resumed action reaches `$.ajax`.
- **Playwright** asserted only that the page reloaded and the stored entry was consumed. Both were true while the bug was present. It now also asserts the loading modal opens, which only the generation handler does.

Both new assertions were verified to fail before the fix (Playwright, real Chromium: `Expect "toBeVisible" ... waiting for locator('#documentate-loading-modal')`).

## Checks

- `make lint` ✅
- `make check-plugin` ✅ No errors found
- `make test` ✅ 1909 tests, 13314 assertions
- `npm run test:unit-js` ✅ 48 tests
- `make test-e2e -- document-unsaved-changes.spec.js` ✅ 6 passed
- `make check-untranslated` ✅ no string changes