### PR TITLE
Bump tested up to WordPress 7.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: ateeducacion
 Tags: documents, resolutions, docx, pdf, opentbs
 Requires at least: 6.1
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 8.3
 Stable tag: 0.0.0
 License: GPL-3.0


### PR DESCRIPTION
## Summary
- Update `Tested up to` in `readme.txt` from 7.0 to 7.1 so plugin-check (and the WordPress.org listing) treats the plugin as compatible with the current WordPress version.

WordPress 7.1 is current; Plugin Check fails CI with `outdated_tested_upto_header` until this header matches.

## Test plan
- [ ] CI `make check-plugin` passes without the `outdated_tested_upto_header` error.