### PR TITLE
Package the release ZIP with wp dist-archive

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,71 +1,122 @@
-# Directories
-.agents
-.claude
-.git
-.github
-.idea
-.wordpress-org
-bin
-build
-build-cs
-build-phpunit
-docs
-node_modules
-patches
-# Distributed via vendor/plugin-check/phpcs-sniffs instead
-/phpcs-sniffs/
-tests
-vendor
-wp-content
+# Files and directories kept out of the release ZIP.
+#
+# This is the single source of truth for what ships. `make package` builds the
+# archive with `wp dist-archive`, which reads this file straight from the working
+# tree, so the generated files that .gitignore keeps out of the repository (the
+# LibreOffice WASM glue under admin/vendor/, the runtime translations) are
+# packaged like any other file.
+#
+# `.gitattributes` does NOT feed this archive. It only shapes the source ZIP that
+# GitHub serves at archive/refs/heads/*.zip, the one blueprint.json installs in
+# WordPress Playground.
+#
+# Two matching rules to keep in mind, both inherited from
+# inmarelibero/gitignore-checker:
+#
+#   * Matching is case-insensitive, unlike git on Linux.
+#   * An unanchored rule matches at any depth. A bare `vendor` rule would strip
+#     admin/vendor/tinybutstrong and includes/vendor/autofirma-intermediate-server,
+#     both of which the plugin loads at runtime.
+#
+# Root-only rules therefore carry a leading slash. The few rules that must match
+# at any depth are grouped at the end.
 
-# Language stuff
-languages/*.pot
+# CI
+/.github
+/.gitlab-ci.yml
+
+# Agent instructions and vendored skills
+/.agents
+/.claude
+/.omc
+/AGENTS.md
+/CLAUDE.md
+/GEMINI.md
+/skills-lock.json
+
+# Development tooling and configuration
+/.editorconfig
+/.nvmrc
+/.phpcs.xml.dist
+/.phpunit.result.cache
+/.stylelintrc
+/.wp-env.docker.json
+/.wp-env.json
+/codecov.yml
+/composer.json
+/composer.lock
+/linter-baseline.toml
+/mago.toml
+/Makefile
+/package.json
+/package-lock.json
+/phpmd.xml
+/phpunit.xml.dist
+/renovate.json
+/scripts
+
+# Tests and everything they write
+/artifacts
+/test-results
+/tests
+
+# Development dependencies. Only the root vendor/ is excluded: the runtime
+# libraries live in admin/vendor/ and includes/vendor/, copied there by
+# composer's copy-runtime-dependencies script.
+/node_modules
+/vendor
+
+# The OpenTBS distribution carries demos and Office add-ins the plugin never
+# loads. demo/ matters most: it is executable PHP that would be reachable over
+# the web from inside the plugin directory. Their READMEs, CHANGELOGs and
+# licences do ship, which is what attribution needs.
+admin/vendor/tinybutstrong/opentbs/demo
+admin/vendor/tinybutstrong/opentbs/ms_office_addins
+admin/vendor/tinybutstrong/opentbs/tbs_plugin_opentbs.html
+admin/vendor/tinybutstrong/opentbs/xml_synopsis.html
+admin/vendor/tinybutstrong/tinybutstrong/tbs_us_manual.htm
+
+# The Cloudflare worker is deployed separately, not shipped with the plugin.
+/cloudflare-worker
+
+# Repository documentation. readme.txt is the user-facing one and does ship.
+/ARCHITECTURE.md
+/blueprint.json
+/CODE_OF_CONDUCT.md
+/CONVENTIONS.md
+/docs
+/README.md
+/SECURITY.md
+
+# fixtures/ ships: Documentate_Demo_Data imports the default templates from it
+# at runtime (documentate.php, includes/class-documentate-demo-data.php). Only
+# the leftovers no runtime code references are kept out.
+fixtures/*copia*
+fixtures/*_OLD.odt
+fixtures/resolucion_logos_europeos.odt
+fixtures/test-sign-placeholder.odt
+
+# Translation sources. Only the runtime files ship: .l10n.php (WordPress 6.5+),
+# .mo (fallback for 6.1-6.4) and the JS .json files. Both rules contain a slash,
+# which already anchors them to the root.
 languages/*.po
+languages/*.pot
 
-# Files
-.aider.chat.history.md
-.aider.input.history
-AGENTS.md
-ARCHITECTURE.md
-CLAUDE.md
-GEMINI.md
-skills-lock.json
-*.DS_Store
-.DS_Store
-.distignore
-.editorconfig
-.eslintrc.js
-.gherkin-lintignore
-.gherkin-lintrc
+# The packaging metadata itself
+/.distignore
+
+# Placeholder that only exists to keep an empty directory in git
+languages/.gitkeep
+
+# Rules that must match at any depth: none of these is ever legitimate inside a
+# release, wherever it turns up. .gitignore and .gitattributes are here rather
+# than anchored because the vendored libraries carry their own.
+.git
 .gitattributes
 .gitignore
-.nvmrc
-.php-cs-fixer.php
-.phpunit.result.cache
-.stylelintrc
-.typos.toml
-.wp-env.json
-.wp-env.override.json
-behat.yml
-codecov.yml
-CODE_OF_CONDUCT.md
-composer.json
-composer.lock
-CONVENTIONS.md
-CONTRIBUTING.md
-docker-compose.yml
-Makefile
-package.json
-package-lock.json
-phpcs.xml
-phpcs.xml.dist
-phpmd.xml
-phpstan.neon
-phpstan.neon.dist
-phpunit.xml
-phpunit.xml.dist
-plugin-check.iml
-README.md
-renovate.json
-SECURITY.md
+node_modules
+.DS_Store
+*.DS_Store
+*.bak
+.idea
 sftp-config.json

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,12 @@
-# Nothing here feeds the release ZIP. That archive is built by `wp dist-archive`
+# Vendored third party, copied verbatim from upstream by composer's
+# copy-runtime-dependencies script. `-text` stops git from re-encoding it
+# whatever the contributor's core.autocrlf is set to — one of these files
+# (tinybutstrong/CHANGELOG.md) is committed with CRLF, and the copy must stay
+# byte-identical to upstream.
+admin/vendor/**    -text
+includes/vendor/** -text
+
+# Nothing below feeds the release ZIP. That archive is built by `wp dist-archive`
 # and its exclusion list is .distignore, the single source of truth for what
 # ships.
 #

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,47 +1,16 @@
-# Exclude hidden files and directories
-.*                         								   export-ignore
-
-# Exclude .po and .pot language files
-languages/*.po             								   export-ignore
-languages/*.pot           								   export-ignore
-
-# Exclude development files
-*.css.map 				   								   export-ignore
-/vendor/                   								   export-ignore
-admin/vendor/tinybutstrong/opentbs/demo/                   export-ignore
-admin/vendor/tinybutstrong/opentbs/ms_office_addins/       export-ignore
-admin/vendor/tinybutstrong/opentbs/tbs_plugin_opentbs.html export-ignore
-admin/vendor/tinybutstrong/opentbs/xml_synopsis.html 	   export-ignore
-admin/vendor/tinybutstrong/tinybutstrong/tbs_us_manual.htm export-ignore
-AGENTS.md                                                  export-ignore
-artifacts/                                                 export-ignore
-blueprint.json                                             export-ignore
-CHANGELOG.md                                               export-ignore
-CLAUDE.md                                                  export-ignore
-cloudflare-worker/		                                   export-ignore
-CODE_OF_CONDUCT.md                                         export-ignore
-composer.json                                              export-ignore
-composer.lock                                              export-ignore
-CONVENTIONS.md                                             export-ignore
-docker-compose.yml                                         export-ignore
-LICENSE.txt                                                export-ignore
-Makefile                                                   export-ignore
-node_modules/                                              export-ignore
-package-lock.json                                          export-ignore
-package.json                                               export-ignore
-phpmd.baseline.xml                                         export-ignore
-phpmd.xml                                                  export-ignore
-phpunit.xml.dist                                           export-ignore
-README.md                                                  export-ignore
-renovate.json                                              export-ignore
-SECURITY.md                                                export-ignore
-sftp-config.json                                           export-ignore
-sonar-project.properties                                   export-ignore
-test.php                                                   export-ignore
-tests/                                                     export-ignore
-linter-baseline.toml                                       export-ignore
-mago.toml                                                  export-ignore
-ARCHITECTURE.md                                            export-ignore
-GEMINI.md                                                  export-ignore
-# `.agents/` and `.claude/` already match the `.*` rule above; this one does not.
-skills-lock.json                                           export-ignore
+# Nothing here feeds the release ZIP. That archive is built by `wp dist-archive`
+# and its exclusion list is .distignore, the single source of truth for what
+# ships.
+#
+# These rules only shape the source ZIP that GitHub serves at
+# archive/refs/heads/*.zip, the one blueprint.json installs in WordPress
+# Playground. Keep the list short and do not mirror .distignore into it: paths
+# git does not track (node_modules/, vendor/, artifacts/) never reach a git
+# archive in the first place.
+/.agents        export-ignore
+/.claude        export-ignore
+/.github        export-ignore
+/.gitattributes export-ignore
+/cloudflare-worker export-ignore
+/docs           export-ignore
+/tests          export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -61,8 +61,10 @@ wordpress-develop/
 artifacts/
 
 # Ignore Sass source maps
-public/style/workarea/*.css.maptest-results/
-test-results/*
+*.css.map
+
+# Playwright output
+test-results/
 .omc/
 
 # Generated runtime translation files. Built from the committed .po sources

--- a/Makefile
+++ b/Makefile
@@ -312,7 +312,7 @@ check-untranslated:
 	composer check-untranslated
 
 # Generate the LibreOffice WASM glue that the plugin ships but does not track.
-# `composer archive` packages the working tree and ignores .gitignore, so these
+# `wp dist-archive` packages the working tree and ignores .gitignore, so these
 # files only need to exist on disk at packaging time.
 package-assets:
 	@if [ -d node_modules/@matbee/libreoffice-converter ]; then \
@@ -338,8 +338,15 @@ package:
 	$(SED_INPLACE) "s/define( *'DOCUMENTATE_VERSION', '[^']*'/define( 'DOCUMENTATE_VERSION', '$(VERSION)'/" documentate.php
 	$(SED_INPLACE) "s/^Stable tag:.*/Stable tag: $(VERSION)/" readme.txt
 
-	# Create the ZIP package
-	composer archive --format=zip --file="documentate-$(VERSION)"
+	@# Create the ZIP package with proper folder structure.
+	@# `wp dist-archive` reads .distignore straight from the working tree, so the
+	@# generated files that .gitignore keeps out of the repository (the WASM glue,
+	@# the runtime translations) are packaged like any other file.
+	@# --plugin-dirname is what makes the archive extract as documentate/. Without
+	@# it WordPress names the plugin folder after the ZIP file and every release
+	@# lands in a new directory.
+	./vendor/bin/wp dist-archive . "$(CURDIR)/documentate-$(VERSION).zip" \
+		--plugin-dirname=documentate --force
 
 	# Restore the version in documentate.php & readme.txt
 	$(SED_INPLACE) "s/^ \* Version:.*/ * Version:           0.0.0/" documentate.php

--- a/Makefile
+++ b/Makefile
@@ -345,6 +345,10 @@ package:
 	@# --plugin-dirname is what makes the archive extract as documentate/. Without
 	@# it WordPress names the plugin folder after the ZIP file and every release
 	@# lands in a new directory.
+	@# `--force` does not empty an existing archive: dist-archive 3.1 shells out
+	@# to the `zip` binary, which ADDS to one. Without this removal a file that a
+	@# new .distignore rule excludes would survive from an earlier build.
+	rm -f "$(CURDIR)/documentate-$(VERSION).zip"
 	./vendor/bin/wp dist-archive . "$(CURDIR)/documentate-$(VERSION).zip" \
 		--plugin-dirname=documentate --force
 

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "phpmd/phpmd": "^2.15",
         "phpunit/phpunit": "^9.6.35",
         "squizlabs/php_codesniffer": "^3.13.5",
+        "wp-cli/dist-archive-command": "^3.1",
         "wp-cli/i18n-command": "^2.7.0",
         "wp-coding-standards/wpcs": "^3.4",
         "wp-phpunit/wp-phpunit": "^7.0.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "577b9ea2be9606ff31ee06c407ae21f8",
+    "content-hash": "dbfeb1cd5d8ff9e6d9a6061f00a012c9",
     "packages": [
         {
             "name": "erseco/autofirma-intermediate-server",
@@ -1058,6 +1058,55 @@
                 "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
             },
             "time": "2025-04-30T06:54:44+00:00"
+        },
+        {
+            "name": "inmarelibero/gitignore-checker",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/inmarelibero/gitignore-checker.git",
+                "reference": "57cdaa05ceaadaabdb671162ad46e58a133ed9dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/inmarelibero/gitignore-checker/zipball/57cdaa05ceaadaabdb671162ad46e58a133ed9dd",
+                "reference": "57cdaa05ceaadaabdb671162ad46e58a133ed9dd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Inmarelibero\\GitIgnoreChecker\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Emanuele Gaspari",
+                    "email": "inmarelibero@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A PHP library to check if a path is ignored by GIT",
+            "keywords": [
+                "git",
+                "gitignore",
+                "vcs"
+            ],
+            "support": {
+                "issues": "https://github.com/inmarelibero/gitignore-checker/issues",
+                "source": "https://github.com/inmarelibero/gitignore-checker/tree/1.0.4"
+            },
+            "time": "2024-05-03T16:17:41+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",
@@ -4592,6 +4641,68 @@
                 }
             ],
             "time": "2025-11-17T20:03:58+00:00"
+        },
+        {
+            "name": "wp-cli/dist-archive-command",
+            "version": "v3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-cli/dist-archive-command.git",
+                "reference": "e91730cddd4b0dc3eb46da588cabee9099ade356"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-cli/dist-archive-command/zipball/e91730cddd4b0dc3eb46da588cabee9099ade356",
+                "reference": "e91730cddd4b0dc3eb46da588cabee9099ade356",
+                "shasum": ""
+            },
+            "require": {
+                "inmarelibero/gitignore-checker": "^1.0.4",
+                "php": ">=7.2",
+                "wp-cli/wp-cli": "^2"
+            },
+            "require-dev": {
+                "wp-cli/extension-command": "^2",
+                "wp-cli/scaffold-command": "^2",
+                "wp-cli/wp-cli-tests": "^5"
+            },
+            "type": "wp-cli-package",
+            "extra": {
+                "readme": {
+                    "shields": [
+                        "[![Testing](https://github.com/wp-cli/dist-archive-command/actions/workflows/testing.yml/badge.svg)](https://github.com/wp-cli/dist-archive-command/actions/workflows/testing.yml)"
+                    ]
+                },
+                "commands": [
+                    "dist-archive"
+                ]
+            },
+            "autoload": {
+                "files": [
+                    "dist-archive-command.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Bachhuber",
+                    "email": "daniel@runcommand.io",
+                    "homepage": "https://runcommand.io"
+                }
+            ],
+            "description": "Create a distribution .zip or .tar.gz based on a plugin or theme's .distignore file.",
+            "homepage": "https://github.com/wp-cli/dist-archive-command/",
+            "support": {
+                "issues": "https://github.com/wp-cli/dist-archive-command/issues",
+                "source": "https://github.com/wp-cli/dist-archive-command/tree/v3.1.0"
+            },
+            "time": "2025-11-11T13:30:45+00:00"
         },
         {
             "name": "wp-cli/i18n-command",


### PR DESCRIPTION
## The bug this fixes

The release ZIP had **no top-level directory**. `composer archive` never adds a path prefix, so WordPress fell back to naming the plugin folder after the ZIP file:

```php
// wp-admin/includes/class-wp-upgrader.php:640-643 — WP_PLUGIN_DIR is a protected directory
$destination = trailingslashit( $destination ) . trailingslashit( basename( $source ) );
```

with `$source` being the working directory, named at `:378` from the package filename. So `documentate-1.2.3.zip` installed into `wp-content/plugins/documentate-1.2.3/`. Every release lands in a **new folder**, WordPress treats it as a different plugin and deactivates the previous one.

## The second problem

**Nothing read `.distignore`.** The list that actually applied was `.gitattributes`, which is why `docs/`, `scripts/` and `codecov.yml` shipped despite being listed in `.distignore` — and why `LICENSE.txt` did *not* ship at all (`.gitattributes` excluded it).

## A near-miss worth flagging

`.distignore` excluded **`fixtures/`**. That directory is not test data: `Documentate_Demo_Data` imports the twelve default templates from it on activation (`documentate.php:85`, `includes/class-documentate-demo-data.php:185-194`). Had this file been switched on as-is, the release would have shipped with no default templates.

Same class of problem with the bare `vendor` rule: matching is case-insensitive and **unanchored rules match at any depth**, so it would have stripped `admin/vendor/tinybutstrong` and `includes/vendor/autofirma-intermediate-server`, both loaded at runtime. Every root-only rule now carries a leading slash.

## What changed

- **`Makefile`** — `composer archive` → `./vendor/bin/wp dist-archive . documentate-$(VERSION).zip --plugin-dirname=documentate --force`. The `package-assets` comment about `composer archive` reading the working tree is updated; the behaviour it relies on is unchanged.
- **`composer.json` / `composer.lock`** — `wp-cli/dist-archive-command: ^3.1` in `require-dev`. The pin matters: 3.2+ needs `wp-cli ^2.13`, which has no stable release; 3.1.0 shells out to the `zip` binary so no `ext-zip` is required. The release workflow already runs `composer install` before `make package`.
- **`.distignore`** — the real list now. Pruned of ~27 `WordPress/plugin-check` leftovers, extended with the paths only `.gitattributes` covered (`.gitlab-ci.yml`, `.phpcs.xml.dist`, `ARCHITECTURE.md`, `GEMINI.md`, `mago.toml`, `linter-baseline.toml`, `cloudflare-worker/`, `.omc/`), and with the five unused `fixtures/` leftovers excluded by pattern.
- **`.gitattributes`** — 41 rules → 7, with a header saying it does not feed the release.

## OpenTBS demos

The old `.gitattributes` deliberately trimmed the vendored OpenTBS distribution; those trims are carried over to `.distignore` rather than lost. `demo/` is the one that matters — 30 files of executable PHP that would otherwise sit inside the plugin directory, reachable over the web. Their `README`, `CHANGELOG` and `composer.json` now *do* ship, which is what attribution needs; the old unanchored `README.md` and `composer.json` rules were clipping them.

## Verification

Built the ZIP before and after and diffed the file lists — **128 → 127 files, 1.77 MB → 1.42 MB**, single `documentate/` root, twelve runtime fixtures intact:

```
out: codecov.yml, docs/ (2), scripts/ (1),
     fixtures/{propuestagasto copia.odt, propuestagasto_OLD.odt,
               propuestagasto.odt.bak, resolucion_logos_europeos.odt,
               test-sign-placeholder.odt}
in:  LICENSE.txt,
     admin/vendor/**/{README.md, CHANGELOG.md, composer.json} (7)
```

## Left out of scope on purpose

Three of the excluded fixtures are **tracked** and referenced by nothing (`propuestagasto copia.odt`, `propuestagasto_OLD.odt`, `resolucion_logos_europeos.odt`); `test-sign-placeholder.odt` is used by `tests/unit/includes/DocumentateTemplateParserTest.php` and belongs in `tests/`. Deleting or moving repository content is a separate call from packaging, so I only kept them out of the ZIP.

Also: `sftp-config.json` sits untracked in the working tree. It is excluded from the ZIP, but worth adding to `.gitignore` so it cannot be committed by accident.

## Context

Third of four PRs unifying packaging across `wp-exelearning`, `wp-decker`, `wp-documentate` and `wp-autofirma`. Design in wp-exelearning's [SDD-0002](https://github.com/exelearning/wp-exelearning/pull/86), decision in ADR-0003.


---

## Añadido

- **`-text` para `admin/vendor/` e `includes/vendor/`**: se copian tal cual de upstream y deben quedar idénticos byte a byte. Uno de esos ficheros (`tinybutstrong/CHANGELOG.md`) está confirmado con CRLF y es el único CRLF del repositorio.
- **Regla del `.gitignore` partida por un salto de línea que faltaba**: `public/style/workarea/*.css.maptest-results/` no casaba con nada, así que la regla de los source maps nunca funcionó (`test-results` sí quedaba cubierto por la línea siguiente). Separada en `*.css.map` y `test-results/`, con la misma cobertura efectiva — comprobado con `git check-ignore`.
- **`rm -f` antes de archivar**, porque `--force` no vacía el ZIP anterior.

Sobre el aviso de `sftp-config.json` que dejé en la descripción original: **estaba equivocado**, ya figura en `.gitignore` (línea 23). No hacía falta ningún cambio.
